### PR TITLE
fix: block unsupported eslint and typescript majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,13 @@ updates:
     labels:
       - 'dependencies'
       - 'automated'
+    ignore:
+      - dependency-name: 'eslint'
+        update-types:
+          - 'version-update:semver-major'
+      - dependency-name: 'typescript'
+        update-types:
+          - 'version-update:semver-major'
     groups:
       # Group development dependencies together (minor and patch updates)
       development-dependencies:

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,15 +1,33 @@
-import nextPlugin from 'eslint-config-next'
+import { defineConfig, globalIgnores } from 'eslint/config'
+import nextVitals from 'eslint-config-next/core-web-vitals'
+import nextTs from 'eslint-config-next/typescript'
 import prettierConfig from 'eslint-config-prettier'
 
-const eslintConfig = [
-  // eslint-config-next may export as array or object depending on version
-  ...(Array.isArray(nextPlugin) ? nextPlugin : [nextPlugin]),
+export default defineConfig([
+  ...nextVitals,
+  ...nextTs,
   prettierConfig,
+  globalIgnores([
+    '.next/**',
+    'out/**',
+    'build/**',
+    'next-env.d.ts',
+    'e2e/**',
+    '*.config.js',
+    '*.config.cjs',
+    '*.config.mjs',
+    '*.config.ts',
+    'jest.setup.js',
+  ]),
   {
     rules: {
       'react/no-unescaped-entities': 'off',
     },
   },
-]
-
-export default eslintConfig
+  {
+    files: ['**/*.js', '**/*.cjs', '**/*.mjs'],
+    rules: {
+      '@typescript-eslint/no-require-imports': 'off',
+    },
+  },
+])

--- a/src/components/CookieConsent.tsx
+++ b/src/components/CookieConsent.tsx
@@ -6,23 +6,46 @@ import { useState, useEffect, useRef } from 'react'
 const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID || 'G-XXXXXXXXXX'
 const META_PIXEL_ID = process.env.NEXT_PUBLIC_META_PIXEL_ID || 'XXXXXXXXXXXXXXX'
 
+type ConsentPreferences = {
+  necessary: boolean
+  analytics: boolean
+  marketing: boolean
+}
+
+type DataLayerValue = string | number | boolean | null | undefined
+
 // Define type for GTM dataLayer events
 interface DataLayerEvent {
   event: string
-  [key: string]: any
+  [key: string]: DataLayerValue
+}
+
+function isConsentPreferences(value: unknown): value is ConsentPreferences {
+  if (typeof value !== 'object' || value === null) {
+    return false
+  }
+
+  const preferences = value as Partial<ConsentPreferences>
+
+  return (
+    typeof preferences.necessary === 'boolean' &&
+    typeof preferences.analytics === 'boolean' &&
+    typeof preferences.marketing === 'boolean'
+  )
 }
 
 // Extend Window interface to include dataLayer
 declare global {
   interface Window {
     dataLayer: DataLayerEvent[]
+    openCookiePreferences?: () => void
   }
 }
 
 export default function CookieConsent() {
   const [showBanner, setShowBanner] = useState(false)
   const [showPreferences, setShowPreferences] = useState(false)
-  const [preferences, setPreferences] = useState({
+  const [preferences, setPreferences] = useState<ConsentPreferences>({
     necessary: true, // Always true, cannot be changed
     analytics: false,
     marketing: false,
@@ -39,22 +62,16 @@ export default function CookieConsent() {
         if (showBannerIfMissing) setShowBanner(true)
         return
       }
-      let savedPreferences
+      let savedPreferences: unknown
       try {
         savedPreferences = JSON.parse(consent)
-      } catch (e) {
+      } catch {
         if (showBannerIfMissing) setShowBanner(true)
         return
       }
 
       // Validate the structure
-      if (
-        typeof savedPreferences === 'object' &&
-        savedPreferences !== null &&
-        typeof savedPreferences.necessary === 'boolean' &&
-        typeof savedPreferences.analytics === 'boolean' &&
-        typeof savedPreferences.marketing === 'boolean'
-      ) {
+      if (isConsentPreferences(savedPreferences)) {
         setPreferences(savedPreferences)
         setSavedPreferencesBackup(savedPreferences)
         applyConsent(savedPreferences)
@@ -70,7 +87,7 @@ export default function CookieConsent() {
 
   useEffect(() => {
     // Expose method to window for reopening preferences from other components
-    ;(window as any).openCookiePreferences = () => {
+    window.openCookiePreferences = () => {
       setShowBanner(true)
       setShowPreferences(true)
       loadPreferencesFromLocalStorage(false)
@@ -81,7 +98,7 @@ export default function CookieConsent() {
 
     // Cleanup function to remove the window method
     return () => {
-      delete (window as any).openCookiePreferences
+      delete window.openCookiePreferences
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
@@ -119,7 +136,7 @@ export default function CookieConsent() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [showPreferences])
 
-  const applyConsent = (prefs: typeof preferences, previousPrefs?: typeof preferences) => {
+  const applyConsent = (prefs: ConsentPreferences, previousPrefs?: ConsentPreferences) => {
     // Set a cookie to indicate consent status with Secure flag (only on HTTPS)
     const cookieValue = JSON.stringify(prefs)
     const secureFlag =
@@ -250,9 +267,9 @@ export default function CookieConsent() {
     setPreferences(allAccepted)
     try {
       localStorage.setItem('cookie-consent', JSON.stringify(allAccepted))
-    } catch (e) {
+    } catch (error) {
       // If localStorage is unavailable, continue anyway
-      console.warn('Unable to save preferences to localStorage:', e)
+      console.warn('Unable to save preferences to localStorage:', error)
     }
     applyConsent(allAccepted, savedPreferencesBackup)
     setSavedPreferencesBackup(allAccepted)

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -3,6 +3,12 @@
 import Link from 'next/link'
 import { guides } from '@/data/guides'
 
+declare global {
+  interface Window {
+    openCookiePreferences?: () => void
+  }
+}
+
 const GUIDESTAR_PROFILE_URL =
   'https://www.guidestar.org/profile/shared/bbbe173a-87b9-4af9-a8a2-cae255a95742'
 
@@ -155,7 +161,7 @@ export default function Footer() {
               </li>
               <li>
                 <button
-                  onClick={() => (window as any).openCookiePreferences?.()}
+                  onClick={() => window.openCookiePreferences?.()}
                   className="text-gray-400 hover:text-white transition-colors text-left"
                   aria-label="Open cookie preferences dialog"
                 >


### PR DESCRIPTION
## Summary
- modernize the flat ESLint config so current lint runs cleanly on the supported toolchain
- type the cookie preference window hook instead of relying on explicit any
- tell Dependabot to ignore unsupported major bumps for eslint and typescript until the Next lint stack supports them

## Validation
- pnpm install --frozen-lockfile
- pnpm run lint