### PR TITLE
feat: DNS cutover plan, /legacy-wordpress-administration/ section (hub + 12 leaves), sister-site routing

### DIFF
--- a/__tests__/components/Footer.test.tsx
+++ b/__tests__/components/Footer.test.tsx
@@ -39,7 +39,7 @@ describe('Footer Component', () => {
       expect(ffcLink).toBeInTheDocument()
       expect(ffcLink).toHaveAttribute('href', 'https://freeforcharity.org')
       expect(ffcLink).toHaveAttribute('target', '_blank')
-      expect(ffcLink).toHaveAttribute('rel', 'noopener')
+      expect(ffcLink).toHaveAttribute('rel', 'noopener noreferrer')
     })
 
     it('should display privacy policy link', () => {

--- a/__tests__/components/LegacyWpAdminSidebar.test.tsx
+++ b/__tests__/components/LegacyWpAdminSidebar.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from '@testing-library/react'
+import Sidebar from '@/components/legacy-wordpress-administration/Sidebar'
+
+const mockUsePathname = jest.fn<string, []>()
+
+jest.mock('next/navigation', () => ({
+  usePathname: () => mockUsePathname(),
+}))
+
+describe('Legacy WordPress Administration Sidebar', () => {
+  afterEach(() => {
+    mockUsePathname.mockReset()
+  })
+
+  test('renders the section-hub link and all category headings', () => {
+    mockUsePathname.mockReturnValue('/legacy-wordpress-administration')
+    render(<Sidebar />)
+    expect(screen.getByRole('link', { name: /section hub/i })).toBeInTheDocument()
+    expect(screen.getByText('WordPress Operations')).toBeInTheDocument()
+    expect(screen.getByText('Charity Onboarding')).toBeInTheDocument()
+    expect(screen.getByText('Volunteer Programs')).toBeInTheDocument()
+  })
+
+  test('renders every leaf as a link (12 leaves + hub = 13)', () => {
+    mockUsePathname.mockReturnValue('/legacy-wordpress-administration')
+    render(<Sidebar />)
+    const nav = screen.getByRole('navigation', { name: /legacy wordpress administration/i })
+    expect(nav.querySelectorAll('a').length).toBe(13)
+  })
+
+  test('marks only the current leaf as aria-current="page"', () => {
+    mockUsePathname.mockReturnValue('/legacy-wordpress-administration/wordpress-domains')
+    render(<Sidebar />)
+    const current = screen.getAllByText('Domain Admin')[0]
+    expect(current.closest('a')).toHaveAttribute('aria-current', 'page')
+    const hubLink = screen.getByRole('link', { name: /section hub/i })
+    expect(hubLink).not.toHaveAttribute('aria-current')
+  })
+
+  test('marks the hub as current only on the hub page itself', () => {
+    mockUsePathname.mockReturnValue('/legacy-wordpress-administration')
+    render(<Sidebar />)
+    expect(screen.getByRole('link', { name: /section hub/i })).toHaveAttribute(
+      'aria-current',
+      'page'
+    )
+  })
+
+  test('does NOT mark anything current on a sibling path that shares the prefix', () => {
+    // A path like /legacy-wordpress-administration-archive must not activate the section hub.
+    mockUsePathname.mockReturnValue('/legacy-wordpress-administration-archive')
+    render(<Sidebar />)
+    expect(screen.getByRole('link', { name: /section hub/i })).not.toHaveAttribute('aria-current')
+  })
+})

--- a/__tests__/components/SisterSiteBanner.test.tsx
+++ b/__tests__/components/SisterSiteBanner.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import SisterSiteBanner from '@/components/SisterSiteBanner'
+
+describe('SisterSiteBanner', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+
+  test('renders on first visit', () => {
+    render(<SisterSiteBanner />)
+    expect(screen.getByRole('region', { name: /sister site routing/i })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /visit freeforcharity\.org/i })).toHaveAttribute(
+      'href',
+      'https://freeforcharity.org/'
+    )
+  })
+
+  test('outbound link uses target=_blank with rel noopener noreferrer', () => {
+    render(<SisterSiteBanner />)
+    const link = screen.getByRole('link', { name: /visit freeforcharity\.org/i })
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link.getAttribute('rel')).toMatch(/noopener/)
+    expect(link.getAttribute('rel')).toMatch(/noreferrer/)
+  })
+
+  test('Dismiss button hides the banner and persists across renders', () => {
+    const { unmount } = render(<SisterSiteBanner />)
+    fireEvent.click(screen.getByRole('button', { name: /dismiss/i }))
+    expect(screen.queryByRole('region', { name: /sister site routing/i })).not.toBeInTheDocument()
+    expect(window.localStorage.getItem('ffc-sister-site-banner-dismissed-v1')).toBe('1')
+
+    unmount()
+    render(<SisterSiteBanner />)
+    expect(screen.queryByRole('region', { name: /sister site routing/i })).not.toBeInTheDocument()
+  })
+
+  test('still renders when localStorage throws (private browsing)', () => {
+    const original = window.localStorage.getItem
+    Object.defineProperty(window.localStorage, 'getItem', {
+      configurable: true,
+      value: () => {
+        throw new Error('blocked')
+      },
+    })
+
+    render(<SisterSiteBanner />)
+    expect(screen.getByRole('region', { name: /sister site routing/i })).toBeInTheDocument()
+
+    Object.defineProperty(window.localStorage, 'getItem', {
+      configurable: true,
+      value: original,
+    })
+  })
+})

--- a/__tests__/legacy-wordpress-administration.test.ts
+++ b/__tests__/legacy-wordpress-administration.test.ts
@@ -1,0 +1,78 @@
+import {
+  LEGACY_WP_ADMIN_BASE,
+  LEGACY_WP_ADMIN_CATEGORIES,
+  LEGACY_WP_ADMIN_PAGES,
+  getLegacyWpAdminHref,
+  getLegacyWpAdminPageBySlug,
+  getLegacyWpAdminPagesByCategory,
+} from '@/data/legacy-wordpress-administration'
+
+describe('Legacy WordPress Administration data', () => {
+  test('exposes exactly the documented page count', () => {
+    expect(LEGACY_WP_ADMIN_PAGES).toHaveLength(12)
+  })
+
+  test('every slug is prefixed `wordpress-`', () => {
+    for (const page of LEGACY_WP_ADMIN_PAGES) {
+      expect(page.slug).toMatch(/^wordpress-/)
+    }
+  })
+
+  test('slugs are unique', () => {
+    const slugs = LEGACY_WP_ADMIN_PAGES.map((p) => p.slug)
+    expect(new Set(slugs).size).toBe(slugs.length)
+  })
+
+  test('every page belongs to a declared category', () => {
+    const ids = new Set(LEGACY_WP_ADMIN_CATEGORIES.map((c) => c.id))
+    for (const page of LEGACY_WP_ADMIN_PAGES) {
+      expect(ids.has(page.category)).toBe(true)
+    }
+  })
+
+  test('every page declares a public-source URL on freeforcharity.org', () => {
+    for (const page of LEGACY_WP_ADMIN_PAGES) {
+      expect(page.publicSourceUrl).toMatch(/^https:\/\/freeforcharity\.org\//)
+    }
+  })
+
+  test('public-source URLs are unique', () => {
+    const urls = LEGACY_WP_ADMIN_PAGES.map((p) => p.publicSourceUrl)
+    expect(new Set(urls).size).toBe(urls.length)
+  })
+
+  test('every category contains at least one page', () => {
+    for (const category of LEGACY_WP_ADMIN_CATEGORIES) {
+      expect(getLegacyWpAdminPagesByCategory(category.id).length).toBeGreaterThan(0)
+    }
+  })
+
+  test('category counts match the documented structure (5 / 3 / 4)', () => {
+    expect(getLegacyWpAdminPagesByCategory('wordpress-operations')).toHaveLength(5)
+    expect(getLegacyWpAdminPagesByCategory('charity-onboarding')).toHaveLength(3)
+    expect(getLegacyWpAdminPagesByCategory('volunteer-programs')).toHaveLength(4)
+  })
+
+  test('getLegacyWpAdminHref returns the canonical path shape', () => {
+    expect(getLegacyWpAdminHref('wordpress-domains')).toBe(
+      `${LEGACY_WP_ADMIN_BASE}/wordpress-domains`
+    )
+  })
+
+  test('getLegacyWpAdminPageBySlug round-trips', () => {
+    for (const page of LEGACY_WP_ADMIN_PAGES) {
+      expect(getLegacyWpAdminPageBySlug(page.slug)?.slug).toBe(page.slug)
+    }
+    expect(getLegacyWpAdminPageBySlug('nonexistent')).toBeUndefined()
+  })
+
+  test('relatedFfcAdminPaths (when present) point at known top-level routes', () => {
+    const allowedRelatedRoots = ['/training-plan', '/contributor-ladder', '/tech-stack']
+    for (const page of LEGACY_WP_ADMIN_PAGES) {
+      if (!page.relatedFfcAdminPaths) continue
+      for (const related of page.relatedFfcAdminPaths) {
+        expect(allowedRelatedRoots).toContain(related)
+      }
+    }
+  })
+})

--- a/__tests__/legacy-wordpress-administration.test.ts
+++ b/__tests__/legacy-wordpress-administration.test.ts
@@ -59,11 +59,13 @@ describe('Legacy WordPress Administration data', () => {
     )
   })
 
-  test('getLegacyWpAdminPageBySlug round-trips', () => {
+  test('getLegacyWpAdminPageBySlug round-trips for every known slug', () => {
     for (const page of LEGACY_WP_ADMIN_PAGES) {
-      expect(getLegacyWpAdminPageBySlug(page.slug)?.slug).toBe(page.slug)
+      expect(getLegacyWpAdminPageBySlug(page.slug).slug).toBe(page.slug)
     }
-    expect(getLegacyWpAdminPageBySlug('nonexistent')).toBeUndefined()
+    // Note: the slug parameter is type-constrained to the literal union
+    // LegacyWpAdminSlug, so a "nonexistent" call would not compile.
+    // TypeScript is the gate; no runtime test needed.
   })
 
   test('relatedFfcAdminPaths (when present) point at known top-level routes', () => {

--- a/__tests__/legacy-wp-admin-cross-references.test.ts
+++ b/__tests__/legacy-wp-admin-cross-references.test.ts
@@ -11,16 +11,15 @@
 
 import { readdirSync, readFileSync, statSync } from 'node:fs'
 import { join } from 'node:path'
-import { LEGACY_WP_ADMIN_BASE, LEGACY_WP_ADMIN_PAGES } from '@/data/legacy-wordpress-administration'
+import { LEGACY_WP_ADMIN_PAGES } from '@/data/legacy-wordpress-administration'
 
 const APP_DIR = join(process.cwd(), 'src', 'app', 'legacy-wordpress-administration')
 
 const KNOWN_SLUGS = new Set(LEGACY_WP_ADMIN_PAGES.map((p) => p.slug))
 
-const linkPattern = new RegExp(
-  `${LEGACY_WP_ADMIN_BASE.replace(/\//g, '\\/')}\\/([a-z0-9-]+)\\/?`,
-  'g'
-)
+// Hardcoded literal regex (CodeQL js/incomplete-sanitization compliant).
+// The section root is a fixed compile-time path; no dynamic interpolation.
+const linkPattern = /\/legacy-wordpress-administration\/([a-z0-9-]+)\/?/g
 
 function walk(dir: string): string[] {
   const out: string[] = []

--- a/__tests__/legacy-wp-admin-cross-references.test.ts
+++ b/__tests__/legacy-wp-admin-cross-references.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Cross-reference integrity for the Legacy WordPress Administration section.
+ *
+ * Every leaf page hand-codes links to sibling pages in the form
+ * `/legacy-wordpress-administration/<slug>/`. If a slug is renamed in
+ * src/data/legacy-wordpress-administration.ts, those hardcoded links
+ * silently break. This test grep-style scans every leaf page.tsx and
+ * the hub page, then asserts every referenced slug exists in the data
+ * file.
+ */
+
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+import { LEGACY_WP_ADMIN_BASE, LEGACY_WP_ADMIN_PAGES } from '@/data/legacy-wordpress-administration'
+
+const APP_DIR = join(process.cwd(), 'src', 'app', 'legacy-wordpress-administration')
+
+const KNOWN_SLUGS = new Set(LEGACY_WP_ADMIN_PAGES.map((p) => p.slug))
+
+const linkPattern = new RegExp(
+  `${LEGACY_WP_ADMIN_BASE.replace(/\//g, '\\/')}\\/([a-z0-9-]+)\\/?`,
+  'g'
+)
+
+function walk(dir: string): string[] {
+  const out: string[] = []
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) {
+      out.push(...walk(full))
+    } else if (entry === 'page.tsx') {
+      out.push(full)
+    }
+  }
+  return out
+}
+
+describe('Legacy WordPress Administration cross-references', () => {
+  const pageFiles = walk(APP_DIR)
+
+  test('found page.tsx for every documented slug + the hub', () => {
+    // 12 leaves + 1 hub = 13 page.tsx files
+    expect(pageFiles.length).toBe(LEGACY_WP_ADMIN_PAGES.length + 1)
+  })
+
+  test.each(pageFiles)('cross-references in %s all resolve to known slugs', (file) => {
+    const contents = readFileSync(file, 'utf-8')
+    const unknown: string[] = []
+    let match: RegExpExecArray | null
+    while ((match = linkPattern.exec(contents)) !== null) {
+      const slug = match[1]
+      // Empty slug means the link is to the hub itself, which is fine.
+      if (!slug) continue
+      if (!KNOWN_SLUGS.has(slug)) {
+        unknown.push(slug)
+      }
+    }
+    expect(unknown).toEqual([])
+  })
+})

--- a/__tests__/navigation-coverage.test.js
+++ b/__tests__/navigation-coverage.test.js
@@ -24,6 +24,7 @@ describe('Navigation Coverage', () => {
     { path: '/sites-list', name: 'Sites List' },
     { path: '/guides', name: 'Guides' },
     { path: '/blog', name: 'Blog' },
+    { path: '/legacy-wordpress-administration', name: 'Legacy WordPress Administration' },
     { path: '/volunteer', name: 'Volunteer' },
     { path: '/privacy-policy', name: 'Privacy Policy' },
     { path: '/cookie-policy', name: 'Cookie Policy' },

--- a/__tests__/route-generation.test.js
+++ b/__tests__/route-generation.test.js
@@ -92,4 +92,65 @@ describe('Route Generation Tests', () => {
       }
     })
   })
+
+  describe('Test Case 4.4: Legacy WordPress Administration Section', () => {
+    const sectionRoot = path.join(outDir, 'legacy-wordpress-administration')
+    const hubPath = path.join(sectionRoot, 'index.html')
+
+    const leafSlugs = [
+      'wordpress-hosting-techstack',
+      'wordpress-web-hosting',
+      'wordpress-domains',
+      'wordpress-cpanel-backup-sop',
+      'wordpress-online-impacts-onboarding',
+      'wordpress-charity-validation',
+      'wordpress-guidestar-guide',
+      'wordpress-service-delivery-stages',
+      'wordpress-training-programs',
+      'wordpress-web-developer-training',
+      'wordpress-tools-for-success',
+      'wordpress-volunteer-proving-ground',
+    ]
+
+    it('should generate the hub page', () => {
+      expect(fs.existsSync(hubPath)).toBe(true)
+    })
+
+    it('should generate index.html for every leaf page', () => {
+      for (const slug of leafSlugs) {
+        const leafPath = path.join(sectionRoot, slug, 'index.html')
+        expect(fs.existsSync(leafPath)).toBe(true)
+      }
+    })
+
+    it('hub page contains the section title and at least one category', () => {
+      if (fs.existsSync(hubPath)) {
+        const content = fs.readFileSync(hubPath, 'utf-8')
+        expect(content).toContain('Legacy WordPress Administration')
+        expect(content).toContain('WordPress Operations')
+      }
+    })
+
+    it('every leaf page contains the audience callout', () => {
+      for (const slug of leafSlugs) {
+        const leafPath = path.join(sectionRoot, slug, 'index.html')
+        if (fs.existsSync(leafPath)) {
+          const content = fs.readFileSync(leafPath, 'utf-8')
+          // The PageHeader component renders this audience callout.
+          expect(content).toMatch(/Looking to apply for a free FFC site\?/)
+        }
+      }
+    })
+
+    it('every leaf page sets a self-canonical URL', () => {
+      for (const slug of leafSlugs) {
+        const leafPath = path.join(sectionRoot, slug, 'index.html')
+        if (fs.existsSync(leafPath)) {
+          const content = fs.readFileSync(leafPath, 'utf-8')
+          const expected = `https://ffcadmin.org/legacy-wordpress-administration/${slug}/`
+          expect(content).toContain(`<link rel="canonical" href="${expected}"/>`)
+        }
+      }
+    })
+  })
 })

--- a/docs/cloudflare-bulk-redirects-cutover.csv
+++ b/docs/cloudflare-bulk-redirects-cutover.csv
@@ -1,0 +1,7 @@
+source_url,target_url,status,preserve_query_string,preserve_path_suffix,subpath_matching,include_subdomains,enabled,notes
+https://freeforcharity.org/free-for-charity-terms-of-service/,https://freeforcharity.org/terms-of-service/,301,true,false,false,false,true,Slug shortened during static rebuild
+https://freeforcharity.org/donor-dashboard/,https://freeforcharity.org/donate/,301,true,false,false,false,true,WP-only page dropped; route donors to canonical donate flow
+https://freeforcharity.org/donation-failed/,https://freeforcharity.org/donate/,301,true,false,false,false,true,Legacy payment-flow page dropped; route to canonical donate flow
+https://freeforcharity.org/donation-confirmation/,https://freeforcharity.org/donate/,301,true,false,false,false,true,Legacy payment-flow page dropped; route to canonical donate flow
+https://freeforcharity.org/sample-page/,https://freeforcharity.org/,301,true,false,false,false,true,WordPress default sample page; no SEO value
+https://freeforcharity.org/codetest/,https://freeforcharity.org/,301,true,false,false,false,true,Developer test page; no SEO value

--- a/docs/dns-cutover-site-plan.md
+++ b/docs/dns-cutover-site-plan.md
@@ -104,78 +104,89 @@ for the volunteer / admin audience. Each ffcadmin copy sets
 cross-links to the public-facing freeforcharity.org page for charity
 visitors.
 
+**Slug convention:** every leaf page slug is prefixed `wordpress-` so the
+URL itself disambiguates the legacy operations copy from the canonical
+freeforcharity.org page. The slug naming holds up in breadcrumbs, nav
+labels, search results, and any in-body cross-reference.
+
 | WordPress Slug                                            | freeforcharity.org (kept)                                 | ffcadmin.org re-home                                                                       |
 | --------------------------------------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| `/free-training-programs/`                                | `/free-training-programs/`                                | `/legacy-wordpress-administration/training-programs/`                                       |
-| `/free-for-charitys-tools-for-success/`                   | `/free-for-charitys-tools-for-success/`                   | `/legacy-wordpress-administration/tools-for-success/`                                       |
-| `/guidestar-guide/`                                       | `/guidestar-guide/`                                       | `/legacy-wordpress-administration/guidestar-guide/`                                         |
-| `/charity-validation-guide-.../`                          | `/charity-validation-guide-.../`                          | `/legacy-wordpress-administration/charity-validation/`                                      |
-| `/online-impacts-onboarding-guide/`                       | `/online-impacts-onboarding-guide/`                       | `/legacy-wordpress-administration/online-impacts-onboarding/`                               |
-| `/ffc-volunteer-proving-ground-core-competencies/`        | `/ffc-volunteer-proving-ground-core-competencies/`        | `/legacy-wordpress-administration/volunteer-proving-ground/`                                |
-| `/free-for-charity-ffc-web-developer-training-guide/`     | `/free-for-charity-ffc-web-developer-training-guide/`     | `/legacy-wordpress-administration/web-developer-training/`                                  |
-| `/free-for-charity-ffc-service-delivery-stages/`          | `/free-for-charity-ffc-service-delivery-stages/`          | `/legacy-wordpress-administration/service-delivery-stages/`                                 |
-| `/techstack/`                                             | `/techstack/`                                             | `/legacy-wordpress-administration/hosting-techstack/` + summary into existing `/tech-stack/` |
+| `/techstack/`                                             | `/techstack/`                                             | `/legacy-wordpress-administration/wordpress-hosting-techstack/`                              |
+| `/free-charity-web-hosting/`                              | `/free-charity-web-hosting/`                              | `/legacy-wordpress-administration/wordpress-web-hosting/`                                    |
+| `/domains/`                                               | `/domains/`                                               | `/legacy-wordpress-administration/wordpress-domains/`                                        |
+| `/ffcadmin-free-for-charity-cpanel-backup-sop/`           | `/ffcadmin-free-for-charity-cpanel-backup-sop/`           | `/legacy-wordpress-administration/wordpress-cpanel-backup-sop/`                              |
+| `/online-impacts-onboarding-guide/`                       | `/online-impacts-onboarding-guide/`                       | `/legacy-wordpress-administration/wordpress-online-impacts-onboarding/`                      |
+| `/charity-validation-guide-.../`                          | `/charity-validation-guide-.../`                          | `/legacy-wordpress-administration/wordpress-charity-validation/`                             |
+| `/guidestar-guide/`                                       | `/guidestar-guide/`                                       | `/legacy-wordpress-administration/wordpress-guidestar-guide/`                                |
+| `/free-for-charity-ffc-service-delivery-stages/`          | `/free-for-charity-ffc-service-delivery-stages/`          | `/legacy-wordpress-administration/wordpress-service-delivery-stages/`                        |
+| `/free-training-programs/`                                | `/free-training-programs/`                                | `/legacy-wordpress-administration/wordpress-training-programs/`                              |
+| `/free-for-charity-ffc-web-developer-training-guide/`     | `/free-for-charity-ffc-web-developer-training-guide/`     | `/legacy-wordpress-administration/wordpress-web-developer-training/`                         |
+| `/free-for-charitys-tools-for-success/`                   | `/free-for-charitys-tools-for-success/`                   | `/legacy-wordpress-administration/wordpress-tools-for-success/`                              |
+| `/ffc-volunteer-proving-ground-core-competencies/`        | `/ffc-volunteer-proving-ground-core-competencies/`        | `/legacy-wordpress-administration/wordpress-volunteer-proving-ground/`                       |
 | `/ffcadmin/`                                              | `/ffcadmin/` (signpost page → links to ffcadmin.org)      | `/` (this site)                                                                            |
-| `/ffcadmin-free-for-charity-cpanel-backup-sop/`           | `/ffcadmin-free-for-charity-cpanel-backup-sop/`           | `/legacy-wordpress-administration/cpanel-backup-sop/`                                       |
 
 ### Section structure
 
 The Legacy WordPress Administration hub is **one-level-deep**: a hub
-landing plus ten sibling pages. Categorization happens visually on the
-hub landing and in the sidebar, driven by a single data file.
+landing plus twelve sibling pages. Categorization happens visually on
+the hub landing and in the sidebar, driven by a single data file.
 
 **URL tree:**
 
 ```
-/legacy-wordpress-administration/                    Hub landing (cards + audience framing)
-├── hosting-techstack/                                WordPress Operations
-├── cpanel-backup-sop/                                WordPress Operations
-├── online-impacts-onboarding/                        WordPress Operations
-├── charity-validation/                               Charity Onboarding
-├── guidestar-guide/                                  Charity Onboarding
-├── service-delivery-stages/                          Charity Onboarding
-├── training-programs/                                Volunteer Programs
-├── web-developer-training/                           Volunteer Programs
-├── tools-for-success/                                Volunteer Programs
-└── volunteer-proving-ground/                         Volunteer Programs
+/legacy-wordpress-administration/                                 Hub landing
+├── wordpress-hosting-techstack/                                   WordPress Operations
+├── wordpress-web-hosting/                                         WordPress Operations
+├── wordpress-domains/                                             WordPress Operations
+├── wordpress-cpanel-backup-sop/                                   WordPress Operations
+├── wordpress-online-impacts-onboarding/                           WordPress Operations
+├── wordpress-charity-validation/                                  Charity Onboarding
+├── wordpress-guidestar-guide/                                     Charity Onboarding
+├── wordpress-service-delivery-stages/                             Charity Onboarding
+├── wordpress-training-programs/                                   Volunteer Programs
+├── wordpress-web-developer-training/                              Volunteer Programs
+├── wordpress-tools-for-success/                                   Volunteer Programs
+└── wordpress-volunteer-proving-ground/                            Volunteer Programs
 ```
 
 **Categories (visual only, not URL segments):**
 
-| Category               | Pages                                                                                                  |
-| ---------------------- | ------------------------------------------------------------------------------------------------------ |
-| WordPress Operations   | hosting-techstack, cpanel-backup-sop, online-impacts-onboarding                                        |
-| Charity Onboarding     | charity-validation, guidestar-guide, service-delivery-stages                                           |
-| Volunteer Programs     | training-programs, web-developer-training, tools-for-success, volunteer-proving-ground                 |
+| Category               | Pages                                                                                                                                              |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| WordPress Operations   | wordpress-hosting-techstack, wordpress-web-hosting, wordpress-domains, wordpress-cpanel-backup-sop, wordpress-online-impacts-onboarding             |
+| Charity Onboarding     | wordpress-charity-validation, wordpress-guidestar-guide, wordpress-service-delivery-stages                                                          |
+| Volunteer Programs     | wordpress-training-programs, wordpress-web-developer-training, wordpress-tools-for-success, wordpress-volunteer-proving-ground                      |
 
 **File / component layout:**
 
 ```
 src/app/legacy-wordpress-administration/
-  layout.tsx                      Sidebar + breadcrumb wrapper for the whole section
-  page.tsx                        Hub landing (intro, cross-link, category grid)
-  hosting-techstack/page.tsx
-  cpanel-backup-sop/page.tsx
-  online-impacts-onboarding/page.tsx
-  charity-validation/page.tsx
-  guidestar-guide/page.tsx
-  service-delivery-stages/page.tsx
-  training-programs/page.tsx
-  web-developer-training/page.tsx
-  tools-for-success/page.tsx
-  volunteer-proving-ground/page.tsx
+  layout.tsx                              Sidebar + breadcrumb wrapper for the whole section
+  page.tsx                                Hub landing (intro, cross-link, category grid)
+  wordpress-hosting-techstack/page.tsx
+  wordpress-web-hosting/page.tsx
+  wordpress-domains/page.tsx
+  wordpress-cpanel-backup-sop/page.tsx
+  wordpress-online-impacts-onboarding/page.tsx
+  wordpress-charity-validation/page.tsx
+  wordpress-guidestar-guide/page.tsx
+  wordpress-service-delivery-stages/page.tsx
+  wordpress-training-programs/page.tsx
+  wordpress-web-developer-training/page.tsx
+  wordpress-tools-for-success/page.tsx
+  wordpress-volunteer-proving-ground/page.tsx
 
 src/components/legacy-wordpress-administration/
-  Sidebar.tsx                     Category-grouped left-rail nav, shared by every child
-  PageHeader.tsx                  Top audience callout + public-version cross-link
-  CategoryGrid.tsx                Card grid for the hub landing
+  Sidebar.tsx                             Category-grouped left-rail nav, shared by every child
+  PageHeader.tsx                          Top audience callout + public-version cross-link
+  CategoryGrid.tsx                        Card grid for the hub landing
 
 src/data/
   legacy-wordpress-administration.ts
-                                  Single source of truth: pages, categories,
-                                  freeforcharity.org cross-link map, summaries.
-                                  Loaded by Sidebar, CategoryGrid, sitemap.ts,
-                                  and each page's metadata export.
+                                          Single source of truth: pages, categories,
+                                          freeforcharity.org cross-link map, summaries.
+                                          Loaded by Sidebar, CategoryGrid, sitemap.ts,
+                                          and each page's metadata export.
 ```
 
 **Hub landing layout (`/legacy-wordpress-administration/`):**
@@ -188,7 +199,7 @@ src/data/
 3. Cross-link strip: "Looking for the charity-facing versions? →
    freeforcharity.org".
 4. Three category sections, each a card grid:
-   - **WordPress Operations** (3 cards)
+   - **WordPress Operations** (5 cards)
    - **Charity Onboarding** (3 cards)
    - **Volunteer Programs** (4 cards)
 5. "Why 'Legacy'?" — short explainer that the procedures stay
@@ -207,7 +218,7 @@ src/data/
 3. Body content (migrated from WP, rewritten for the volunteer / admin
    voice).
 4. Sidebar (left rail on desktop, collapsed accordion on mobile) —
-   category-grouped list of all 10 leaf pages with current page
+   category-grouped list of all 12 leaf pages with current page
    highlighted.
 5. Bottom CTAs:
    - "Back to Legacy WordPress Administration hub →"
@@ -221,7 +232,7 @@ in-page anchors to the hub landing, plus "View all" linking to the hub.
 
 **Sitemap (`src/app/sitemap.ts`):**
 
-11 new URLs (hub + 10 children) at `priority: 0.6`, `changeFrequency:
+13 new URLs (hub + 12 children) at `priority: 0.6`, `changeFrequency:
 'monthly'`. Driven from `src/data/legacy-wordpress-administration.ts` so
 adding a page automatically adds a sitemap entry.
 
@@ -230,8 +241,9 @@ adding a page automatically adds a sitemap entry.
 Each ffcadmin page sets `metadata.alternates.canonical` to its own
 ffcadmin.org URL. The matching freeforcharity.org page also canonicals
 to itself. Both copies are intentional — different audience, different
-voice — so duplicate-content risk is mitigated by intent + cross-links,
-not by canonical pointing across domains.
+voice, different slug — so duplicate-content risk is mitigated by
+intent + naming + cross-links, not by canonical pointing across
+domains.
 
 ### Drop (with redirects)
 

--- a/docs/dns-cutover-site-plan.md
+++ b/docs/dns-cutover-site-plan.md
@@ -17,7 +17,7 @@ keeps **every major category** it has today — we are not pruning pages,
 we are converting them to the Next.js / static architecture.
 
 What changes is the **emphasis** on each site, and the addition of a
-clearly demarcated **Legacy Administration** section on ffcadmin.org that
+clearly demarcated **Legacy WordPress Administration** section on ffcadmin.org that
 re-homes the operations-flavored content for the volunteer / admin
 audience.
 
@@ -61,7 +61,7 @@ Source: `docs/ffc-content-audit.csv`, `docs/ffc-url-mapping.md`.
 `freeforcharity.org/<slug>/` URL after cutover. The static Next.js
 implementation in `FreeForCharity/FreeForCharity.org` is the new
 authoritative copy. The "moves" below are **copies into ffcadmin.org's
-Legacy Administration section** — not removals from freeforcharity.org.
+Legacy WordPress Administration section** — not removals from freeforcharity.org.
 
 ### Keep on freeforcharity.org (donor / marketing / acquisition)
 
@@ -94,29 +94,144 @@ and remain there. The cutover plan does not remove them.
 | `/vulnerability-disclosure-policy/`  | Required legal                                |
 | `/security-acknowledgements/`        | Required legal                                |
 
-### Re-home on ffcadmin.org (Legacy Administration section)
+### Re-home on ffcadmin.org (Legacy WordPress Administration section)
 
 These pages are operational. They **remain published** at their
 freeforcharity.org URLs (rebuilt in Next.js) AND get a re-homed copy
-under ffcadmin.org's new `/legacy-administration/` hub, framed for the
-volunteer / admin audience. Each ffcadmin copy sets
+under ffcadmin.org's new `/legacy-wordpress-administration/` hub, framed
+for the volunteer / admin audience. Each ffcadmin copy sets
 `<link rel="canonical">` to itself (it's the operations-team copy) and
 cross-links to the public-facing freeforcharity.org page for charity
 visitors.
 
-| WordPress Slug                                            | freeforcharity.org (kept)                                 | ffcadmin.org re-home                                                    |
-| --------------------------------------------------------- | --------------------------------------------------------- | ----------------------------------------------------------------------- |
-| `/free-training-programs/`                                | `/free-training-programs/`                                | `/legacy-administration/training-programs/` + link from `/training-plan/` |
-| `/free-for-charitys-tools-for-success/`                   | `/free-for-charitys-tools-for-success/`                   | `/legacy-administration/tools-for-success/`                             |
-| `/guidestar-guide/`                                       | `/guidestar-guide/`                                       | `/legacy-administration/guidestar-guide/`                               |
-| `/charity-validation-guide-.../`                          | `/charity-validation-guide-.../`                          | `/legacy-administration/charity-validation/`                            |
-| `/online-impacts-onboarding-guide/`                       | `/online-impacts-onboarding-guide/`                       | `/legacy-administration/online-impacts-onboarding/`                     |
-| `/ffc-volunteer-proving-ground-core-competencies/`        | `/ffc-volunteer-proving-ground-core-competencies/`        | `/legacy-administration/volunteer-proving-ground/` + link from `/contributor-ladder/` |
-| `/free-for-charity-ffc-web-developer-training-guide/`     | `/free-for-charity-ffc-web-developer-training-guide/`     | `/legacy-administration/web-developer-training/` + link from `/training-plan/` |
-| `/free-for-charity-ffc-service-delivery-stages/`          | `/free-for-charity-ffc-service-delivery-stages/`          | `/legacy-administration/service-delivery-stages/`                       |
-| `/techstack/`                                             | `/techstack/`                                             | merge into existing `/tech-stack/` + summary in Legacy Administration   |
-| `/ffcadmin/`                                              | `/ffcadmin/` (signpost page → links to ffcadmin.org)      | `/` (this site)                                                         |
-| `/ffcadmin-free-for-charity-cpanel-backup-sop/`           | `/ffcadmin-free-for-charity-cpanel-backup-sop/`           | `/legacy-administration/cpanel-backup-sop/`                             |
+| WordPress Slug                                            | freeforcharity.org (kept)                                 | ffcadmin.org re-home                                                                       |
+| --------------------------------------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| `/free-training-programs/`                                | `/free-training-programs/`                                | `/legacy-wordpress-administration/training-programs/`                                       |
+| `/free-for-charitys-tools-for-success/`                   | `/free-for-charitys-tools-for-success/`                   | `/legacy-wordpress-administration/tools-for-success/`                                       |
+| `/guidestar-guide/`                                       | `/guidestar-guide/`                                       | `/legacy-wordpress-administration/guidestar-guide/`                                         |
+| `/charity-validation-guide-.../`                          | `/charity-validation-guide-.../`                          | `/legacy-wordpress-administration/charity-validation/`                                      |
+| `/online-impacts-onboarding-guide/`                       | `/online-impacts-onboarding-guide/`                       | `/legacy-wordpress-administration/online-impacts-onboarding/`                               |
+| `/ffc-volunteer-proving-ground-core-competencies/`        | `/ffc-volunteer-proving-ground-core-competencies/`        | `/legacy-wordpress-administration/volunteer-proving-ground/`                                |
+| `/free-for-charity-ffc-web-developer-training-guide/`     | `/free-for-charity-ffc-web-developer-training-guide/`     | `/legacy-wordpress-administration/web-developer-training/`                                  |
+| `/free-for-charity-ffc-service-delivery-stages/`          | `/free-for-charity-ffc-service-delivery-stages/`          | `/legacy-wordpress-administration/service-delivery-stages/`                                 |
+| `/techstack/`                                             | `/techstack/`                                             | `/legacy-wordpress-administration/hosting-techstack/` + summary into existing `/tech-stack/` |
+| `/ffcadmin/`                                              | `/ffcadmin/` (signpost page → links to ffcadmin.org)      | `/` (this site)                                                                            |
+| `/ffcadmin-free-for-charity-cpanel-backup-sop/`           | `/ffcadmin-free-for-charity-cpanel-backup-sop/`           | `/legacy-wordpress-administration/cpanel-backup-sop/`                                       |
+
+### Section structure
+
+The Legacy WordPress Administration hub is **one-level-deep**: a hub
+landing plus ten sibling pages. Categorization happens visually on the
+hub landing and in the sidebar, driven by a single data file.
+
+**URL tree:**
+
+```
+/legacy-wordpress-administration/                    Hub landing (cards + audience framing)
+├── hosting-techstack/                                WordPress Operations
+├── cpanel-backup-sop/                                WordPress Operations
+├── online-impacts-onboarding/                        WordPress Operations
+├── charity-validation/                               Charity Onboarding
+├── guidestar-guide/                                  Charity Onboarding
+├── service-delivery-stages/                          Charity Onboarding
+├── training-programs/                                Volunteer Programs
+├── web-developer-training/                           Volunteer Programs
+├── tools-for-success/                                Volunteer Programs
+└── volunteer-proving-ground/                         Volunteer Programs
+```
+
+**Categories (visual only, not URL segments):**
+
+| Category               | Pages                                                                                                  |
+| ---------------------- | ------------------------------------------------------------------------------------------------------ |
+| WordPress Operations   | hosting-techstack, cpanel-backup-sop, online-impacts-onboarding                                        |
+| Charity Onboarding     | charity-validation, guidestar-guide, service-delivery-stages                                           |
+| Volunteer Programs     | training-programs, web-developer-training, tools-for-success, volunteer-proving-ground                 |
+
+**File / component layout:**
+
+```
+src/app/legacy-wordpress-administration/
+  layout.tsx                      Sidebar + breadcrumb wrapper for the whole section
+  page.tsx                        Hub landing (intro, cross-link, category grid)
+  hosting-techstack/page.tsx
+  cpanel-backup-sop/page.tsx
+  online-impacts-onboarding/page.tsx
+  charity-validation/page.tsx
+  guidestar-guide/page.tsx
+  service-delivery-stages/page.tsx
+  training-programs/page.tsx
+  web-developer-training/page.tsx
+  tools-for-success/page.tsx
+  volunteer-proving-ground/page.tsx
+
+src/components/legacy-wordpress-administration/
+  Sidebar.tsx                     Category-grouped left-rail nav, shared by every child
+  PageHeader.tsx                  Top audience callout + public-version cross-link
+  CategoryGrid.tsx                Card grid for the hub landing
+
+src/data/
+  legacy-wordpress-administration.ts
+                                  Single source of truth: pages, categories,
+                                  freeforcharity.org cross-link map, summaries.
+                                  Loaded by Sidebar, CategoryGrid, sitemap.ts,
+                                  and each page's metadata export.
+```
+
+**Hub landing layout (`/legacy-wordpress-administration/`):**
+
+1. Hero: title + one-paragraph audience framing.
+2. "What this section is" callout: "Operations and SOP reference for
+   FFC volunteers, admins, and partner charities still running their
+   own WordPress. The public charity-facing versions of these pages
+   live on freeforcharity.org."
+3. Cross-link strip: "Looking for the charity-facing versions? →
+   freeforcharity.org".
+4. Three category sections, each a card grid:
+   - **WordPress Operations** (3 cards)
+   - **Charity Onboarding** (3 cards)
+   - **Volunteer Programs** (4 cards)
+5. "Why 'Legacy'?" — short explainer that the procedures stay
+   published because many partner charities still run WordPress.
+6. Bottom CTAs:
+   - "Ready to move off WordPress? → `/guides/wordpress-to-nextjs-guide/`"
+   - "Apply for FFC migration help → freeforcharity.org/submit-information"
+
+**Child page template (every leaf page):**
+
+1. Breadcrumb: Home → Legacy WordPress Administration → \<Category\> → \<Page\>.
+2. `PageHeader` component:
+   - Audience callout (one line).
+   - "Public version for charity visitors →" link to the matching
+     freeforcharity.org URL (from `legacy-wordpress-administration.ts`).
+3. Body content (migrated from WP, rewritten for the volunteer / admin
+   voice).
+4. Sidebar (left rail on desktop, collapsed accordion on mobile) —
+   category-grouped list of all 10 leaf pages with current page
+   highlighted.
+5. Bottom CTAs:
+   - "Back to Legacy WordPress Administration hub →"
+   - "Ready to move off WordPress? → `/guides/wordpress-to-nextjs-guide/`"
+
+**Navigation (`src/data/navigation.ts`):**
+
+Add a new top-level dropdown **"Legacy WP Admin"** (or place under
+Resources — see issue discussion). Items: the three category names as
+in-page anchors to the hub landing, plus "View all" linking to the hub.
+
+**Sitemap (`src/app/sitemap.ts`):**
+
+11 new URLs (hub + 10 children) at `priority: 0.6`, `changeFrequency:
+'monthly'`. Driven from `src/data/legacy-wordpress-administration.ts` so
+adding a page automatically adds a sitemap entry.
+
+**Canonicals:**
+
+Each ffcadmin page sets `metadata.alternates.canonical` to its own
+ffcadmin.org URL. The matching freeforcharity.org page also canonicals
+to itself. Both copies are intentional — different audience, different
+voice — so duplicate-content risk is mitigated by intent + cross-links,
+not by canonical pointing across domains.
 
 ### Drop (with redirects)
 
@@ -141,7 +256,8 @@ they are donor / trust-signal content. Do not move to ffcadmin.org's blog
 
 ## Changes Required on ffcadmin.org (this repo)
 
-1. **Build the Legacy Administration hub** at `/legacy-administration/`
+1. **Build the Legacy WordPress Administration hub** at
+   `/legacy-wordpress-administration/`
    that receives the 11 re-homed pages (listed above). Each page must:
    - Be authored in Next.js / Tailwind matching the existing
      `src/app/guides/` and `src/app/training-plan/` patterns.
@@ -162,11 +278,11 @@ they are donor / trust-signal content. Do not move to ffcadmin.org's blog
    site" block with one-line description and link.
 
 4. **Sitemap update** — `src/app/sitemap.ts` must include the new
-   Legacy Administration routes.
+   Legacy WordPress Administration routes.
 
 5. **Internal-link audit** — every in-body link from ffcadmin pages to
    freeforcharity.org should be reviewed: if it points to operations
-   content, redirect to the ffcadmin Legacy Administration page; if it
+   content, redirect to the ffcadmin Legacy WordPress Administration page; if it
    points to donor / applicant content, keep pointing to freeforcharity.
 
 ## Changes Required on freeforcharity.org (`FreeForCharity/FreeForCharity.org`)

--- a/docs/dns-cutover-site-plan.md
+++ b/docs/dns-cutover-site-plan.md
@@ -21,10 +21,10 @@ clearly demarcated **Legacy WordPress Administration** section on ffcadmin.org t
 re-homes the operations-flavored content for the volunteer / admin
 audience.
 
-| Site                | Repo                                  | Audience                              | Primary CTA                             |
-| ------------------- | ------------------------------------- | ------------------------------------- | --------------------------------------- |
-| freeforcharity.org  | `FreeForCharity/FreeForCharity.org`   | Donors, prospective charity clients   | **Apply for a free site** → backlog     |
-| ffcadmin.org        | `FreeForCharity/FFC-IN-ffcadmin.org`  | Volunteers, admins, partner charities | **Start training / contribute**         |
+| Site               | Repo                                 | Audience                              | Primary CTA                         |
+| ------------------ | ------------------------------------ | ------------------------------------- | ----------------------------------- |
+| freeforcharity.org | `FreeForCharity/FreeForCharity.org`  | Donors, prospective charity clients   | **Apply for a free site** → backlog |
+| ffcadmin.org       | `FreeForCharity/FFC-IN-ffcadmin.org` | Volunteers, admins, partner charities | **Start training / contribute**     |
 
 ffcadmin.org also remains the **public training portal and Legacy
 Administration archive for charities still running their own WordPress**
@@ -68,31 +68,31 @@ Legacy WordPress Administration section** — not removals from freeforcharity.o
 These pages are already built in the marketing repo per the URL mapping doc
 and remain there. The cutover plan does not remove them.
 
-| WordPress Slug                       | Why it stays                                  |
-| ------------------------------------ | --------------------------------------------- |
-| `/`                                  | Homepage — primary CTA = Apply                |
-| `/about-us/`                         | About FFC, leadership, history                |
-| `/contact-us/`                       | Donor / applicant contact                     |
-| `/donate/`                           | Donation flow                                 |
-| `/volunteer/`                        | Recruitment landing (links → ffcadmin.org)    |
-| `/501c3/`                            | Charity-applicant marketing                   |
-| `/pre501c3/`                         | Charity-applicant marketing                   |
-| `/domains/`                          | Charity-applicant marketing                   |
-| `/free-charity-web-hosting/`         | Charity-applicant marketing                   |
-| `/help-for-charities/`               | Charity-applicant marketing                   |
-| `/free-for-charity-endowment-fund/`  | Donor / sustainability story                  |
-| `/consulting/`                       | Acquisition for paid consulting               |
-| `/workforce-development/`            | Acquisition for volunteer / hire pipeline     |
-| `/case-studies/`                     | Donor / applicant social proof                |
-| `/technology-directory/`             | Public-facing partner / applicant resource    |
-| `/service-directory/`                | Public-facing partner / applicant resource    |
-| `/submit-information/`               | **Primary CTA target form** — apply for site  |
-| `/blog/` (donor-facing posts only)   | Press / SEO                                   |
-| `/privacy-policy/`                   | Required legal                                |
-| `/free-for-charity-terms-of-service/`| Required legal                                |
-| `/free-for-charity-donation-policy/` | Required legal                                |
-| `/vulnerability-disclosure-policy/`  | Required legal                                |
-| `/security-acknowledgements/`        | Required legal                                |
+| WordPress Slug                        | Why it stays                                 |
+| ------------------------------------- | -------------------------------------------- |
+| `/`                                   | Homepage — primary CTA = Apply               |
+| `/about-us/`                          | About FFC, leadership, history               |
+| `/contact-us/`                        | Donor / applicant contact                    |
+| `/donate/`                            | Donation flow                                |
+| `/volunteer/`                         | Recruitment landing (links → ffcadmin.org)   |
+| `/501c3/`                             | Charity-applicant marketing                  |
+| `/pre501c3/`                          | Charity-applicant marketing                  |
+| `/domains/`                           | Charity-applicant marketing                  |
+| `/free-charity-web-hosting/`          | Charity-applicant marketing                  |
+| `/help-for-charities/`                | Charity-applicant marketing                  |
+| `/free-for-charity-endowment-fund/`   | Donor / sustainability story                 |
+| `/consulting/`                        | Acquisition for paid consulting              |
+| `/workforce-development/`             | Acquisition for volunteer / hire pipeline    |
+| `/case-studies/`                      | Donor / applicant social proof               |
+| `/technology-directory/`              | Public-facing partner / applicant resource   |
+| `/service-directory/`                 | Public-facing partner / applicant resource   |
+| `/submit-information/`                | **Primary CTA target form** — apply for site |
+| `/blog/` (donor-facing posts only)    | Press / SEO                                  |
+| `/privacy-policy/`                    | Required legal                               |
+| `/free-for-charity-terms-of-service/` | Required legal                               |
+| `/free-for-charity-donation-policy/`  | Required legal                               |
+| `/vulnerability-disclosure-policy/`   | Required legal                               |
+| `/security-acknowledgements/`         | Required legal                               |
 
 ### Re-home on ffcadmin.org (Legacy WordPress Administration section)
 
@@ -109,21 +109,21 @@ URL itself disambiguates the legacy operations copy from the canonical
 freeforcharity.org page. The slug naming holds up in breadcrumbs, nav
 labels, search results, and any in-body cross-reference.
 
-| WordPress Slug                                            | freeforcharity.org (kept)                                 | ffcadmin.org re-home                                                                       |
-| --------------------------------------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| `/techstack/`                                             | `/techstack/`                                             | `/legacy-wordpress-administration/wordpress-hosting-techstack/`                              |
-| `/free-charity-web-hosting/`                              | `/free-charity-web-hosting/`                              | `/legacy-wordpress-administration/wordpress-web-hosting/`                                    |
-| `/domains/`                                               | `/domains/`                                               | `/legacy-wordpress-administration/wordpress-domains/`                                        |
-| `/ffcadmin-free-for-charity-cpanel-backup-sop/`           | `/ffcadmin-free-for-charity-cpanel-backup-sop/`           | `/legacy-wordpress-administration/wordpress-cpanel-backup-sop/`                              |
-| `/online-impacts-onboarding-guide/`                       | `/online-impacts-onboarding-guide/`                       | `/legacy-wordpress-administration/wordpress-online-impacts-onboarding/`                      |
-| `/charity-validation-guide-.../`                          | `/charity-validation-guide-.../`                          | `/legacy-wordpress-administration/wordpress-charity-validation/`                             |
-| `/guidestar-guide/`                                       | `/guidestar-guide/`                                       | `/legacy-wordpress-administration/wordpress-guidestar-guide/`                                |
-| `/free-for-charity-ffc-service-delivery-stages/`          | `/free-for-charity-ffc-service-delivery-stages/`          | `/legacy-wordpress-administration/wordpress-service-delivery-stages/`                        |
-| `/free-training-programs/`                                | `/free-training-programs/`                                | `/legacy-wordpress-administration/wordpress-training-programs/`                              |
-| `/free-for-charity-ffc-web-developer-training-guide/`     | `/free-for-charity-ffc-web-developer-training-guide/`     | `/legacy-wordpress-administration/wordpress-web-developer-training/`                         |
-| `/free-for-charitys-tools-for-success/`                   | `/free-for-charitys-tools-for-success/`                   | `/legacy-wordpress-administration/wordpress-tools-for-success/`                              |
-| `/ffc-volunteer-proving-ground-core-competencies/`        | `/ffc-volunteer-proving-ground-core-competencies/`        | `/legacy-wordpress-administration/wordpress-volunteer-proving-ground/`                       |
-| `/ffcadmin/`                                              | `/ffcadmin/` (signpost page → links to ffcadmin.org)      | `/` (this site)                                                                            |
+| WordPress Slug                                        | freeforcharity.org (kept)                             | ffcadmin.org re-home                                                    |
+| ----------------------------------------------------- | ----------------------------------------------------- | ----------------------------------------------------------------------- |
+| `/techstack/`                                         | `/techstack/`                                         | `/legacy-wordpress-administration/wordpress-hosting-techstack/`         |
+| `/free-charity-web-hosting/`                          | `/free-charity-web-hosting/`                          | `/legacy-wordpress-administration/wordpress-web-hosting/`               |
+| `/domains/`                                           | `/domains/`                                           | `/legacy-wordpress-administration/wordpress-domains/`                   |
+| `/ffcadmin-free-for-charity-cpanel-backup-sop/`       | `/ffcadmin-free-for-charity-cpanel-backup-sop/`       | `/legacy-wordpress-administration/wordpress-cpanel-backup-sop/`         |
+| `/online-impacts-onboarding-guide/`                   | `/online-impacts-onboarding-guide/`                   | `/legacy-wordpress-administration/wordpress-online-impacts-onboarding/` |
+| `/charity-validation-guide-.../`                      | `/charity-validation-guide-.../`                      | `/legacy-wordpress-administration/wordpress-charity-validation/`        |
+| `/guidestar-guide/`                                   | `/guidestar-guide/`                                   | `/legacy-wordpress-administration/wordpress-guidestar-guide/`           |
+| `/free-for-charity-ffc-service-delivery-stages/`      | `/free-for-charity-ffc-service-delivery-stages/`      | `/legacy-wordpress-administration/wordpress-service-delivery-stages/`   |
+| `/free-training-programs/`                            | `/free-training-programs/`                            | `/legacy-wordpress-administration/wordpress-training-programs/`         |
+| `/free-for-charity-ffc-web-developer-training-guide/` | `/free-for-charity-ffc-web-developer-training-guide/` | `/legacy-wordpress-administration/wordpress-web-developer-training/`    |
+| `/free-for-charitys-tools-for-success/`               | `/free-for-charitys-tools-for-success/`               | `/legacy-wordpress-administration/wordpress-tools-for-success/`         |
+| `/ffc-volunteer-proving-ground-core-competencies/`    | `/ffc-volunteer-proving-ground-core-competencies/`    | `/legacy-wordpress-administration/wordpress-volunteer-proving-ground/`  |
+| `/ffcadmin/`                                          | `/ffcadmin/` (signpost page → links to ffcadmin.org)  | `/` (this site)                                                         |
 
 ### Section structure
 
@@ -151,11 +151,11 @@ the hub landing and in the sidebar, driven by a single data file.
 
 **Categories (visual only, not URL segments):**
 
-| Category               | Pages                                                                                                                                              |
-| ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| WordPress Operations   | wordpress-hosting-techstack, wordpress-web-hosting, wordpress-domains, wordpress-cpanel-backup-sop, wordpress-online-impacts-onboarding             |
-| Charity Onboarding     | wordpress-charity-validation, wordpress-guidestar-guide, wordpress-service-delivery-stages                                                          |
-| Volunteer Programs     | wordpress-training-programs, wordpress-web-developer-training, wordpress-tools-for-success, wordpress-volunteer-proving-ground                      |
+| Category             | Pages                                                                                                                                   |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| WordPress Operations | wordpress-hosting-techstack, wordpress-web-hosting, wordpress-domains, wordpress-cpanel-backup-sop, wordpress-online-impacts-onboarding |
+| Charity Onboarding   | wordpress-charity-validation, wordpress-guidestar-guide, wordpress-service-delivery-stages                                              |
+| Volunteer Programs   | wordpress-training-programs, wordpress-web-developer-training, wordpress-tools-for-success, wordpress-volunteer-proving-ground          |
 
 **File / component layout:**
 
@@ -249,13 +249,13 @@ domains.
 
 Per the URL mapping doc — keep these decisions:
 
-| WordPress Slug              | Redirect target                |
-| --------------------------- | ------------------------------ |
-| `/sample-page/`             | `/`                            |
-| `/codetest/`                | `/`                            |
-| `/donor-dashboard/`         | `/donate/`                     |
-| `/donation-failed/`         | `/donate/`                     |
-| `/donation-confirmation/`   | `/donate/`                     |
+| WordPress Slug            | Redirect target |
+| ------------------------- | --------------- |
+| `/sample-page/`           | `/`             |
+| `/codetest/`              | `/`             |
+| `/donor-dashboard/`       | `/donate/`      |
+| `/donation-failed/`       | `/donate/`      |
+| `/donation-confirmation/` | `/donate/`      |
 
 ### Blog posts (6)
 

--- a/docs/dns-cutover-site-plan.md
+++ b/docs/dns-cutover-site-plan.md
@@ -1,0 +1,230 @@
+# DNS Cutover Site Plan: freeforcharity.org → GitHub Pages + ffcadmin.org Split
+
+> **Generated:** 2026-05-23
+> **Status:** Pre-cutover planning
+> **Scope:** Content split between the two FFC-owned public sites once the
+> WordPress install at freeforcharity.org is replaced by the static site in
+> `FreeForCharity/FreeForCharity.org`.
+
+---
+
+## Goal
+
+We are about to complete DNS cutover for `freeforcharity.org` from the
+InterServer cPanel WordPress install to a GitHub Pages static site
+(`FreeForCharity/FreeForCharity.org`). At the same time we want a clean
+audience split between the two sites so that each has a single primary
+purpose.
+
+| Site                | Repo                                  | Audience                              | Primary CTA                             |
+| ------------------- | ------------------------------------- | ------------------------------------- | --------------------------------------- |
+| freeforcharity.org  | `FreeForCharity/FreeForCharity.org`   | Donors, prospective charity clients   | **Apply for a free site** → backlog     |
+| ffcadmin.org        | `FreeForCharity/FFC-IN-ffcadmin.org`  | Volunteers, admins, partner charities | **Start training / contribute**         |
+
+ffcadmin.org also remains the **public training portal for charities still
+running their own WordPress** (FFC- or non-FFC-managed) so their staff can
+reference our procedures without needing to be in our org.
+
+---
+
+## Persona Boundary Rules
+
+Rules a reviewer can apply when deciding where a page belongs:
+
+1. **Acquisition?** (donor, applicant charity, press, search engine) →
+   freeforcharity.org
+2. **Operations?** (how we do the work — training, SOPs, runbooks, tech
+   stack, conversion guide) → ffcadmin.org
+3. **Cross-domain links** are required in both directions in the global
+   footer and on at least one in-body CTA per relevant page.
+4. **Donate** lives only on freeforcharity.org. ffcadmin.org links to it,
+   never hosts a donate flow itself.
+5. **Apply for a free site** lives only on freeforcharity.org. ffcadmin.org
+   links to it.
+6. **Training paths, contributor ladder, conversion guides** live only on
+   ffcadmin.org. freeforcharity.org links to them as "Volunteer" /
+   "How we build sites".
+
+---
+
+## Content Disposition — WordPress freeforcharity.org (38 pages)
+
+Source: `docs/ffc-content-audit.csv`, `docs/ffc-url-mapping.md`.
+
+### Keep on freeforcharity.org (donor / marketing / acquisition)
+
+These pages are already built in the marketing repo per the URL mapping doc
+and should remain. The cutover plan does not move them.
+
+| WordPress Slug                       | Why it stays                                  |
+| ------------------------------------ | --------------------------------------------- |
+| `/`                                  | Homepage — primary CTA = Apply                |
+| `/about-us/`                         | About FFC, leadership, history                |
+| `/contact-us/`                       | Donor / applicant contact                     |
+| `/donate/`                           | Donation flow                                 |
+| `/volunteer/`                        | Recruitment landing (links → ffcadmin.org)    |
+| `/501c3/`                            | Charity-applicant marketing                   |
+| `/pre501c3/`                         | Charity-applicant marketing                   |
+| `/domains/`                          | Charity-applicant marketing                   |
+| `/free-charity-web-hosting/`         | Charity-applicant marketing                   |
+| `/help-for-charities/`               | Charity-applicant marketing                   |
+| `/free-for-charity-endowment-fund/`  | Donor / sustainability story                  |
+| `/consulting/`                       | Acquisition for paid consulting               |
+| `/workforce-development/`            | Acquisition for volunteer / hire pipeline     |
+| `/case-studies/`                     | Donor / applicant social proof                |
+| `/technology-directory/`             | Public-facing partner / applicant resource    |
+| `/service-directory/`                | Public-facing partner / applicant resource    |
+| `/submit-information/`               | **Primary CTA target form** — apply for site  |
+| `/blog/` (donor-facing posts only)   | Press / SEO                                   |
+| `/privacy-policy/`                   | Required legal                                |
+| `/free-for-charity-terms-of-service/`| Required legal                                |
+| `/free-for-charity-donation-policy/` | Required legal                                |
+| `/vulnerability-disclosure-policy/`  | Required legal                                |
+| `/security-acknowledgements/`        | Required legal                                |
+
+### Move to ffcadmin.org (operations / training / procedures)
+
+These pages are operational — they belong with the volunteers and the
+partner-charity admins, not with donors. They should be migrated to
+ffcadmin.org and the freeforcharity.org URL should 301 to the ffcadmin.org
+equivalent.
+
+| WordPress Slug                                            | Move target on ffcadmin.org                       | Reason                                            |
+| --------------------------------------------------------- | ------------------------------------------------- | ------------------------------------------------- |
+| `/free-training-programs/`                                | `/training-plan/` (hub) + child pages             | Volunteer training                                |
+| `/free-for-charitys-tools-for-success/`                   | `/guides/tools-for-success/`                      | Partner-charity SOP                               |
+| `/guidestar-guide/`                                       | `/guides/guidestar-guide/`                        | Partner-charity SOP                               |
+| `/charity-validation-guide-.../`                          | `/guides/charity-validation/`                     | Internal SOP, public for transparency             |
+| `/online-impacts-onboarding-guide/`                       | `/guides/online-impacts-onboarding/`              | Partner-charity SOP                               |
+| `/ffc-volunteer-proving-ground-core-competencies/`        | `/contributor-ladder/proving-ground/`             | Volunteer training                                |
+| `/free-for-charity-ffc-web-developer-training-guide/`     | `/training-plan/web-developer/`                   | Volunteer training                                |
+| `/free-for-charity-ffc-service-delivery-stages/`          | `/guides/service-delivery-stages/`                | Internal SOP, public for transparency             |
+| `/techstack/`                                             | `/tech-stack/` (already exists — merge content)   | Operations                                        |
+| `/ffcadmin/`                                              | `/` (already the ffcadmin.org home)               | Already the right place                           |
+| `/ffcadmin-free-for-charity-cpanel-backup-sop/`           | `/guides/cpanel-backup-sop/`                      | Internal SOP                                      |
+
+### Drop (with redirects)
+
+Per the URL mapping doc — keep these decisions:
+
+| WordPress Slug              | Redirect target                |
+| --------------------------- | ------------------------------ |
+| `/sample-page/`             | `/`                            |
+| `/codetest/`                | `/`                            |
+| `/donor-dashboard/`         | `/donate/`                     |
+| `/donation-failed/`         | `/donate/`                     |
+| `/donation-confirmation/`   | `/donate/`                     |
+
+### Blog posts (6)
+
+The 6 legacy WP posts are largely GuideStar-seal updates and one cost FAQ.
+Recommendation: keep on freeforcharity.org under `/blog/[slug]/` because
+they are donor / trust-signal content. Do not move to ffcadmin.org's blog
+(which is volunteer-focused per Issue #186).
+
+---
+
+## Changes Required on ffcadmin.org (this repo)
+
+1. **Receive 11 migrated pages** from WordPress (listed above). Each page
+   must:
+   - Be authored in Next.js / Tailwind matching the existing
+     `src/app/guides/` and `src/app/training-plan/` patterns.
+   - Carry a top callout: "Looking to apply for a free FFC site? Visit
+     freeforcharity.org/submit-information."
+   - Include canonical link back to itself on ffcadmin.org.
+
+2. **Disambiguate the homepage and nav** so visitors who arrive at
+   ffcadmin.org looking for donation / application are bounced to
+   freeforcharity.org with a single click (banner + nav item "For
+   Charities / Donors → freeforcharity.org").
+
+3. **Footer cross-link block** — both sites' footers must include a "Sister
+   site" block with one-line description and link.
+
+4. **Public "For Partner Charities" hub** at `/for-charities/` that
+   collects the migrated procedures pages and explains: "Your charity may
+   still be on WordPress while you wait for or evaluate a static
+   migration. These procedures are kept public so your staff can use them."
+
+5. **Sitemap update** — `src/app/sitemap.ts` must include the new
+   guides / training routes.
+
+6. **Internal-link sweep** — replace any in-body link to
+   `freeforcharity.org/<moved-slug>` with the ffcadmin.org equivalent.
+
+7. **Drop overlapping admin-only pages from freeforcharity.org**: the
+   marketing repo should `noindex` or remove `/ffcadmin/`, `/techstack/`,
+   `/ffc-volunteer-proving-ground.../`, etc. once the redirects below are
+   in place.
+
+## Changes Required on freeforcharity.org (`FreeForCharity/FreeForCharity.org`)
+
+Filed via companion issues / PRs in that repo, but coordinated from here:
+
+1. **Homepage CTA hierarchy**: primary = "Apply for a free site" (form
+   submit), secondary = "Donate", tertiary = "Volunteer (→ ffcadmin.org)".
+2. **Remove or stub the migrated pages** (see Move list). Each becomes a
+   301 → ffcadmin.org equivalent.
+3. **Volunteer page**: trim WordPress content, repurpose as a one-screen
+   landing that funnels to ffcadmin.org/get-involved.
+4. **Sister-site footer block** linking to ffcadmin.org.
+5. **Sitemap + robots**: confirm no longer indexes the moved slugs.
+
+## Cloudflare Bulk Redirects
+
+Configure in Cloudflare for `freeforcharity.org` before DNS cutover so the
+WordPress origin can be retired with no broken inbound links:
+
+```
+# Drops (existing — keep from ffc-url-mapping.md)
+/free-for-charity-terms-of-service/   →  /terms-of-service/                       [same domain]
+/donor-dashboard/                     →  /donate/                                  [same domain]
+/donation-failed/                     →  /donate/                                  [same domain]
+/donation-confirmation/               →  /donate/                                  [same domain]
+/sample-page/                         →  /                                          [same domain]
+/codetest/                            →  /                                          [same domain]
+
+# Cross-domain moves (new for this cutover)
+/free-training-programs/                                →  https://ffcadmin.org/training-plan/
+/free-for-charitys-tools-for-success/                   →  https://ffcadmin.org/guides/tools-for-success/
+/guidestar-guide/                                       →  https://ffcadmin.org/guides/guidestar-guide/
+/charity-validation-guide-.../                          →  https://ffcadmin.org/guides/charity-validation/
+/online-impacts-onboarding-guide/                       →  https://ffcadmin.org/guides/online-impacts-onboarding/
+/ffc-volunteer-proving-ground-core-competencies/        →  https://ffcadmin.org/contributor-ladder/proving-ground/
+/free-for-charity-ffc-web-developer-training-guide/     →  https://ffcadmin.org/training-plan/web-developer/
+/free-for-charity-ffc-service-delivery-stages/          →  https://ffcadmin.org/guides/service-delivery-stages/
+/techstack/                                             →  https://ffcadmin.org/tech-stack/
+/ffcadmin/                                              →  https://ffcadmin.org/
+/ffcadmin-free-for-charity-cpanel-backup-sop/           →  https://ffcadmin.org/guides/cpanel-backup-sop/
+```
+
+All redirects use **301 Permanent** and **preserve query strings**.
+
+---
+
+## Cutover Day Checklist
+
+- [ ] Cloudflare Bulk Redirects loaded and tested against the WordPress
+      origin (so the redirects can be exercised before DNS is moved).
+- [ ] `FreeForCharity/FreeForCharity.org` deployed to GitHub Pages and
+      validated against staging hostname.
+- [ ] All migrated ffcadmin.org pages live and indexed.
+- [ ] Sitemaps refreshed on both sites; both submitted to Google Search
+      Console.
+- [ ] DNS A/AAAA records changed at registrar to GitHub Pages
+      (`185.199.108-111.153`).
+- [ ] WordPress origin gracefully shut down (read-only DB snapshot kept
+      offline per `docs/ffc-simply-static-config.md`).
+- [ ] Linkinator run against both sites — zero external 404s.
+- [ ] Cloudflare cache purged.
+
+---
+
+## Issue Tracking
+
+A tracking issue plus per-workstream child issues live in this repo —
+search for label `dns-cutover-2026` once the issues below land.
+
+_Document maintained for the DNS cutover. Will be archived once cutover is
+complete and the issues close._

--- a/docs/dns-cutover-site-plan.md
+++ b/docs/dns-cutover-site-plan.md
@@ -12,18 +12,24 @@
 
 We are about to complete DNS cutover for `freeforcharity.org` from the
 InterServer cPanel WordPress install to a GitHub Pages static site
-(`FreeForCharity/FreeForCharity.org`). At the same time we want a clean
-audience split between the two sites so that each has a single primary
-purpose.
+(`FreeForCharity/FreeForCharity.org`). After cutover the marketing site
+keeps **every major category** it has today — we are not pruning pages,
+we are converting them to the Next.js / static architecture.
+
+What changes is the **emphasis** on each site, and the addition of a
+clearly demarcated **Legacy Administration** section on ffcadmin.org that
+re-homes the operations-flavored content for the volunteer / admin
+audience.
 
 | Site                | Repo                                  | Audience                              | Primary CTA                             |
 | ------------------- | ------------------------------------- | ------------------------------------- | --------------------------------------- |
 | freeforcharity.org  | `FreeForCharity/FreeForCharity.org`   | Donors, prospective charity clients   | **Apply for a free site** → backlog     |
 | ffcadmin.org        | `FreeForCharity/FFC-IN-ffcadmin.org`  | Volunteers, admins, partner charities | **Start training / contribute**         |
 
-ffcadmin.org also remains the **public training portal for charities still
-running their own WordPress** (FFC- or non-FFC-managed) so their staff can
-reference our procedures without needing to be in our org.
+ffcadmin.org also remains the **public training portal and Legacy
+Administration archive for charities still running their own WordPress**
+(FFC- or non-FFC-managed) so their staff can reference our procedures
+without needing to be in our org.
 
 ---
 
@@ -51,10 +57,16 @@ Rules a reviewer can apply when deciding where a page belongs:
 
 Source: `docs/ffc-content-audit.csv`, `docs/ffc-url-mapping.md`.
 
+**Rule:** every major-category page stays addressable at its current
+`freeforcharity.org/<slug>/` URL after cutover. The static Next.js
+implementation in `FreeForCharity/FreeForCharity.org` is the new
+authoritative copy. The "moves" below are **copies into ffcadmin.org's
+Legacy Administration section** — not removals from freeforcharity.org.
+
 ### Keep on freeforcharity.org (donor / marketing / acquisition)
 
 These pages are already built in the marketing repo per the URL mapping doc
-and should remain. The cutover plan does not move them.
+and remain there. The cutover plan does not remove them.
 
 | WordPress Slug                       | Why it stays                                  |
 | ------------------------------------ | --------------------------------------------- |
@@ -82,26 +94,29 @@ and should remain. The cutover plan does not move them.
 | `/vulnerability-disclosure-policy/`  | Required legal                                |
 | `/security-acknowledgements/`        | Required legal                                |
 
-### Move to ffcadmin.org (operations / training / procedures)
+### Re-home on ffcadmin.org (Legacy Administration section)
 
-These pages are operational — they belong with the volunteers and the
-partner-charity admins, not with donors. They should be migrated to
-ffcadmin.org and the freeforcharity.org URL should 301 to the ffcadmin.org
-equivalent.
+These pages are operational. They **remain published** at their
+freeforcharity.org URLs (rebuilt in Next.js) AND get a re-homed copy
+under ffcadmin.org's new `/legacy-administration/` hub, framed for the
+volunteer / admin audience. Each ffcadmin copy sets
+`<link rel="canonical">` to itself (it's the operations-team copy) and
+cross-links to the public-facing freeforcharity.org page for charity
+visitors.
 
-| WordPress Slug                                            | Move target on ffcadmin.org                       | Reason                                            |
-| --------------------------------------------------------- | ------------------------------------------------- | ------------------------------------------------- |
-| `/free-training-programs/`                                | `/training-plan/` (hub) + child pages             | Volunteer training                                |
-| `/free-for-charitys-tools-for-success/`                   | `/guides/tools-for-success/`                      | Partner-charity SOP                               |
-| `/guidestar-guide/`                                       | `/guides/guidestar-guide/`                        | Partner-charity SOP                               |
-| `/charity-validation-guide-.../`                          | `/guides/charity-validation/`                     | Internal SOP, public for transparency             |
-| `/online-impacts-onboarding-guide/`                       | `/guides/online-impacts-onboarding/`              | Partner-charity SOP                               |
-| `/ffc-volunteer-proving-ground-core-competencies/`        | `/contributor-ladder/proving-ground/`             | Volunteer training                                |
-| `/free-for-charity-ffc-web-developer-training-guide/`     | `/training-plan/web-developer/`                   | Volunteer training                                |
-| `/free-for-charity-ffc-service-delivery-stages/`          | `/guides/service-delivery-stages/`                | Internal SOP, public for transparency             |
-| `/techstack/`                                             | `/tech-stack/` (already exists — merge content)   | Operations                                        |
-| `/ffcadmin/`                                              | `/` (already the ffcadmin.org home)               | Already the right place                           |
-| `/ffcadmin-free-for-charity-cpanel-backup-sop/`           | `/guides/cpanel-backup-sop/`                      | Internal SOP                                      |
+| WordPress Slug                                            | freeforcharity.org (kept)                                 | ffcadmin.org re-home                                                    |
+| --------------------------------------------------------- | --------------------------------------------------------- | ----------------------------------------------------------------------- |
+| `/free-training-programs/`                                | `/free-training-programs/`                                | `/legacy-administration/training-programs/` + link from `/training-plan/` |
+| `/free-for-charitys-tools-for-success/`                   | `/free-for-charitys-tools-for-success/`                   | `/legacy-administration/tools-for-success/`                             |
+| `/guidestar-guide/`                                       | `/guidestar-guide/`                                       | `/legacy-administration/guidestar-guide/`                               |
+| `/charity-validation-guide-.../`                          | `/charity-validation-guide-.../`                          | `/legacy-administration/charity-validation/`                            |
+| `/online-impacts-onboarding-guide/`                       | `/online-impacts-onboarding-guide/`                       | `/legacy-administration/online-impacts-onboarding/`                     |
+| `/ffc-volunteer-proving-ground-core-competencies/`        | `/ffc-volunteer-proving-ground-core-competencies/`        | `/legacy-administration/volunteer-proving-ground/` + link from `/contributor-ladder/` |
+| `/free-for-charity-ffc-web-developer-training-guide/`     | `/free-for-charity-ffc-web-developer-training-guide/`     | `/legacy-administration/web-developer-training/` + link from `/training-plan/` |
+| `/free-for-charity-ffc-service-delivery-stages/`          | `/free-for-charity-ffc-service-delivery-stages/`          | `/legacy-administration/service-delivery-stages/`                       |
+| `/techstack/`                                             | `/techstack/`                                             | merge into existing `/tech-stack/` + summary in Legacy Administration   |
+| `/ffcadmin/`                                              | `/ffcadmin/` (signpost page → links to ffcadmin.org)      | `/` (this site)                                                         |
+| `/ffcadmin-free-for-charity-cpanel-backup-sop/`           | `/ffcadmin-free-for-charity-cpanel-backup-sop/`           | `/legacy-administration/cpanel-backup-sop/`                             |
 
 ### Drop (with redirects)
 
@@ -126,13 +141,17 @@ they are donor / trust-signal content. Do not move to ffcadmin.org's blog
 
 ## Changes Required on ffcadmin.org (this repo)
 
-1. **Receive 11 migrated pages** from WordPress (listed above). Each page
-   must:
+1. **Build the Legacy Administration hub** at `/legacy-administration/`
+   that receives the 11 re-homed pages (listed above). Each page must:
    - Be authored in Next.js / Tailwind matching the existing
      `src/app/guides/` and `src/app/training-plan/` patterns.
    - Carry a top callout: "Looking to apply for a free FFC site? Visit
      freeforcharity.org/submit-information."
-   - Include canonical link back to itself on ffcadmin.org.
+   - Set `<link rel="canonical">` to its own ffcadmin.org URL — this is
+     the operations-team copy, not a duplicate of the marketing page.
+   - Link back to the public freeforcharity.org equivalent ("Public
+     version for charity visitors") so SEO crawlers and human readers
+     understand the relationship.
 
 2. **Disambiguate the homepage and nav** so visitors who arrive at
    ffcadmin.org looking for donation / application are bounced to
@@ -142,21 +161,13 @@ they are donor / trust-signal content. Do not move to ffcadmin.org's blog
 3. **Footer cross-link block** — both sites' footers must include a "Sister
    site" block with one-line description and link.
 
-4. **Public "For Partner Charities" hub** at `/for-charities/` that
-   collects the migrated procedures pages and explains: "Your charity may
-   still be on WordPress while you wait for or evaluate a static
-   migration. These procedures are kept public so your staff can use them."
+4. **Sitemap update** — `src/app/sitemap.ts` must include the new
+   Legacy Administration routes.
 
-5. **Sitemap update** — `src/app/sitemap.ts` must include the new
-   guides / training routes.
-
-6. **Internal-link sweep** — replace any in-body link to
-   `freeforcharity.org/<moved-slug>` with the ffcadmin.org equivalent.
-
-7. **Drop overlapping admin-only pages from freeforcharity.org**: the
-   marketing repo should `noindex` or remove `/ffcadmin/`, `/techstack/`,
-   `/ffc-volunteer-proving-ground.../`, etc. once the redirects below are
-   in place.
+5. **Internal-link audit** — every in-body link from ffcadmin pages to
+   freeforcharity.org should be reviewed: if it points to operations
+   content, redirect to the ffcadmin Legacy Administration page; if it
+   points to donor / applicant content, keep pointing to freeforcharity.
 
 ## Changes Required on freeforcharity.org (`FreeForCharity/FreeForCharity.org`)
 
@@ -164,42 +175,35 @@ Filed via companion issues / PRs in that repo, but coordinated from here:
 
 1. **Homepage CTA hierarchy**: primary = "Apply for a free site" (form
    submit), secondary = "Donate", tertiary = "Volunteer (→ ffcadmin.org)".
-2. **Remove or stub the migrated pages** (see Move list). Each becomes a
-   301 → ffcadmin.org equivalent.
-3. **Volunteer page**: trim WordPress content, repurpose as a one-screen
-   landing that funnels to ffcadmin.org/get-involved.
-4. **Sister-site footer block** linking to ffcadmin.org.
-5. **Sitemap + robots**: confirm no longer indexes the moved slugs.
+2. **Convert WordPress pages to Next.js static** — every major-category
+   page keeps its current URL but is reimplemented as a static route.
+3. **Volunteer page**: keep the donor-facing recruitment copy, add a
+   prominent "Already convinced? Start training at
+   ffcadmin.org/get-involved →" CTA at the top.
+4. **Sister-site footer block** linking to ffcadmin.org's Legacy
+   Administration section and Get Involved page.
+5. **Sitemap + robots**: confirm all kept routes are indexed and
+   canonical to themselves.
 
 ## Cloudflare Bulk Redirects
 
-Configure in Cloudflare for `freeforcharity.org` before DNS cutover so the
-WordPress origin can be retired with no broken inbound links:
+Because every major-category page **stays** on freeforcharity.org under
+its current slug, the cross-domain redirect set is no longer needed.
+Only the WordPress-only drops and the slug-shortening redirects remain:
 
 ```
-# Drops (existing — keep from ffc-url-mapping.md)
 /free-for-charity-terms-of-service/   →  /terms-of-service/                       [same domain]
 /donor-dashboard/                     →  /donate/                                  [same domain]
 /donation-failed/                     →  /donate/                                  [same domain]
 /donation-confirmation/               →  /donate/                                  [same domain]
 /sample-page/                         →  /                                          [same domain]
 /codetest/                            →  /                                          [same domain]
-
-# Cross-domain moves (new for this cutover)
-/free-training-programs/                                →  https://ffcadmin.org/training-plan/
-/free-for-charitys-tools-for-success/                   →  https://ffcadmin.org/guides/tools-for-success/
-/guidestar-guide/                                       →  https://ffcadmin.org/guides/guidestar-guide/
-/charity-validation-guide-.../                          →  https://ffcadmin.org/guides/charity-validation/
-/online-impacts-onboarding-guide/                       →  https://ffcadmin.org/guides/online-impacts-onboarding/
-/ffc-volunteer-proving-ground-core-competencies/        →  https://ffcadmin.org/contributor-ladder/proving-ground/
-/free-for-charity-ffc-web-developer-training-guide/     →  https://ffcadmin.org/training-plan/web-developer/
-/free-for-charity-ffc-service-delivery-stages/          →  https://ffcadmin.org/guides/service-delivery-stages/
-/techstack/                                             →  https://ffcadmin.org/tech-stack/
-/ffcadmin/                                              →  https://ffcadmin.org/
-/ffcadmin-free-for-charity-cpanel-backup-sop/           →  https://ffcadmin.org/guides/cpanel-backup-sop/
 ```
 
 All redirects use **301 Permanent** and **preserve query strings**.
+
+> Note: `/ffcadmin/` on freeforcharity.org stays as a thin signpost page
+> linking to `https://ffcadmin.org/` — it is not a redirect.
 
 ---
 

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -5,7 +5,9 @@
       "url": [
         "http://localhost/index.html",
         "http://localhost/tech-stack/index.html",
-        "http://localhost/documentation/index.html"
+        "http://localhost/documentation/index.html",
+        "http://localhost/legacy-wordpress-administration/index.html",
+        "http://localhost/legacy-wordpress-administration/wordpress-web-hosting/index.html"
       ],
       "numberOfRuns": 3
     },

--- a/scripts/generate-legacy-wp-admin-stubs.ts
+++ b/scripts/generate-legacy-wp-admin-stubs.ts
@@ -31,8 +31,8 @@ function stubFor(page: LegacyWpAdminPage): string {
 import LeafPageShell from '@/components/legacy-wordpress-administration/LeafPageShell'
 import { getLegacyWpAdminPageBySlug } from '@/data/legacy-wordpress-administration'
 
-const SLUG = ${JSON.stringify(page.slug)}
-const page = getLegacyWpAdminPageBySlug(SLUG)!
+const SLUG = ${JSON.stringify(page.slug)} as const
+const page = getLegacyWpAdminPageBySlug(SLUG)
 
 export const metadata: Metadata = {
   title: page.title,

--- a/scripts/generate-legacy-wp-admin-stubs.ts
+++ b/scripts/generate-legacy-wp-admin-stubs.ts
@@ -1,0 +1,82 @@
+#!/usr/bin/env tsx
+/**
+ * One-shot scaffolder for /legacy-wordpress-administration/<slug>/page.tsx.
+ *
+ * Reads src/data/legacy-wordpress-administration.ts, writes a stub
+ * page.tsx for every entry that does not yet have one. Stubs use
+ * <LeafPageShell page={page}> and contain a placeholder body that flags
+ * the content as pending migration. Content fill-ins happen in
+ * follow-up PRs per page.
+ *
+ * Idempotent: existing pages are left alone (the script never
+ * overwrites). Re-run after adding a new entry to the data file.
+ *
+ * Usage:  pnpm tsx scripts/generate-legacy-wp-admin-stubs.ts
+ */
+
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import {
+  LEGACY_WP_ADMIN_PAGES,
+  type LegacyWpAdminPage,
+} from '../src/data/legacy-wordpress-administration'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+const APP_DIR = resolve(__dirname, '../src/app/legacy-wordpress-administration')
+
+function stubFor(page: LegacyWpAdminPage): string {
+  return `import type { Metadata } from 'next'
+import LeafPageShell from '@/components/legacy-wordpress-administration/LeafPageShell'
+import { getLegacyWpAdminPageBySlug } from '@/data/legacy-wordpress-administration'
+
+const SLUG = ${JSON.stringify(page.slug)}
+const page = getLegacyWpAdminPageBySlug(SLUG)!
+
+export const metadata: Metadata = {
+  title: page.title,
+  description: page.summary,
+  alternates: {
+    canonical: \`https://ffcadmin.org/legacy-wordpress-administration/\${SLUG}/\`,
+  },
+}
+
+export default function Page() {
+  return (
+    <LeafPageShell page={page}>
+      <p>
+        <strong>Content migration in progress.</strong> This page is the
+        ffcadmin.org operations-team copy of{' '}
+        <a href={page.publicSourceUrl} target="_blank" rel="noopener noreferrer">
+          {page.publicSourceUrl}
+        </a>
+        . Body content is being migrated from the legacy WordPress source as
+        part of issue #241.
+      </p>
+      <p>
+        Until the migration lands, see the public version on freeforcharity.org
+        for the current content.
+      </p>
+    </LeafPageShell>
+  )
+}
+`
+}
+
+let created = 0
+let skipped = 0
+for (const page of LEGACY_WP_ADMIN_PAGES) {
+  const dir = resolve(APP_DIR, page.slug)
+  const file = resolve(dir, 'page.tsx')
+  if (existsSync(file)) {
+    skipped++
+    continue
+  }
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(file, stubFor(page))
+  created++
+  console.log(`created ${page.slug}/page.tsx`)
+}
+
+console.log(`\nDone. created=${created} skipped=${skipped}`)

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -70,3 +70,70 @@
 html {
   scroll-behavior: smooth;
 }
+
+/*
+ * Print stylesheet.
+ *
+ * Legacy WordPress Administration SOPs are frequently saved as PDF or
+ * printed for offline reference, so the print layer must strip the
+ * interactive chrome and preserve link destinations on paper.
+ *
+ * Rules apply site-wide because the marketing pages may also be saved.
+ */
+@media print {
+  /* Hide site chrome — irrelevant on paper. */
+  nav,
+  footer,
+  [role='region'][aria-label='Sister site routing'],
+  nav[aria-label='Breadcrumb'],
+  aside[aria-label='Section navigation'],
+  aside[aria-label='Section context and cross-links'] {
+    display: none !important;
+  }
+
+  /* Hero gradient saturates ink on laser printers. Flatten. */
+  header[class*='bg-gradient'] {
+    background: white !important;
+    color: black !important;
+    border-bottom: 1px solid #999;
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+  }
+  header[class*='bg-gradient'] * {
+    color: black !important;
+  }
+
+  /* Show URLs after every external link so paper readers can follow them. */
+  a[href^='http']::after,
+  a[href^='tel:']::after,
+  a[href^='mailto:']::after {
+    content: ' (' attr(href) ')';
+    font-size: 0.85em;
+    word-break: break-all;
+  }
+  /* Don't append URLs to images, anchors-as-targets, or print-hidden links. */
+  a[href^='#']::after {
+    content: '';
+  }
+
+  /* Page-break control: keep prose sections together when possible. */
+  section,
+  ul,
+  ol,
+  pre,
+  table {
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+  h2,
+  h3,
+  h4 {
+    break-after: avoid;
+    page-break-after: avoid;
+  }
+
+  /* Universal contrast — laser printers wash out light blues / grays. */
+  body {
+    color: black;
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import Navigation from '@/components/Navigation'
 import Footer from '@/components/Footer'
 import CookieConsent from '@/components/CookieConsent'
 import BackToTop from '@/components/BackToTop'
+import SisterSiteBanner from '@/components/SisterSiteBanner'
 import { assetPath } from '@/lib/assetPath'
 
 const SITE_URL = 'https://ffcadmin.org'
@@ -119,6 +120,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             style={{ display: 'none', visibility: 'hidden' }}
           />
         </noscript>
+        <SisterSiteBanner />
         <Navigation />
         <main className="flex-grow">{children}</main>
         <Footer />

--- a/src/app/legacy-wordpress-administration/layout.tsx
+++ b/src/app/legacy-wordpress-administration/layout.tsx
@@ -4,9 +4,12 @@ import type { ReactNode } from 'react'
 const SITE_URL = 'https://ffcadmin.org'
 
 export const metadata: Metadata = {
+  // Use just the page title on leaves (no section suffix) so the
+  // global '%s | Free For Charity Admin' template from layout.tsx
+  // applies once — keeps titles within Google's ~60-char cutoff.
   title: {
     default: 'Legacy WordPress Administration',
-    template: '%s | Legacy WordPress Administration',
+    template: '%s',
   },
   description:
     'Operations and SOP reference for FFC volunteers, admins, and partner charities still running their own WordPress.',

--- a/src/app/legacy-wordpress-administration/layout.tsx
+++ b/src/app/legacy-wordpress-administration/layout.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from 'next'
+import type { ReactNode } from 'react'
+
+const SITE_URL = 'https://ffcadmin.org'
+
+export const metadata: Metadata = {
+  title: {
+    default: 'Legacy WordPress Administration',
+    template: '%s | Legacy WordPress Administration',
+  },
+  description:
+    'Operations and SOP reference for FFC volunteers, admins, and partner charities still running their own WordPress.',
+  alternates: {
+    canonical: `${SITE_URL}/legacy-wordpress-administration/`,
+  },
+}
+
+export default function LegacyWordPressAdministrationLayout({ children }: { children: ReactNode }) {
+  return <>{children}</>
+}

--- a/src/app/legacy-wordpress-administration/page.tsx
+++ b/src/app/legacy-wordpress-administration/page.tsx
@@ -1,0 +1,136 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import Breadcrumbs from '@/components/Breadcrumbs'
+import CategoryGrid from '@/components/legacy-wordpress-administration/CategoryGrid'
+import { LEGACY_WP_ADMIN_CATEGORIES } from '@/data/legacy-wordpress-administration'
+
+const SITE_URL = 'https://ffcadmin.org'
+
+export const metadata: Metadata = {
+  title: 'Legacy WordPress Administration',
+  description:
+    'Operations and SOP reference for FFC volunteers, admins, and partner charities still running their own WordPress — hosting, domains, charity onboarding, and volunteer programs.',
+  alternates: {
+    canonical: `${SITE_URL}/legacy-wordpress-administration/`,
+  },
+}
+
+export default function LegacyWordPressAdministrationHubPage() {
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Breadcrumbs
+        items={[{ label: 'Home', href: '/' }, { label: 'Legacy WordPress Administration' }]}
+      />
+
+      {/* Hero */}
+      <header className="bg-gradient-to-r from-slate-700 to-slate-900 text-white py-16 px-4 sm:px-6 lg:px-8">
+        <div className="max-w-5xl mx-auto">
+          <p className="text-xs uppercase tracking-wider text-slate-300 mb-3">
+            For volunteers, admins, and partner charities
+          </p>
+          <h1 className="text-4xl sm:text-5xl font-bold mb-4">Legacy WordPress Administration</h1>
+          <p className="text-slate-200 text-lg max-w-3xl">
+            Operations and SOP reference for FFC volunteers, admins, and partner charities still
+            running their own WordPress. The public, charity-facing versions of these pages live on{' '}
+            <a
+              href="https://freeforcharity.org/"
+              className="underline hover:no-underline"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              freeforcharity.org
+            </a>
+            .
+          </p>
+          <div className="mt-6 flex flex-wrap gap-3 text-sm">
+            {LEGACY_WP_ADMIN_CATEGORIES.map((c) => (
+              <a
+                key={c.id}
+                href={`#${c.id}`}
+                className="px-3 py-1.5 rounded bg-white/10 hover:bg-white/20 transition-colors"
+              >
+                {c.label}
+              </a>
+            ))}
+          </div>
+        </div>
+      </header>
+
+      {/* What this section is */}
+      <section className="border-y border-blue-100 bg-blue-50">
+        <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-6 grid gap-3 sm:grid-cols-2 text-sm text-blue-900">
+          <p>
+            <strong>Looking to apply for a free FFC site?</strong>{' '}
+            <a
+              href="https://freeforcharity.org/submit-information/"
+              className="underline hover:no-underline"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Apply at freeforcharity.org →
+            </a>
+          </p>
+          <p className="sm:text-right">
+            <a
+              href="https://freeforcharity.org/"
+              className="underline hover:no-underline"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              See the charity-facing pages on freeforcharity.org →
+            </a>
+          </p>
+        </div>
+      </section>
+
+      {/* Category card grid */}
+      <section className="py-12 px-4 sm:px-6 lg:px-8">
+        <div className="max-w-7xl mx-auto">
+          <CategoryGrid />
+        </div>
+      </section>
+
+      {/* Why "Legacy"? */}
+      <section className="py-12 px-4 sm:px-6 lg:px-8 bg-white border-t border-gray-200">
+        <div className="max-w-3xl mx-auto">
+          <h2 className="text-2xl font-bold text-gray-900 mb-4">Why &ldquo;Legacy&rdquo;?</h2>
+          <p className="text-gray-700 mb-3">
+            Many partner charities still run on WordPress while they evaluate or wait for a
+            migration to the FFC static-site stack. We keep these procedures published so their
+            staff can use them without joining the FFC GitHub org.
+          </p>
+          <p className="text-gray-700">
+            The same content also serves as the operations-team reference for FFC volunteers and
+            admins working on charity sites that have not yet migrated. As migrations complete,
+            individual pages will be updated to reflect the modern stack or retired in place of the
+            corresponding ffcadmin.org guide.
+          </p>
+        </div>
+      </section>
+
+      {/* Bottom CTAs */}
+      <section className="py-12 px-4 sm:px-6 lg:px-8">
+        <div className="max-w-5xl mx-auto grid gap-4 sm:grid-cols-2">
+          <Link
+            href="/guides/wordpress-to-nextjs-guide"
+            className="block rounded-lg bg-white border border-gray-200 p-6 hover:border-blue-400 hover:shadow-md transition-all"
+          >
+            <p className="font-semibold text-gray-900 mb-1">Ready to move off WordPress? →</p>
+            <p className="text-sm text-gray-600">Read the WordPress-to-Next.js conversion guide.</p>
+          </Link>
+          <a
+            href="https://freeforcharity.org/submit-information/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="block rounded-lg bg-white border border-gray-200 p-6 hover:border-blue-400 hover:shadow-md transition-all"
+          >
+            <p className="font-semibold text-gray-900 mb-1">Apply for FFC migration help →</p>
+            <p className="text-sm text-gray-600">
+              Submit your charity for the FFC backlog at freeforcharity.org.
+            </p>
+          </a>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/app/legacy-wordpress-administration/wordpress-charity-validation/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-charity-validation/page.tsx
@@ -1,0 +1,33 @@
+import type { Metadata } from 'next'
+import LeafPageShell from '@/components/legacy-wordpress-administration/LeafPageShell'
+import { getLegacyWpAdminPageBySlug } from '@/data/legacy-wordpress-administration'
+
+const SLUG = 'wordpress-charity-validation'
+const page = getLegacyWpAdminPageBySlug(SLUG)!
+
+export const metadata: Metadata = {
+  title: page.title,
+  description: page.summary,
+  alternates: {
+    canonical: `https://ffcadmin.org/legacy-wordpress-administration/${SLUG}/`,
+  },
+}
+
+export default function Page() {
+  return (
+    <LeafPageShell page={page}>
+      <p>
+        <strong>Content migration in progress.</strong> This page is the ffcadmin.org
+        operations-team copy of{' '}
+        <a href={page.publicSourceUrl} target="_blank" rel="noopener noreferrer">
+          {page.publicSourceUrl}
+        </a>
+        . Body content is being migrated from the legacy WordPress source as part of issue #241.
+      </p>
+      <p>
+        Until the migration lands, see the public version on freeforcharity.org for the current
+        content.
+      </p>
+    </LeafPageShell>
+  )
+}

--- a/src/app/legacy-wordpress-administration/wordpress-charity-validation/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-charity-validation/page.tsx
@@ -196,9 +196,9 @@ export default function Page() {
       </p>
 
       <p>
-        The charity-facing version of this page is{' '}
+        The charity-facing version of this page is the{' '}
         <a href={page.publicSourceUrl} target="_blank" rel="noopener noreferrer">
-          freeforcharity.org/charity-validation-guide-.../
+          Charity Validation Guide on freeforcharity.org
         </a>{' '}
         and explains the &ldquo;mutual benefit&rdquo; framing in plain language. This page is the
         operations-team runbook — what an FFC volunteer admin actually does, in what order, for each

--- a/src/app/legacy-wordpress-administration/wordpress-charity-validation/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-charity-validation/page.tsx
@@ -34,7 +34,7 @@ const externalChecks: Check[] = [
     charitySideValue:
       'Verified GuideStar profile improves donor confidence and unlocks funding opportunities the charity may not have known about.',
     runbook: [
-      'Search the EIN at https://www.guidestar.org/.',
+      'Search the EIN at https://candid.org/ (formerly GuideStar).',
       'Confirm 501(c)(3) status is active (not revoked, not pending).',
       'Record the NTEE code in the FFC intake record.',
       'If no profile exists, queue the charity for GuideStar profile setup via the GuideStar guide.',

--- a/src/app/legacy-wordpress-administration/wordpress-charity-validation/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-charity-validation/page.tsx
@@ -3,7 +3,7 @@ import LeafPageShell from '@/components/legacy-wordpress-administration/LeafPage
 import { getLegacyWpAdminPageBySlug } from '@/data/legacy-wordpress-administration'
 
 const SLUG = 'wordpress-charity-validation'
-const page = getLegacyWpAdminPageBySlug(SLUG)!
+const page = getLegacyWpAdminPageBySlug(SLUG)
 
 export const metadata: Metadata = {
   title: page.title,

--- a/src/app/legacy-wordpress-administration/wordpress-charity-validation/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-charity-validation/page.tsx
@@ -11,22 +11,228 @@ export const metadata: Metadata = {
   alternates: {
     canonical: `https://ffcadmin.org/legacy-wordpress-administration/${SLUG}/`,
   },
+  keywords:
+    '501c3 validation, GuideStar, TechSoup, VolunteerMatch, charity vetting, FFC intake, mutual benefit',
+}
+
+interface Check {
+  id: string
+  index: number
+  name: string
+  whyFfcRunsIt: string
+  charitySideValue: string
+  runbook: string[]
+}
+
+const externalChecks: Check[] = [
+  {
+    id: '501c3-guidestar',
+    index: 1,
+    name: '501(c)(3) status via Candid / GuideStar',
+    whyFfcRunsIt:
+      'Confirms the charity is what it claims to be against the canonical nonprofit transparency authority, and surfaces the NTEE code we use for mission-alignment scoring.',
+    charitySideValue:
+      'Verified GuideStar profile improves donor confidence and unlocks funding opportunities the charity may not have known about.',
+    runbook: [
+      'Search the EIN at https://www.guidestar.org/.',
+      'Confirm 501(c)(3) status is active (not revoked, not pending).',
+      'Record the NTEE code in the FFC intake record.',
+      'If no profile exists, queue the charity for GuideStar profile setup via the GuideStar guide.',
+    ],
+  },
+  {
+    id: 'techsoup',
+    index: 2,
+    name: 'TechSoup legal-entity confirmation',
+    whyFfcRunsIt:
+      'Independent vetting from a respected charity-services provider; also unlocks the discounted-software pipeline (QuickBooks, Adobe, Microsoft) FFC routes charities through.',
+    charitySideValue:
+      'TechSoup membership gives the charity access to enterprise software at nonprofit prices, often saving thousands per year.',
+    runbook: [
+      'Search the EIN at https://www.techsoup.org/.',
+      'Confirm validation status is "Validated" (not "Pending").',
+      'If "Pending", help the charity submit the missing paperwork to TechSoup.',
+    ],
+  },
+  {
+    id: 'volunteermatch',
+    index: 3,
+    name: 'VolunteerMatch engagement check',
+    whyFfcRunsIt:
+      'Signals whether the charity already engages volunteers — important because FFC delivery depends on charity staff being able to receive and respond to volunteer work.',
+    charitySideValue:
+      'A public VolunteerMatch presence opens the charity to FFC technical volunteers as well as their existing networks.',
+    runbook: [
+      'Search the charity at https://www.volunteermatch.org/.',
+      'Note the cadence of their listings (active / dormant / never posted).',
+      'If never posted, flag the intake record so FFC volunteer coordinators know to onboard them.',
+    ],
+  },
+  {
+    id: 'facebook-page',
+    index: 4,
+    name: 'Verified Facebook page',
+    whyFfcRunsIt:
+      "Cross-checks that the charity's public information matches what they submitted on the intake form. Discrepancies are an early signal of identity / branding inconsistency.",
+    charitySideValue:
+      'Confirmed Facebook presence supports outreach, donor communication, and event marketing.',
+    runbook: [
+      "Locate the charity's Facebook page.",
+      'Compare name, address, mission, leadership against the intake form.',
+      'Note any discrepancies for follow-up before service delivery starts.',
+    ],
+  },
+  {
+    id: 'email-microsoft',
+    index: 5,
+    name: 'Email on a reputable provider (Microsoft 365 preferred)',
+    whyFfcRunsIt:
+      "A charity emailing from a Gmail / Yahoo address blocks our ability to set up SPF / DKIM / DMARC under the charity's own domain, and risks IP blacklisting on the FFC origin server.",
+    charitySideValue:
+      'M365 (free for nonprofits) gives the charity a professional address, calendar, Teams, and the productivity suite FFC volunteers also use.',
+    runbook: [
+      'Confirm at least one charity-domain mailbox exists.',
+      'If only personal-provider mailboxes exist, plan an M365 nonprofit onboarding before site launch.',
+    ],
+  },
+  {
+    id: 'whmcs-paypal',
+    index: 6,
+    name: 'WHMCS account + PayPal donor flow',
+    whyFfcRunsIt:
+      'WHMCS account creation acts as a Know-Your-Customer step that reduces inbound spam; PayPal integration is the path through which donors fund the charity once their FFC site is live.',
+    charitySideValue:
+      'Secure transaction handling, donor confidence, and the "Donate Now" flow on the eventual FFC-delivered site.',
+    runbook: [
+      'Confirm the charity has created a WHMCS account against the same EIN.',
+      'Confirm PayPal Giving Fund (or equivalent) is set up; if not, add to the onboarding checklist.',
+    ],
+  },
+]
+
+const internalChecks: Check[] = [
+  {
+    id: 'cost-funding-analysis',
+    index: 1,
+    name: 'Cost-and-funding analysis (small-charity profile)',
+    whyFfcRunsIt:
+      "Sizes the charity's budget so FFC can scope the engagement realistically. Lets us route micro-charities (under $50k revenue) to lighter-weight templates and larger ones to the full FFC service.",
+    charitySideValue:
+      'Documented financial resourcefulness becomes an asset when courting cost-conscious donors and grant-makers.',
+    runbook: [
+      "Pull the charity's most recent Form 990 / 990-EZ / 990-N from GuideStar or ProPublica Nonprofit Explorer.",
+      'Categorize as micro (under $50k), small ($50k-$250k), mid ($250k-$1M), large (over $1M).',
+      'Record the category on the intake record — it drives template selection.',
+    ],
+  },
+  {
+    id: 'website-form-review',
+    index: 2,
+    name: 'Existing website + intake-form content review',
+    whyFfcRunsIt:
+      "Holistic check that the charity's mission, leadership, and program description line up across every public source — their current site, the intake form, the GuideStar profile, and social.",
+    charitySideValue:
+      'The charity gets explicit feedback on mission consistency and public messaging before we touch their site.',
+    runbook: [
+      'Read the existing website end-to-end (every page).',
+      'Compare against the intake form line-by-line.',
+      'List discrepancies and surface them in the intake reply before kickoff.',
+    ],
+  },
+  {
+    id: 'demographic-assessment',
+    index: 3,
+    name: 'Target-demographic assessment',
+    whyFfcRunsIt:
+      'Establishes who the charity actually serves — the foundation for everything from copy tone to image selection to accessibility considerations on the FFC-delivered site.',
+    charitySideValue:
+      'Specialized impact becomes a recruitable narrative: aligned donors, aligned volunteers, aligned grant opportunities.',
+    runbook: [
+      'Identify the primary served population (age, geography, condition, sector).',
+      'Confirm with the charity that this matches their lived experience.',
+      'Record demographic notes on the intake record — they feed into the design brief.',
+    ],
+  },
+]
+
+function ChecksTable({ rows, title, lead }: { rows: Check[]; title: string; lead: string }) {
+  return (
+    <section>
+      <h2>{title}</h2>
+      <p>{lead}</p>
+      {rows.map((row) => (
+        <section key={row.id} id={row.id}>
+          <h3>
+            {row.index}. {row.name}
+          </h3>
+          <p>
+            <strong>Why FFC runs it:</strong> {row.whyFfcRunsIt}
+          </p>
+          <p>
+            <strong>What the charity gets:</strong> {row.charitySideValue}
+          </p>
+          <p>
+            <strong>Runbook:</strong>
+          </p>
+          <ol>
+            {row.runbook.map((step) => (
+              <li key={step}>{step}</li>
+            ))}
+          </ol>
+        </section>
+      ))}
+    </section>
+  )
 }
 
 export default function Page() {
   return (
     <LeafPageShell page={page}>
       <p>
-        <strong>Content migration in progress.</strong> This page is the ffcadmin.org
-        operations-team copy of{' '}
-        <a href={page.publicSourceUrl} target="_blank" rel="noopener noreferrer">
-          {page.publicSourceUrl}
-        </a>
-        . Body content is being migrated from the legacy WordPress source as part of issue #241.
+        FFC validates every prospective partner charity against a fixed set of external and internal
+        checks before any service-delivery work starts. The checks exist for two reasons at once:
+        they protect FFC&apos;s mission integrity, and they hand the charity a richer public
+        footprint than they walked in with.
       </p>
+
       <p>
-        Until the migration lands, see the public version on freeforcharity.org for the current
-        content.
+        The charity-facing version of this page is{' '}
+        <a href={page.publicSourceUrl} target="_blank" rel="noopener noreferrer">
+          freeforcharity.org/charity-validation-guide-.../
+        </a>{' '}
+        and explains the &ldquo;mutual benefit&rdquo; framing in plain language. This page is the
+        operations-team runbook — what an FFC volunteer admin actually does, in what order, for each
+        check.
+      </p>
+
+      <h2>When to run validation</h2>
+      <p>
+        Validation runs during <strong>Stage 1 — Intake</strong> in the FFC service-delivery
+        lifecycle. See{' '}
+        <a href="/legacy-wordpress-administration/wordpress-service-delivery-stages/">
+          service delivery stages
+        </a>{' '}
+        for how this fits into the broader engagement.
+      </p>
+
+      <ChecksTable
+        title="External validation checks"
+        lead="Six third-party signals FFC confirms before committing service-delivery time."
+        rows={externalChecks}
+      />
+
+      <ChecksTable
+        title="Internal validation checks"
+        lead="Three FFC-internal reviews that scope the engagement once external checks pass."
+        rows={internalChecks}
+      />
+
+      <h2>Outcome</h2>
+      <p>
+        A passing validation lands the charity in the FFC backlog with a complete intake record:
+        EIN, NTEE code, validated public profiles, target-demographic notes, and a sized engagement.
+        From there, FFC schedules the kickoff and the migration playbook (legacy WordPress today,
+        Next.js / static increasingly going forward) takes over.
       </p>
     </LeafPageShell>
   )

--- a/src/app/legacy-wordpress-administration/wordpress-cpanel-backup-sop/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-cpanel-backup-sop/page.tsx
@@ -3,7 +3,7 @@ import LeafPageShell from '@/components/legacy-wordpress-administration/LeafPage
 import { getLegacyWpAdminPageBySlug } from '@/data/legacy-wordpress-administration'
 
 const SLUG = 'wordpress-cpanel-backup-sop'
-const page = getLegacyWpAdminPageBySlug(SLUG)!
+const page = getLegacyWpAdminPageBySlug(SLUG)
 
 export const metadata: Metadata = {
   title: page.title,

--- a/src/app/legacy-wordpress-administration/wordpress-cpanel-backup-sop/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-cpanel-backup-sop/page.tsx
@@ -1,0 +1,33 @@
+import type { Metadata } from 'next'
+import LeafPageShell from '@/components/legacy-wordpress-administration/LeafPageShell'
+import { getLegacyWpAdminPageBySlug } from '@/data/legacy-wordpress-administration'
+
+const SLUG = 'wordpress-cpanel-backup-sop'
+const page = getLegacyWpAdminPageBySlug(SLUG)!
+
+export const metadata: Metadata = {
+  title: page.title,
+  description: page.summary,
+  alternates: {
+    canonical: `https://ffcadmin.org/legacy-wordpress-administration/${SLUG}/`,
+  },
+}
+
+export default function Page() {
+  return (
+    <LeafPageShell page={page}>
+      <p>
+        <strong>Content migration in progress.</strong> This page is the ffcadmin.org
+        operations-team copy of{' '}
+        <a href={page.publicSourceUrl} target="_blank" rel="noopener noreferrer">
+          {page.publicSourceUrl}
+        </a>
+        . Body content is being migrated from the legacy WordPress source as part of issue #241.
+      </p>
+      <p>
+        Until the migration lands, see the public version on freeforcharity.org for the current
+        content.
+      </p>
+    </LeafPageShell>
+  )
+}

--- a/src/app/legacy-wordpress-administration/wordpress-cpanel-backup-sop/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-cpanel-backup-sop/page.tsx
@@ -11,23 +11,169 @@ export const metadata: Metadata = {
   alternates: {
     canonical: `https://ffcadmin.org/legacy-wordpress-administration/${SLUG}/`,
   },
+  keywords:
+    'cPanel backup, WordPress full backup, DirectAdmin, Hostinger hPanel, Snapshot Pro, FFC SOP',
 }
+
+interface Step {
+  id: string
+  index: number
+  name: string
+  details: string[]
+  gotcha?: string
+}
+
+const fullBackupSteps: Step[] = [
+  {
+    id: 'pre-checks',
+    index: 1,
+    name: 'Pre-flight checks',
+    details: [
+      'Confirm disk-space headroom in cPanel/DirectAdmin/hPanel ≥ 2× the current site footprint.',
+      'Confirm WPMUDEV Snapshot Pro shows green on the most recent automated run; if red, fix that before doing a manual backup so you do not chain failures.',
+      'Pause any active Simply Static export — the export branch will compete for the same resources.',
+    ],
+    gotcha:
+      'On Hostinger hPanel, the "Disk Usage" widget under-reports email storage. Open File Manager and confirm the mail directory separately.',
+  },
+  {
+    id: 'cpanel-full-backup',
+    index: 2,
+    name: 'cPanel / DirectAdmin full backup',
+    details: [
+      'Log in to cPanel / DirectAdmin / hPanel for the charity account.',
+      'Navigate to "Backup" (cPanel), "Create / Restore Backups" (DirectAdmin), or "Files → Backups" (hPanel).',
+      'Choose "Full Backup" — includes home directory, MySQL, mail, and configuration.',
+      'Set destination: "Generate / Download a Full Backup", then download to the FFC encrypted volume once it completes.',
+    ],
+    gotcha:
+      'Full backups can take 30-90 minutes for a populated charity site. Do not interrupt the panel session — most hosts produce a partial tarball if you do.',
+  },
+  {
+    id: 'database-export',
+    index: 3,
+    name: 'Database export (belt and suspenders)',
+    details: [
+      'Open phpMyAdmin from the panel.',
+      'Select the WordPress database for the charity site.',
+      'Export → custom → format SQL → check "Add DROP TABLE" → check "Save as file" → gzipped output.',
+      'Store the .sql.gz alongside the full backup, named <charity>-<YYYY-MM-DD>.sql.gz.',
+    ],
+    gotcha:
+      'wp_options.cron and wp_options.transient bloat databases over time. If the export is > 100 MB, run a transient-cleanup plugin before re-exporting.',
+  },
+  {
+    id: 'verify',
+    index: 4,
+    name: 'Verify the backup is restorable',
+    details: [
+      'Pull the cPanel tarball into a local Docker (e.g. lscr.io/linuxserver/wordpress) or a staging subdomain.',
+      'Confirm site loads, admin login works, key pages render.',
+      'Log the verification timestamp in the charity intake record.',
+    ],
+    gotcha:
+      'A backup that has never been restored is not a backup. Run this step at least quarterly per charity.',
+  },
+  {
+    id: 'rotate',
+    index: 5,
+    name: 'Rotate and offsite',
+    details: [
+      'Move the backup off the host volume to FFC offsite storage (Microsoft 365 SharePoint, Google Drive nonprofit tier, or the FFC SFTP archive).',
+      'Retention: keep weekly snapshots for one month, monthly for one year, annual indefinitely.',
+      'Encrypt the offsite copy at rest (host storage encryption is fine; if using consumer cloud, wrap with `age` or `gpg`).',
+    ],
+    gotcha:
+      'Do not store the backup on the same host volume long-term. A compromised host loses both the live site and the backup.',
+  },
+]
+
+const partialBackupTriggers = [
+  'Before a major plugin or theme update.',
+  'Before a content audit run that rewrites images at scale.',
+  'Before a Simply Static export attempt on a charity site (the export rewrites links and clears caches; revert path needs a known-good baseline).',
+  'Before any DNS / nameserver / SSL change at the registrar.',
+]
 
 export default function Page() {
   return (
     <LeafPageShell page={page}>
       <p>
-        <strong>Content migration in progress.</strong> This page is the ffcadmin.org
-        operations-team copy of{' '}
-        <a href={page.publicSourceUrl} target="_blank" rel="noopener noreferrer">
-          {page.publicSourceUrl}
-        </a>
-        . Body content is being migrated from the legacy WordPress source as part of issue #241.
+        Every FFC-managed WordPress site is backed up automatically by WPMUDEV Snapshot Pro on a
+        daily cadence. This SOP covers the <em>manual</em> backup path — what an FFC admin runs
+        before risky operations, on quarterly verification cadence, and during rescue scenarios.
       </p>
+
       <p>
-        Until the migration lands, see the public version on freeforcharity.org for the current
-        content.
+        The charity-facing version of this page on{' '}
+        <a href={page.publicSourceUrl} target="_blank" rel="noopener noreferrer">
+          freeforcharity.org
+        </a>{' '}
+        is access-controlled (it is an internal FFC SOP). This ffcadmin.org copy is the
+        operations-team reference for volunteer admins onboarding to backup duty.
       </p>
+
+      <h2>When to run a manual full backup</h2>
+      <ul>
+        {partialBackupTriggers.map((t) => (
+          <li key={t}>{t}</li>
+        ))}
+        <li>On a quarterly cadence per site (restore verification).</li>
+        <li>Whenever Snapshot Pro reports red for more than one consecutive day.</li>
+      </ul>
+
+      <h2>The five-step procedure</h2>
+      {fullBackupSteps.map((step) => (
+        <section key={step.id} id={step.id}>
+          <h3>
+            Step {step.index} &mdash; {step.name}
+          </h3>
+          <ul>
+            {step.details.map((d) => (
+              <li key={d}>{d}</li>
+            ))}
+          </ul>
+          {step.gotcha && (
+            <p>
+              <strong>Gotcha:</strong> {step.gotcha}
+            </p>
+          )}
+        </section>
+      ))}
+
+      <h2>Restore quick-reference</h2>
+      <ol>
+        <li>Spin up the target environment (staging subdomain or local Docker).</li>
+        <li>Restore the database from the .sql.gz first.</li>
+        <li>Extract the cPanel tarball into the WordPress document root.</li>
+        <li>
+          Run <code>wp search-replace</code> against the live → staging hostname.
+        </li>
+        <li>
+          Run <code>wp cache flush</code> and <code>wp transient delete --all</code>.
+        </li>
+        <li>Spot-check: home, donate, two interior pages, admin login.</li>
+      </ol>
+
+      <h2>Cross-references</h2>
+      <ul>
+        <li>
+          <a href="/legacy-wordpress-administration/wordpress-hosting-techstack/">
+            wordpress-hosting-techstack
+          </a>{' '}
+          — the layer the backup operates against.
+        </li>
+        <li>
+          <a href="/legacy-wordpress-administration/wordpress-service-delivery-stages/">
+            wordpress-service-delivery-stages
+          </a>{' '}
+          — Stage 8 first-backup verification.
+        </li>
+        <li>
+          <code>docs/ffc-simply-static-config.md</code> — Simply Static export interactions with the
+          backup window.
+        </li>
+      </ul>
     </LeafPageShell>
   )
 }

--- a/src/app/legacy-wordpress-administration/wordpress-domains/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-domains/page.tsx
@@ -11,22 +11,176 @@ export const metadata: Metadata = {
   alternates: {
     canonical: `https://ffcadmin.org/legacy-wordpress-administration/${SLUG}/`,
   },
+  keywords:
+    'FFC domains, eNom reseller, Cloudflare DNS, .org registration, domain transfer, ICANN verification, nonprofit domain',
 }
+
+interface Step {
+  index: number
+  id: string
+  title: string
+  description: string
+  adminCheck: string
+}
+
+const fourStepFlow: Step[] = [
+  {
+    index: 1,
+    id: 'cloudflare-signup',
+    title: 'Charity creates Cloudflare account',
+    description:
+      'Direct the charity to https://dash.cloudflare.com/sign-up using their charity-domain Outlook mailbox. They must keep this tab open through the entire flow.',
+    adminCheck:
+      'Confirm the account uses the charity-domain mailbox (not a personal Gmail). Cloudflare verification emails land in the same mailbox; personal addresses cause silent failures later.',
+  },
+  {
+    index: 2,
+    id: 'open-management',
+    title: 'Access the FFC domain management system',
+    description:
+      'The charity opens hub.freeforcharity.org (WHMCS) using the credentials issued during charity onboarding.',
+    adminCheck:
+      'If the charity has not completed onboarding (Stage 1-2 of service delivery), do not issue a domain — route them back to the validation flow first.',
+  },
+  {
+    index: 3,
+    id: 'register-domain',
+    title: 'Register a new .org through FFC',
+    description:
+      'FFC operates as a Platinum eNom reseller. The charity selects the .org name, applies the discount coupon code from their onboarding confirmation email, and submits.',
+    adminCheck:
+      'The coupon code is mandatory — without it, the charity is charged real money. If they paste the wrong code, cancel the order and reissue rather than refunding.',
+  },
+  {
+    index: 4,
+    id: 'configure-dns',
+    title: 'Configure DNS to point at Cloudflare',
+    description:
+      'In Cloudflare, add the new domain, copy the assigned nameservers, and paste them into the FFC eNom record under "Nameservers". Cloudflare confirms within 24 hours via email.',
+    adminCheck:
+      "If Cloudflare verification does not complete within 24 hours, check that nameservers were entered in eNom (not the WHMCS UI) and that the charity's mailbox actually received the verification email.",
+  },
+]
+
+const hardRequirements = [
+  'Use an organizational Outlook.com mailbox (never personal Gmail).',
+  'Keep the Cloudflare tab open through the domain purchase.',
+  'Include the discount coupon code from onboarding confirmation (mandatory).',
+  'Provide a payment method despite the $0 invoice (eNom requires a card on file).',
+  'Create at least two user accounts with admin access for redundancy and recovery.',
+  'Respond to every ICANN verification email within 14 days. Failure suspends the domain.',
+]
+
+const transferGotchas = [
+  'GoDaddy transfers fail when privacy is active — disable WHOIS privacy on the source first.',
+  'EPP codes must be entered exactly as supplied; trailing whitespace is a common cause of "invalid code" errors.',
+  'Fraud-flagged orders (typically because of mismatched billing address) need verification of US location and matching card/address — escalate to the FFC founder if the charity is legitimate.',
+  'Transfers typically take 5-10 business days. Set the charity expectation up front.',
+]
 
 export default function Page() {
   return (
     <LeafPageShell page={page}>
       <p>
-        <strong>Content migration in progress.</strong> This page is the ffcadmin.org
-        operations-team copy of{' '}
-        <a href={page.publicSourceUrl} target="_blank" rel="noopener noreferrer">
-          {page.publicSourceUrl}
-        </a>
-        . Body content is being migrated from the legacy WordPress source as part of issue #241.
+        FFC issues free .org domains to validated partner charities through its eNom Platinum
+        reseller account. The flow is four steps for the charity and four matching checks for the
+        FFC admin. This page documents both sides.
       </p>
+
       <p>
-        Until the migration lands, see the public version on freeforcharity.org for the current
-        content.
+        Charity-facing version:{' '}
+        <a href={page.publicSourceUrl} target="_blank" rel="noopener noreferrer">
+          freeforcharity.org/domains/
+        </a>
+        .
+      </p>
+
+      <h2>Two pathways into the domain flow</h2>
+      <ul>
+        <li>
+          <strong>501(c)(3) charities</strong> complete the standard onboarding via{' '}
+          <a href="https://freeforcharity.org/501c3/" target="_blank" rel="noopener noreferrer">
+            freeforcharity.org/501c3
+          </a>{' '}
+          before being issued a coupon.
+        </li>
+        <li>
+          <strong>Pre-501(c)(3) organizations</strong> use the alternate flow at{' '}
+          <a href="https://freeforcharity.org/pre501c3/" target="_blank" rel="noopener noreferrer">
+            freeforcharity.org/pre501c3
+          </a>{' '}
+          which trades a smaller toolkit for a faster path to a domain.
+        </li>
+      </ul>
+
+      <h2>The four-step domain flow</h2>
+      {fourStepFlow.map((step) => (
+        <section key={step.id} id={step.id}>
+          <h3>
+            Step {step.index} &mdash; {step.title}
+          </h3>
+          <p>{step.description}</p>
+          <p>
+            <strong>Admin check:</strong> {step.adminCheck}
+          </p>
+        </section>
+      ))}
+
+      <h2>Hard requirements (do not skip)</h2>
+      <ul>
+        {hardRequirements.map((r) => (
+          <li key={r}>{r}</li>
+        ))}
+      </ul>
+
+      <h2>Domain transfers from another registrar</h2>
+      <p>
+        For charities arriving with an existing domain (e.g. on GoDaddy, Namecheap, or another
+        registrar) we run a transfer-in instead of a new registration. Same coupon process, but with
+        these recurring gotchas:
+      </p>
+      <ul>
+        {transferGotchas.map((g) => (
+          <li key={g}>{g}</li>
+        ))}
+      </ul>
+
+      <h2>Email hosting (downstream)</h2>
+      <p>
+        Once the domain resolves through Cloudflare, the charity moves to Microsoft 365 Business
+        Premium for email — free for verified 501(c)(3) organizations, up to 10 mailboxes. See{' '}
+        <a href="/legacy-wordpress-administration/wordpress-online-impacts-onboarding/">
+          wordpress-online-impacts-onboarding
+        </a>{' '}
+        for the M365 provisioning steps.
+      </p>
+
+      <h2>Cross-references</h2>
+      <ul>
+        <li>
+          <a href="/legacy-wordpress-administration/wordpress-web-hosting/">
+            wordpress-web-hosting
+          </a>{' '}
+          — host setup that pairs with this domain registration.
+        </li>
+        <li>
+          <a href="/legacy-wordpress-administration/wordpress-hosting-techstack/">
+            wordpress-hosting-techstack
+          </a>{' '}
+          — DNS / SSL layer.
+        </li>
+        <li>
+          <a href="/legacy-wordpress-administration/wordpress-service-delivery-stages/">
+            wordpress-service-delivery-stages
+          </a>{' '}
+          — Stage 4-5 (Basic Services + Charity System & Website Setup).
+        </li>
+      </ul>
+
+      <h2>Support contact</h2>
+      <p>
+        Clarke Moyer (FFC founder): clarkemoyer@freeforcharity.org,{' '}
+        <a href="tel:5202228104">520-222-8104</a>.
       </p>
     </LeafPageShell>
   )

--- a/src/app/legacy-wordpress-administration/wordpress-domains/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-domains/page.tsx
@@ -1,0 +1,33 @@
+import type { Metadata } from 'next'
+import LeafPageShell from '@/components/legacy-wordpress-administration/LeafPageShell'
+import { getLegacyWpAdminPageBySlug } from '@/data/legacy-wordpress-administration'
+
+const SLUG = 'wordpress-domains'
+const page = getLegacyWpAdminPageBySlug(SLUG)!
+
+export const metadata: Metadata = {
+  title: page.title,
+  description: page.summary,
+  alternates: {
+    canonical: `https://ffcadmin.org/legacy-wordpress-administration/${SLUG}/`,
+  },
+}
+
+export default function Page() {
+  return (
+    <LeafPageShell page={page}>
+      <p>
+        <strong>Content migration in progress.</strong> This page is the ffcadmin.org
+        operations-team copy of{' '}
+        <a href={page.publicSourceUrl} target="_blank" rel="noopener noreferrer">
+          {page.publicSourceUrl}
+        </a>
+        . Body content is being migrated from the legacy WordPress source as part of issue #241.
+      </p>
+      <p>
+        Until the migration lands, see the public version on freeforcharity.org for the current
+        content.
+      </p>
+    </LeafPageShell>
+  )
+}

--- a/src/app/legacy-wordpress-administration/wordpress-domains/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-domains/page.tsx
@@ -3,7 +3,7 @@ import LeafPageShell from '@/components/legacy-wordpress-administration/LeafPage
 import { getLegacyWpAdminPageBySlug } from '@/data/legacy-wordpress-administration'
 
 const SLUG = 'wordpress-domains'
-const page = getLegacyWpAdminPageBySlug(SLUG)!
+const page = getLegacyWpAdminPageBySlug(SLUG)
 
 export const metadata: Metadata = {
   title: page.title,

--- a/src/app/legacy-wordpress-administration/wordpress-guidestar-guide/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-guidestar-guide/page.tsx
@@ -11,23 +11,188 @@ export const metadata: Metadata = {
   alternates: {
     canonical: `https://ffcadmin.org/legacy-wordpress-administration/${SLUG}/`,
   },
+  keywords:
+    'Candid GuideStar profile, transparency seal, Bronze Silver Gold Platinum, NTEE code, 501c3 verification, FFC onboarding',
 }
+
+interface Seal {
+  id: string
+  name: string
+  ffcRequirement: 'minimum' | 'preferred' | 'starting' | 'optional'
+  requirements: string[]
+  adminNotes: string
+}
+
+const seals: Seal[] = [
+  {
+    id: 'bronze',
+    name: 'Bronze Seal',
+    ffcRequirement: 'starting',
+    requirements: [
+      'Mission statement',
+      'Address and contact details',
+      'EIN / Tax ID',
+      'Leadership names and titles',
+    ],
+    adminNotes:
+      'Confirm the EIN matches the intake record and the IRS Business Master File. Mismatches are an early sign of an incorrect entity record.',
+  },
+  {
+    id: 'silver',
+    name: 'Silver Seal',
+    ffcRequirement: 'starting',
+    requirements: [
+      'Program names and descriptions',
+      'Geographic service areas',
+      'Goals and target beneficiary populations',
+    ],
+    adminNotes:
+      'The "geographic service areas" entries feed the technology- and service-directory cross-references on freeforcharity.org. Keep them accurate.',
+  },
+  {
+    id: 'gold',
+    name: 'Gold Seal',
+    ffcRequirement: 'minimum',
+    requirements: [
+      'IRS Form 990 (most recent year)',
+      'Audited financial statements (when available)',
+      'Fiscal-year financial data (revenue, expenses, assets, liabilities)',
+      'Diversity, Equity, and Inclusion organizational data',
+      'Board roster + IRS determination letter (FFC requirement on top of Candid baseline)',
+    ],
+    adminNotes:
+      'This is the FFC floor for full onboarding. A charity below Gold gets routed to "complete your GuideStar Gold seal first" rather than to service-delivery scheduling.',
+  },
+  {
+    id: 'platinum',
+    name: 'Platinum Seal',
+    ffcRequirement: 'preferred',
+    requirements: [
+      'Quantitative impact metrics (individuals served, program outcomes, performance indicators)',
+      'Strategic planning documents or relevant board reports',
+    ],
+    adminNotes:
+      'Platinum is the bar FFC itself holds (see Candid profile 9159614). Charities at Platinum receive the FFC widget treatment and a featured slot in the FFC partner directory.',
+  },
+]
 
 export default function Page() {
   return (
     <LeafPageShell page={page}>
       <p>
-        <strong>Content migration in progress.</strong> This page is the ffcadmin.org
-        operations-team copy of{' '}
-        <a href={page.publicSourceUrl} target="_blank" rel="noopener noreferrer">
-          {page.publicSourceUrl}
-        </a>
-        . Body content is being migrated from the legacy WordPress source as part of issue #241.
+        Candid (formerly GuideStar) is the canonical public registry for US nonprofits. Every FFC
+        partner charity maintains an active Candid profile, and FFC volunteer admins help them
+        progress through the four transparency seals — Bronze, Silver, Gold, Platinum. This page is
+        the operations-team runbook for that process.
       </p>
+
       <p>
-        Until the migration lands, see the public version on freeforcharity.org for the current
-        content.
+        The charity-facing version of this page is{' '}
+        <a href={page.publicSourceUrl} target="_blank" rel="noopener noreferrer">
+          freeforcharity.org/guidestar-guide/
+        </a>{' '}
+        and is written for charity staff doing the work. This page is the FFC admin&apos;s coaching
+        guide — what to check, what to require, what the gotchas are.
       </p>
+
+      <h2>FFC requirement floor</h2>
+      <p>
+        FFC requires <strong>at minimum the Gold seal</strong> plus board roster and IRS
+        determination letter uploads before completing service delivery. Charities below Gold get
+        routed back to seal completion before kickoff.
+      </p>
+
+      <p>Time budget for the charity:</p>
+      <ul>
+        <li>Initial run to Platinum: 2-3 hours.</li>
+        <li>Annual refresh: roughly 30 minutes.</li>
+      </ul>
+
+      <h2>Part 1 &mdash; Earning the seals</h2>
+
+      <h3>Step 0 &mdash; Claim the profile</h3>
+      <ol>
+        <li>
+          Create a free Candid account at{' '}
+          <a href="https://candid.org/" target="_blank" rel="noopener noreferrer">
+            candid.org
+          </a>
+          .
+        </li>
+        <li>
+          Search by EIN. If the profile already exists, current managers must add the charity&apos;s
+          email as an authorized updater — coach the charity through that handoff rather than
+          creating a duplicate profile.
+        </li>
+        <li>Verify the charity-side contact through the email confirmation Candid sends.</li>
+      </ol>
+
+      {seals.map((seal) => (
+        <section key={seal.id} id={seal.id}>
+          <h3>
+            {seal.name} {seal.ffcRequirement === 'minimum' && <em>— FFC minimum requirement</em>}
+            {seal.ffcRequirement === 'preferred' && <em>— FFC preferred level</em>}
+            {seal.ffcRequirement === 'starting' && <em>— starting requirement</em>}
+          </h3>
+          <p>
+            <strong>What the charity must supply:</strong>
+          </p>
+          <ul>
+            {seal.requirements.map((r) => (
+              <li key={r}>{r}</li>
+            ))}
+          </ul>
+          <p>
+            <strong>Admin notes:</strong> {seal.adminNotes}
+          </p>
+        </section>
+      ))}
+
+      <h2>Part 2 &mdash; Sharing the profile with FFC</h2>
+      <p>
+        After publishing the seal, Candid exposes three artefacts FFC needs in the intake record.
+        Collect them and paste into the charity&apos;s WHMCS notes:
+      </p>
+      <ol>
+        <li>
+          <strong>Full Profile link</strong> — the authenticated view, used by FFC admins to
+          double-check submissions.
+        </li>
+        <li>
+          <strong>Public Profile link</strong> — the URL displayed on the charity&apos;s eventual
+          FFC-delivered site and on the FFC directory pages.
+        </li>
+        <li>
+          <strong>Seal Code</strong> — the embed snippet that renders the seal badge. Used on the
+          charity&apos;s site footer (and FFC&apos;s own footer; see the GuideStar widget at the
+          bottom of this site).
+        </li>
+      </ol>
+
+      <h2>Annual refresh</h2>
+      <p>
+        Calendar a 30-minute slot every year — Q1 is the FFC convention. Refresh the most recent
+        990, reaffirm the impact metrics, and re-publish so the seal stays current. Lapsed seals
+        roll back to the previous tier publicly.
+      </p>
+
+      <h2>Cross-references</h2>
+      <ul>
+        <li>
+          Charity validation gate that requires this seal:{' '}
+          <a href="/legacy-wordpress-administration/wordpress-charity-validation/">
+            wordpress-charity-validation
+          </a>
+          .
+        </li>
+        <li>
+          Stage where this typically blocks delivery:{' '}
+          <a href="/legacy-wordpress-administration/wordpress-service-delivery-stages/">
+            wordpress-service-delivery-stages
+          </a>
+          .
+        </li>
+      </ul>
     </LeafPageShell>
   )
 }

--- a/src/app/legacy-wordpress-administration/wordpress-guidestar-guide/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-guidestar-guide/page.tsx
@@ -1,0 +1,33 @@
+import type { Metadata } from 'next'
+import LeafPageShell from '@/components/legacy-wordpress-administration/LeafPageShell'
+import { getLegacyWpAdminPageBySlug } from '@/data/legacy-wordpress-administration'
+
+const SLUG = 'wordpress-guidestar-guide'
+const page = getLegacyWpAdminPageBySlug(SLUG)!
+
+export const metadata: Metadata = {
+  title: page.title,
+  description: page.summary,
+  alternates: {
+    canonical: `https://ffcadmin.org/legacy-wordpress-administration/${SLUG}/`,
+  },
+}
+
+export default function Page() {
+  return (
+    <LeafPageShell page={page}>
+      <p>
+        <strong>Content migration in progress.</strong> This page is the ffcadmin.org
+        operations-team copy of{' '}
+        <a href={page.publicSourceUrl} target="_blank" rel="noopener noreferrer">
+          {page.publicSourceUrl}
+        </a>
+        . Body content is being migrated from the legacy WordPress source as part of issue #241.
+      </p>
+      <p>
+        Until the migration lands, see the public version on freeforcharity.org for the current
+        content.
+      </p>
+    </LeafPageShell>
+  )
+}

--- a/src/app/legacy-wordpress-administration/wordpress-guidestar-guide/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-guidestar-guide/page.tsx
@@ -3,7 +3,7 @@ import LeafPageShell from '@/components/legacy-wordpress-administration/LeafPage
 import { getLegacyWpAdminPageBySlug } from '@/data/legacy-wordpress-administration'
 
 const SLUG = 'wordpress-guidestar-guide'
-const page = getLegacyWpAdminPageBySlug(SLUG)!
+const page = getLegacyWpAdminPageBySlug(SLUG)
 
 export const metadata: Metadata = {
   title: page.title,

--- a/src/app/legacy-wordpress-administration/wordpress-hosting-techstack/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-hosting-techstack/page.tsx
@@ -11,22 +11,195 @@ export const metadata: Metadata = {
   alternates: {
     canonical: `https://ffcadmin.org/legacy-wordpress-administration/${SLUG}/`,
   },
+  keywords:
+    'WordPress hosting, InterServer DirectAdmin, Hostinger, WPMUDEV, Divi, Cloudflare DNS, Microsoft 365, FFC operations',
 }
+
+interface Layer {
+  id: string
+  index: number
+  name: string
+  vendor: string
+  metaphor: string
+  responsibility: string
+  escalationOrder: string[]
+  notes: string
+}
+
+const layers: Layer[] = [
+  {
+    id: 'foundation',
+    index: 1,
+    name: 'Foundation: Hosting Infrastructure',
+    vendor: 'InterServer (DirectAdmin) — legacy; Hostinger (hPanel) for current sites',
+    metaphor: 'The land beneath the house.',
+    responsibility:
+      'Physical servers, network, and the OS-level control panel that hosts every charity WordPress install.',
+    escalationOrder: [
+      'Vendor support (InterServer or Hostinger) for outages, server errors, disk / quota issues.',
+      'FFC Global Admin if vendor escalation is needed.',
+    ],
+    notes:
+      'Most legacy FFC sites live on InterServer DirectAdmin (IPs 192.64.86.202, 216.158.234.18). Newer sites have been migrated to Hostinger hPanel (IP 153.92.213.212). See the FFC sites list for the per-domain mapping.',
+  },
+  {
+    id: 'wordpress-install',
+    index: 2,
+    name: 'WordPress Installation: Softaculous',
+    vendor: 'Softaculous (bundled with DirectAdmin / hPanel)',
+    metaphor: 'The foundation of the house.',
+    responsibility:
+      'Automated WordPress install / upgrade / clone. Owns the wp-config.php, the database name, and the file ownership at install time.',
+    escalationOrder: [
+      'Host vendor support for install-time errors.',
+      'FFC Global Admin for charity-side reinstall / clone / staging copy.',
+    ],
+    notes:
+      "Softaculous installs land in the host's WordPress staging slot. The FFC convention is one charity per cPanel/hPanel account so backups stay scoped.",
+  },
+  {
+    id: 'plugins',
+    index: 3,
+    name: 'Plugins: WPMUDEV Suite',
+    vendor: 'WPMUDEV',
+    metaphor: 'Essential utilities (electricity, water, HVAC).',
+    responsibility:
+      'Security (Defender Pro), performance (Hummingbird, Smush Pro), backups (Snapshot Pro / Shipper Pro), and the WPMUDEV Dashboard plugin that ties everything together.',
+    escalationOrder: [
+      'WPMUDEV in-product help and documentation.',
+      'FFC Global Admin for hub-level account access.',
+    ],
+    notes:
+      'WPMUDEV plugins ship admin tokens that trigger GitHub push-protection during Simply Static exports — see docs/ffc-simply-static-config.md for the plugin allowlist used at conversion time.',
+  },
+  {
+    id: 'theme',
+    index: 4,
+    name: 'Theme: Divi',
+    vendor: 'Elegant Themes',
+    metaphor: 'Interior design.',
+    responsibility:
+      'Page builder, theme styling, and per-site customization. Owns the visual layer the charity edits day-to-day.',
+    escalationOrder: [
+      'Elegant Themes support for theme bugs and customization.',
+      'FFC Global Admin for licence and customization-template questions.',
+    ],
+    notes:
+      'Divi Builder ships its own cached CSS — clear Divi > Theme Options > Builder > Advanced > Static CSS before any Simply Static export.',
+  },
+  {
+    id: 'dns-ssl',
+    index: 5,
+    name: 'DNS and SSL: Cloudflare',
+    vendor: 'Cloudflare',
+    metaphor: 'The security system.',
+    responsibility:
+      "DNS authority, SSL certificate provisioning, WAF, and bulk-redirect rulesets. Connects the charity's domain to its origin server.",
+    escalationOrder: [
+      'Cloudflare in-product diagnostics (Trace, Audit Log).',
+      'FFC Global Admin for zone-level changes (registrar transfers, nameserver updates).',
+    ],
+    notes:
+      'See docs/cloudflare-bulk-redirects-cutover.csv for the redirect set used during a static-site cutover.',
+  },
+  {
+    id: 'email',
+    index: 6,
+    name: 'Email: Microsoft 365',
+    vendor: 'Microsoft 365 (Tenant: freeforcharity.onmicrosoft.com)',
+    metaphor: 'The post office.',
+    responsibility:
+      'Mailbox, calendar, and Teams services for FFC staff and partner-charity contacts. Separate trust boundary from the WordPress install — the WP server does not relay mail.',
+    escalationOrder: [
+      'Microsoft 365 admin centre for tenant issues.',
+      'FFC Global Admin for licence assignments and tenant-level requests.',
+    ],
+    notes:
+      'M365 admin is one of the two Global Administrator tracks volunteers complete in the FFC contributor ladder — see /training-plan/.',
+  },
+]
 
 export default function Page() {
   return (
     <LeafPageShell page={page}>
       <p>
-        <strong>Content migration in progress.</strong> This page is the ffcadmin.org
-        operations-team copy of{' '}
+        FFC charity WordPress sites combine six distinct vendor services in a single stack. Each
+        layer has a clear owner, a clear escalation path, and a clear failure mode. This page is the
+        operations-team reference for that stack — use it when triaging a charity issue, onboarding
+        a new volunteer admin, or scoping a migration off WordPress.
+      </p>
+
+      <p>
+        The charity-facing version of this content lives at{' '}
         <a href={page.publicSourceUrl} target="_blank" rel="noopener noreferrer">
-          {page.publicSourceUrl}
-        </a>
-        . Body content is being migrated from the legacy WordPress source as part of issue #241.
+          freeforcharity.org/techstack/
+        </a>{' '}
+        and uses simpler &ldquo;your house&rdquo; metaphors for non-technical charity staff. The
+        layers below preserve those metaphors as anchors.
+      </p>
+
+      <h2>How to use this page</h2>
+      <p>
+        Each layer below documents <strong>what it is</strong>, <strong>who owns it</strong>,{' '}
+        <strong>how to escalate</strong>, and the <strong>operational notes</strong> a volunteer
+        admin needs to know — including the gotchas that show up during static-site conversions.
+      </p>
+
+      <p>
+        If a charity issue is unresolved within 48 hours of escalating, text founder Clarke Moyer at{' '}
+        <a href="tel:5202228104">520-222-8104</a> — same cadence as the charity-facing page.
+      </p>
+
+      <h2>The six layers</h2>
+      <ol>
+        {layers.map((layer) => (
+          <li key={layer.id}>
+            <a href={`#${layer.id}`}>{layer.name}</a>
+          </li>
+        ))}
+      </ol>
+
+      {layers.map((layer) => (
+        <section key={layer.id} id={layer.id}>
+          <h2>
+            Layer {layer.index} &mdash; {layer.name}
+          </h2>
+          <p>
+            <em>{layer.metaphor}</em>
+          </p>
+          <p>
+            <strong>Vendor:</strong> {layer.vendor}
+          </p>
+          <p>
+            <strong>Responsibility:</strong> {layer.responsibility}
+          </p>
+          <p>
+            <strong>Escalation path:</strong>
+          </p>
+          <ol>
+            {layer.escalationOrder.map((step) => (
+              <li key={step}>{step}</li>
+            ))}
+          </ol>
+          <p>
+            <strong>Operational notes:</strong> {layer.notes}
+          </p>
+        </section>
+      ))}
+
+      <h2>Why this is &ldquo;legacy&rdquo;</h2>
+      <p>
+        Every charity site FFC builds today targets the GitHub Pages / Next.js static stack instead
+        — no WordPress, no plugin sprawl, no monthly licence cost. The layered model above still
+        applies (we still operate vendor-by-vendor), but the layers collapse to{' '}
+        <em>GitHub Pages + Cloudflare + Microsoft 365</em>: hosting, DNS, and email. No Softaculous,
+        no WPMUDEV, no Divi.
       </p>
       <p>
-        Until the migration lands, see the public version on freeforcharity.org for the current
-        content.
+        Read the{' '}
+        <a href="/guides/wordpress-to-nextjs-guide">WordPress-to-Next.js conversion guide</a> for
+        the migration playbook, and the <a href="/tech-stack">current FFC tech stack</a> for the
+        modern equivalent of this page.
       </p>
     </LeafPageShell>
   )

--- a/src/app/legacy-wordpress-administration/wordpress-hosting-techstack/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-hosting-techstack/page.tsx
@@ -3,7 +3,7 @@ import LeafPageShell from '@/components/legacy-wordpress-administration/LeafPage
 import { getLegacyWpAdminPageBySlug } from '@/data/legacy-wordpress-administration'
 
 const SLUG = 'wordpress-hosting-techstack'
-const page = getLegacyWpAdminPageBySlug(SLUG)!
+const page = getLegacyWpAdminPageBySlug(SLUG)
 
 export const metadata: Metadata = {
   title: page.title,

--- a/src/app/legacy-wordpress-administration/wordpress-hosting-techstack/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-hosting-techstack/page.tsx
@@ -1,0 +1,33 @@
+import type { Metadata } from 'next'
+import LeafPageShell from '@/components/legacy-wordpress-administration/LeafPageShell'
+import { getLegacyWpAdminPageBySlug } from '@/data/legacy-wordpress-administration'
+
+const SLUG = 'wordpress-hosting-techstack'
+const page = getLegacyWpAdminPageBySlug(SLUG)!
+
+export const metadata: Metadata = {
+  title: page.title,
+  description: page.summary,
+  alternates: {
+    canonical: `https://ffcadmin.org/legacy-wordpress-administration/${SLUG}/`,
+  },
+}
+
+export default function Page() {
+  return (
+    <LeafPageShell page={page}>
+      <p>
+        <strong>Content migration in progress.</strong> This page is the ffcadmin.org
+        operations-team copy of{' '}
+        <a href={page.publicSourceUrl} target="_blank" rel="noopener noreferrer">
+          {page.publicSourceUrl}
+        </a>
+        . Body content is being migrated from the legacy WordPress source as part of issue #241.
+      </p>
+      <p>
+        Until the migration lands, see the public version on freeforcharity.org for the current
+        content.
+      </p>
+    </LeafPageShell>
+  )
+}

--- a/src/app/legacy-wordpress-administration/wordpress-online-impacts-onboarding/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-online-impacts-onboarding/page.tsx
@@ -11,23 +11,263 @@ export const metadata: Metadata = {
   alternates: {
     canonical: `https://ffcadmin.org/legacy-wordpress-administration/${SLUG}/`,
   },
+  keywords:
+    'Online Impacts onboarding, charity transition, FFC takeover, InterServer nonprofit, Microsoft 365 nonprofit, GuideStar onboarding',
 }
+
+const prereqMaterials = [
+  'IRS 501(c)(3) determination letter',
+  'EIN (Employer Identification Number)',
+  'Board member names, titles, contact info, LinkedIn profiles, and bios',
+  'Mission statement',
+  'Most recent Form 990',
+  'Annual report (if available)',
+  'Programs and services list',
+  'Financial statements (past 2 years)',
+  'Current operating budget',
+  'Strategic plan (if available)',
+  'Current website URL',
+  'Social media links',
+  'High-resolution logo files',
+  'Brand guidelines',
+]
+
+const externalAccounts = [
+  {
+    name: 'Charity-named Outlook mailbox',
+    adminNote: 'M365 nonprofit tenant; FFC creates the tenant on behalf of the charity if missing.',
+  },
+  {
+    name: 'Candid (GuideStar) profile at Gold or higher',
+    adminNote: 'See wordpress-guidestar-guide for the seal-progression runbook.',
+  },
+  {
+    name: 'Verified Nonprofit Facebook page',
+    adminNote: 'Cross-checked against intake record during validation.',
+  },
+  {
+    name: 'Verified Nonprofit LinkedIn page',
+    adminNote: 'Required for board-bio cross-references.',
+  },
+  {
+    name: 'VolunteerMatch profile',
+    adminNote: 'Even if dormant — confirms the charity engages volunteers.',
+  },
+  {
+    name: 'TechSoup validated account',
+    adminNote: 'Drives the discounted-software pipeline (QuickBooks, Adobe, Microsoft).',
+  },
+  {
+    name: 'PayPal Nonprofits account',
+    adminNote: 'Donor flow target after the FFC-delivered site is live.',
+  },
+]
+
+interface OnboardingStep {
+  index: number
+  id: string
+  title: string
+  description: string
+  adminAction: string
+}
+
+const onboardingSteps: OnboardingStep[] = [
+  {
+    index: 1,
+    id: 'guidestar-verification',
+    title: 'GuideStar 501(c)(3) verification',
+    description:
+      'Charity supplies both the Public Profile link and the Full Profile link from their Candid record.',
+    adminAction:
+      'Validate the EIN matches the IRS Business Master File. Confirm seal ≥ Gold or queue them back to wordpress-guidestar-guide.',
+  },
+  {
+    index: 2,
+    id: 'board-contact-info',
+    title: 'Board contact information',
+    description:
+      'Charity supplies full contact details for President/Chair, Secretary, Treasurer. Optionally Vice and Member-At-Large.',
+    adminAction:
+      'Cross-reference board names against the GuideStar profile and any pre-existing FFC records.',
+  },
+  {
+    index: 3,
+    id: 'primary-technical-contacts',
+    title: 'Primary + technical contacts',
+    description:
+      'Full contact details for the charity-side primary contact and the technical contact, including timezone and preferred contact hours.',
+    adminAction:
+      'Add both to the M365 tenant directory under the charity domain once Stage 5 completes.',
+  },
+  {
+    index: 4,
+    id: 'onboarding-form',
+    title: 'Complete the WHMCS onboarding form',
+    description:
+      'Charity submits the "Online Impacts to FFC Onboarding" product at the FFC store. This creates the charity record in WHMCS and triggers the FFC intake notification.',
+    adminAction:
+      'Watch the FFC intake inbox for the form submission, then proceed to domain + hosting steps below.',
+  },
+]
+
+interface ResourceStep {
+  index: number
+  id: string
+  title: string
+  steps: string[]
+  adminGotcha: string
+}
+
+const domainSteps: ResourceStep = {
+  index: 1,
+  id: 'domain-email',
+  title: 'Domain + email setup',
+  steps: [
+    'Issue the charity a domain discount code through WHMCS once Stage 4 (Basic Services) starts.',
+    'Direct them to freeforcharity.org/domains to request a new .org or transfer an existing one.',
+    "Once domain management is in FFC's control, provision charity-domain mailboxes on the M365 tenant (board@, info@, donate@, etc.).",
+  ],
+  adminGotcha:
+    'Domain transfers from non-cooperative registrars can take 5-10 business days. Set the charity expectation up front so they do not chase the status weekly.',
+}
+
+const hostingSteps: ResourceStep = {
+  index: 2,
+  id: 'hosting-setup',
+  title: 'InterServer / Hostinger hosting setup',
+  steps: [
+    'Charity creates an account at my.interserver.net (or hpanel.hostinger.com for newer onboarding) using the charity-domain mailbox.',
+    "Charity emails the host's nonprofit-services address with a copy of the IRS 501(c)(3) letter and the registered domain.",
+    'FFC admin co-signs as tech sponsor.',
+    "Once the host's nonprofit program approves, log in to the control panel and proceed to WordPress install.",
+  ],
+  adminGotcha:
+    "InterServer's nonprofit approval letter routes through sales@interserver.net — historically 24-48 hours; budget a full week to keep expectations conservative.",
+}
+
+const wpInstallSteps: ResourceStep = {
+  index: 3,
+  id: 'wordpress-install',
+  title: 'WordPress install + FFC admin account',
+  steps: [
+    'In Softaculous (DirectAdmin) or the equivalent on hPanel, install WordPress at the root of the charity domain (leave the "directory" field blank).',
+    'Set admin username/password from the FFC password manager. Use a generated password — never re-use across charities.',
+    'Set site title and tagline from the intake record.',
+    'After install, create a second admin user: username globaladmin, email globaladmin@freeforcharity.org, generated password.',
+    'Add the "Powered by InterServer" footer link within 30 days of install (or "Powered by Hostinger" on hPanel-hosted sites). This is a hard requirement of the nonprofit hosting deal.',
+  ],
+  adminGotcha:
+    'Missing the footer-link requirement converts a free hosting account into a paid one retroactively. Calendar a 28-day check and ship the link.',
+}
+
+const resourceSteps = [domainSteps, hostingSteps, wpInstallSteps]
 
 export default function Page() {
   return (
     <LeafPageShell page={page}>
       <p>
-        <strong>Content migration in progress.</strong> This page is the ffcadmin.org
-        operations-team copy of{' '}
-        <a href={page.publicSourceUrl} target="_blank" rel="noopener noreferrer">
-          {page.publicSourceUrl}
-        </a>
-        . Body content is being migrated from the legacy WordPress source as part of issue #241.
+        Online Impacts charities transitioning into the FFC support footprint follow a structured
+        onboarding sequence. The flow exists because Online Impacts and FFC have slightly different
+        intake requirements, and the transition needs to capture the delta before service delivery
+        starts.
       </p>
+
       <p>
-        Until the migration lands, see the public version on freeforcharity.org for the current
-        content.
+        The charity-facing version of this guide lives at{' '}
+        <a href={page.publicSourceUrl} target="_blank" rel="noopener noreferrer">
+          freeforcharity.org/online-impacts-onboarding-guide/
+        </a>{' '}
+        and walks the charity team through it. This page is the admin-side companion — what to watch
+        for at each step.
       </p>
+
+      <h2>Prerequisites (charity supplies)</h2>
+      <p>
+        Confirm the charity has the following in hand before the onboarding form goes out. Missing
+        prereqs are the single biggest source of stuck onboardings.
+      </p>
+      <ul>
+        {prereqMaterials.map((m) => (
+          <li key={m}>{m}</li>
+        ))}
+      </ul>
+
+      <h2>External validation accounts</h2>
+      <p>
+        Each account below maps to a check from{' '}
+        <a href="/legacy-wordpress-administration/wordpress-charity-validation/">
+          wordpress-charity-validation
+        </a>
+        :
+      </p>
+      <ul>
+        {externalAccounts.map((acct) => (
+          <li key={acct.name}>
+            <strong>{acct.name}</strong> — {acct.adminNote}
+          </li>
+        ))}
+      </ul>
+
+      <h2>Onboarding flow</h2>
+      {onboardingSteps.map((step) => (
+        <section key={step.id} id={step.id}>
+          <h3>
+            Step {step.index} &mdash; {step.title}
+          </h3>
+          <p>{step.description}</p>
+          <p>
+            <strong>Admin action:</strong> {step.adminAction}
+          </p>
+        </section>
+      ))}
+
+      <h2>Resource provisioning (FFC admin runs)</h2>
+      {resourceSteps.map((step) => (
+        <section key={step.id} id={step.id}>
+          <h3>
+            {step.index}. {step.title}
+          </h3>
+          <ol>
+            {step.steps.map((s) => (
+              <li key={s}>{s}</li>
+            ))}
+          </ol>
+          <p>
+            <strong>Gotcha:</strong> {step.adminGotcha}
+          </p>
+        </section>
+      ))}
+
+      <h2>Support contacts</h2>
+      <ul>
+        <li>
+          Clarke Moyer (FFC founder) — clarkemoyer@freeforcharity.org,{' '}
+          <a href="tel:5202228104">520-222-8104</a>
+        </li>
+        <li>Pardhasaradhi Namburi (Online Impacts founder) — pardhu@onlineimpacts.org</li>
+      </ul>
+
+      <h2>Cross-references</h2>
+      <ul>
+        <li>
+          <a href="/legacy-wordpress-administration/wordpress-service-delivery-stages/">
+            wordpress-service-delivery-stages
+          </a>{' '}
+          — broader lifecycle this fits into.
+        </li>
+        <li>
+          <a href="/legacy-wordpress-administration/wordpress-charity-validation/">
+            wordpress-charity-validation
+          </a>{' '}
+          — checks that gate each step.
+        </li>
+        <li>
+          <a href="/legacy-wordpress-administration/wordpress-guidestar-guide/">
+            wordpress-guidestar-guide
+          </a>{' '}
+          — seal progression requirement.
+        </li>
+      </ul>
     </LeafPageShell>
   )
 }

--- a/src/app/legacy-wordpress-administration/wordpress-online-impacts-onboarding/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-online-impacts-onboarding/page.tsx
@@ -3,7 +3,7 @@ import LeafPageShell from '@/components/legacy-wordpress-administration/LeafPage
 import { getLegacyWpAdminPageBySlug } from '@/data/legacy-wordpress-administration'
 
 const SLUG = 'wordpress-online-impacts-onboarding'
-const page = getLegacyWpAdminPageBySlug(SLUG)!
+const page = getLegacyWpAdminPageBySlug(SLUG)
 
 export const metadata: Metadata = {
   title: page.title,

--- a/src/app/legacy-wordpress-administration/wordpress-online-impacts-onboarding/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-online-impacts-onboarding/page.tsx
@@ -244,7 +244,13 @@ export default function Page() {
           Clarke Moyer (FFC founder) — clarkemoyer@freeforcharity.org,{' '}
           <a href="tel:5202228104">520-222-8104</a>
         </li>
-        <li>Pardhasaradhi Namburi (Online Impacts founder) — pardhu@onlineimpacts.org</li>
+        <li>
+          Online Impacts founder — contact via{' '}
+          <a href="https://onlineimpacts.org/" target="_blank" rel="noopener noreferrer">
+            onlineimpacts.org
+          </a>
+          .
+        </li>
       </ul>
 
       <h2>Cross-references</h2>

--- a/src/app/legacy-wordpress-administration/wordpress-online-impacts-onboarding/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-online-impacts-onboarding/page.tsx
@@ -1,0 +1,33 @@
+import type { Metadata } from 'next'
+import LeafPageShell from '@/components/legacy-wordpress-administration/LeafPageShell'
+import { getLegacyWpAdminPageBySlug } from '@/data/legacy-wordpress-administration'
+
+const SLUG = 'wordpress-online-impacts-onboarding'
+const page = getLegacyWpAdminPageBySlug(SLUG)!
+
+export const metadata: Metadata = {
+  title: page.title,
+  description: page.summary,
+  alternates: {
+    canonical: `https://ffcadmin.org/legacy-wordpress-administration/${SLUG}/`,
+  },
+}
+
+export default function Page() {
+  return (
+    <LeafPageShell page={page}>
+      <p>
+        <strong>Content migration in progress.</strong> This page is the ffcadmin.org
+        operations-team copy of{' '}
+        <a href={page.publicSourceUrl} target="_blank" rel="noopener noreferrer">
+          {page.publicSourceUrl}
+        </a>
+        . Body content is being migrated from the legacy WordPress source as part of issue #241.
+      </p>
+      <p>
+        Until the migration lands, see the public version on freeforcharity.org for the current
+        content.
+      </p>
+    </LeafPageShell>
+  )
+}

--- a/src/app/legacy-wordpress-administration/wordpress-service-delivery-stages/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-service-delivery-stages/page.tsx
@@ -3,7 +3,7 @@ import LeafPageShell from '@/components/legacy-wordpress-administration/LeafPage
 import { getLegacyWpAdminPageBySlug } from '@/data/legacy-wordpress-administration'
 
 const SLUG = 'wordpress-service-delivery-stages'
-const page = getLegacyWpAdminPageBySlug(SLUG)!
+const page = getLegacyWpAdminPageBySlug(SLUG)
 
 export const metadata: Metadata = {
   title: page.title,

--- a/src/app/legacy-wordpress-administration/wordpress-service-delivery-stages/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-service-delivery-stages/page.tsx
@@ -11,23 +11,198 @@ export const metadata: Metadata = {
   alternates: {
     canonical: `https://ffcadmin.org/legacy-wordpress-administration/${SLUG}/`,
   },
+  keywords:
+    'FFC service delivery, intake validation kickoff, WHMCS portal, charity onboarding lifecycle, WPMUDEV, M365 nonprofit',
 }
+
+interface Stage {
+  id: string
+  index: number
+  name: string
+  description: string
+  exitGate: string
+  blockerHandling: string
+  ownerRole: 'Intake Volunteer' | 'FFC Global Admin' | 'Web Developer Volunteer'
+}
+
+const stages: Stage[] = [
+  {
+    id: 'initial-contact',
+    index: 1,
+    name: 'Initial Contact & Onboarding',
+    description:
+      'Charity discovers FFC and completes account setup through the WHMCS portal by selecting the "Charity Onboarding & Validation" product. Intake form is submitted at no cost.',
+    exitGate:
+      'WHMCS account exists, intake form is fully completed, charity has acknowledged the FFC AUP.',
+    blockerHandling:
+      'Missing fields → reply with the specific gaps. International charities → polite decline, US-only restriction.',
+    ownerRole: 'Intake Volunteer',
+  },
+  {
+    id: 'validation-checks',
+    index: 2,
+    name: 'FFC Validation Checks',
+    description:
+      'External + internal validation runs against the intake record (501(c)(3) status, NTEE code, TechSoup, VolunteerMatch, Facebook, email, WHMCS / PayPal, financial sizing, content review, demographic).',
+    exitGate: 'All nine validation checks resolve to a documented pass or a documented exception.',
+    blockerHandling:
+      'Below Gold seal → bounce back to GuideStar guide. Below US-citizen point of contact → polite decline. Pending TechSoup → put intake on hold with reminder cadence.',
+    ownerRole: 'Intake Volunteer',
+  },
+  {
+    id: 'service-offer',
+    index: 3,
+    name: 'FFC Offers Services',
+    description:
+      'Approved charity receives a service offer based on mission fit and operational capacity. Priority is given to charities with under $1M revenue that are not federally grant-funded. FFC supports up to 100 organizations.',
+    exitGate: 'Charity accepts the offer in writing (WHMCS quote signed).',
+    blockerHandling:
+      'Over capacity → backlog with a quarterly review. Mission misalignment → polite decline with rationale.',
+    ownerRole: 'FFC Global Admin',
+  },
+  {
+    id: 'basic-services',
+    index: 4,
+    name: 'Basic Services Package',
+    description:
+      'Two FFC-funded foundations: (a) free domain, registered and maintained by FFC, connected through Cloudflare; (b) Microsoft 365 tenant via the Nonprofits program with domain validation.',
+    exitGate:
+      'Domain resolves through Cloudflare. Microsoft 365 tenant validates and grants nonprofit pricing.',
+    blockerHandling:
+      "Cloudflare verification stuck → check registrar nameserver records first. M365 nonprofit validation rejected → re-submit with the charity's Candid profile link.",
+    ownerRole: 'FFC Global Admin',
+  },
+  {
+    id: 'system-website-setup',
+    index: 5,
+    name: 'Charity System & Website Setup',
+    description:
+      'Branches by status. Pre-501(c)(3) charities complete the WordPress site checkout product and receive an auto-built starter site. 501(c)(3) charities complete the InterServer / Hostinger nonprofit application and designate FFC as tech sponsor.',
+    exitGate:
+      'WordPress install is live on its eventual production hostname; charity has admin credentials.',
+    blockerHandling:
+      'Hosting application denied → escalate to the FFC founder for sponsor letter. WordPress install errors → see wordpress-hosting-techstack escalation order.',
+    ownerRole: 'FFC Global Admin',
+  },
+  {
+    id: 'tech-stack-assignment',
+    index: 6,
+    name: 'Technical Stack Assignment',
+    description:
+      'Volunteer admin configures the underlying WordPress infrastructure: SSO accounts, role assignments to charity stakeholders, two-factor enforcement, backup schedule.',
+    exitGate: 'Charity primary contact can log into WP admin and into the M365 tenant via SSO.',
+    blockerHandling:
+      'SSO mismatch (charity using personal email instead of charity-domain mailbox) → block until charity-domain mailbox exists.',
+    ownerRole: 'Web Developer Volunteer',
+  },
+  {
+    id: 'plugin-theme-deployment',
+    index: 7,
+    name: 'Plugin & Theme Deployment',
+    description:
+      'Install the WPMUDEV Dashboard plugin, Defender (security), Hummingbird / Smush (performance), Snapshot (backups). Deploy Divi parent theme and the FFC child layout.',
+    exitGate:
+      'WPMUDEV Dashboard reports green across security, performance, backup. Divi child theme is active.',
+    blockerHandling:
+      'Plugin licence conflicts → confirm the WPMUDEV account membership covers the site.',
+    ownerRole: 'Web Developer Volunteer',
+  },
+  {
+    id: 'launch-config',
+    index: 8,
+    name: 'Initial Site Launch & Configuration',
+    description:
+      "Functional template site goes live in minutes, pre-populated with the charity's onboarding info. Upgrade PHP to the host-supported 8.x track. First production backup runs.",
+    exitGate:
+      'Site is reachable at production hostname over HTTPS, Lighthouse > 80, first backup successfully restored to staging as a smoke test.',
+    blockerHandling:
+      'PHP upgrade breaks Divi → roll back to the previous PHP minor and open a Divi support ticket.',
+    ownerRole: 'Web Developer Volunteer',
+  },
+]
 
 export default function Page() {
   return (
     <LeafPageShell page={page}>
       <p>
-        <strong>Content migration in progress.</strong> This page is the ffcadmin.org
-        operations-team copy of{' '}
+        FFC delivers a charity website through an eight-stage lifecycle. Each stage has a clear exit
+        gate, a clear owner role, and a documented way to handle the typical blockers. This page is
+        the operations-team reference; the charity-facing version on{' '}
         <a href={page.publicSourceUrl} target="_blank" rel="noopener noreferrer">
-          {page.publicSourceUrl}
-        </a>
-        . Body content is being migrated from the legacy WordPress source as part of issue #241.
+          freeforcharity.org
+        </a>{' '}
+        describes the same flow from the charity&apos;s perspective.
       </p>
+
+      <h2>The &ldquo;filter out&rdquo; philosophy</h2>
       <p>
-        Until the migration lands, see the public version on freeforcharity.org for the current
-        content.
+        FFC&apos;s intake is intentionally selective: charities demonstrate readiness through the
+        validation steps before service-delivery resources commit. This protects volunteer time and
+        ensures every shipped site lands at a charity that can actually run it.
       </p>
+
+      <h2>Eligibility floor</h2>
+      <ul>
+        <li>US-based charity with US-citizen point of contact.</li>
+        <li>501(c)(3) status active (or pre-501(c)(3) using the pre501c3 track).</li>
+        <li>At minimum Gold Candid seal (see wordpress-guidestar-guide).</li>
+        <li>Revenue under $1M and not federally grant-funded (priority criterion).</li>
+      </ul>
+
+      <h2>Stage table</h2>
+
+      {stages.map((stage) => (
+        <section key={stage.id} id={stage.id}>
+          <h3>
+            Stage {stage.index} &mdash; {stage.name}
+          </h3>
+          <p>{stage.description}</p>
+          <p>
+            <strong>Owner role:</strong> {stage.ownerRole}
+          </p>
+          <p>
+            <strong>Exit gate:</strong> {stage.exitGate}
+          </p>
+          <p>
+            <strong>Blocker handling:</strong> {stage.blockerHandling}
+          </p>
+        </section>
+      ))}
+
+      <h2>After Stage 8 &mdash; service expansion</h2>
+      <p>
+        Once the basic site is launched and the charity demonstrates they can actually operate it
+        (post a few news items, respond to a contact-form submission, manage their own user
+        accounts), FFC unlocks advanced services: full design polish, custom functionality, advocacy
+        tooling, and increasingly, a static-site migration to the modern{' '}
+        <a href="/tech-stack">FFC Next.js stack</a>.
+      </p>
+
+      <h2>Cross-references</h2>
+      <ul>
+        <li>
+          <a href="/legacy-wordpress-administration/wordpress-charity-validation/">
+            wordpress-charity-validation
+          </a>{' '}
+          — Stage 2 detail.
+        </li>
+        <li>
+          <a href="/legacy-wordpress-administration/wordpress-guidestar-guide/">
+            wordpress-guidestar-guide
+          </a>{' '}
+          — Eligibility floor.
+        </li>
+        <li>
+          <a href="/legacy-wordpress-administration/wordpress-hosting-techstack/">
+            wordpress-hosting-techstack
+          </a>{' '}
+          — Stages 4-8 vendor map.
+        </li>
+        <li>
+          <a href="/guides/wordpress-to-nextjs-guide">WordPress-to-Next.js conversion guide</a> —
+          Where charities go after they outgrow the WordPress delivery.
+        </li>
+      </ul>
     </LeafPageShell>
   )
 }

--- a/src/app/legacy-wordpress-administration/wordpress-service-delivery-stages/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-service-delivery-stages/page.tsx
@@ -1,0 +1,33 @@
+import type { Metadata } from 'next'
+import LeafPageShell from '@/components/legacy-wordpress-administration/LeafPageShell'
+import { getLegacyWpAdminPageBySlug } from '@/data/legacy-wordpress-administration'
+
+const SLUG = 'wordpress-service-delivery-stages'
+const page = getLegacyWpAdminPageBySlug(SLUG)!
+
+export const metadata: Metadata = {
+  title: page.title,
+  description: page.summary,
+  alternates: {
+    canonical: `https://ffcadmin.org/legacy-wordpress-administration/${SLUG}/`,
+  },
+}
+
+export default function Page() {
+  return (
+    <LeafPageShell page={page}>
+      <p>
+        <strong>Content migration in progress.</strong> This page is the ffcadmin.org
+        operations-team copy of{' '}
+        <a href={page.publicSourceUrl} target="_blank" rel="noopener noreferrer">
+          {page.publicSourceUrl}
+        </a>
+        . Body content is being migrated from the legacy WordPress source as part of issue #241.
+      </p>
+      <p>
+        Until the migration lands, see the public version on freeforcharity.org for the current
+        content.
+      </p>
+    </LeafPageShell>
+  )
+}

--- a/src/app/legacy-wordpress-administration/wordpress-tools-for-success/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-tools-for-success/page.tsx
@@ -11,23 +11,294 @@ export const metadata: Metadata = {
   alternates: {
     canonical: `https://ffcadmin.org/legacy-wordpress-administration/${SLUG}/`,
   },
+  keywords:
+    'FFC tools for success, nonprofit toolkit, productivity, accounting, CRM, password management, M365 nonprofit, Salesforce, TechSoup',
 }
+
+interface Tool {
+  id: string
+  name: string
+  cost: string
+  description: string
+  ffcStance: 'required' | 'recommended' | 'optional' | 'deprecated'
+  modernNotes: string
+}
+
+interface ToolCategory {
+  id: string
+  label: string
+  blurb: string
+  tools: Tool[]
+}
+
+const categories: ToolCategory[] = [
+  {
+    id: 'general-everyone',
+    label: 'General tools for everyone',
+    blurb: 'Personal-productivity tools FFC recommends to anyone working with a charity.',
+    tools: [
+      {
+        id: 'lastpass',
+        name: 'LastPass',
+        cost: 'Free + Premium',
+        description:
+          'Password vault for credential storage. Legacy FFC standard for secrets sharing across volunteers.',
+        ffcStance: 'recommended',
+        modernNotes:
+          'Modern FFC is migrating to Bitwarden / 1Password Teams. Still acceptable but evaluate at next renewal.',
+      },
+      {
+        id: 'mint',
+        name: 'Mint',
+        cost: 'Free, ad-supported',
+        description: 'Personal financial tracking — earning and spending patterns over time.',
+        ffcStance: 'optional',
+        modernNotes:
+          'Intuit retired Mint in early 2024. Replacements: Credit Karma (same vendor), Monarch, YNAB.',
+      },
+      {
+        id: 'credit-karma',
+        name: 'Credit Karma',
+        cost: 'Free, ad-supported',
+        description: 'Credit score and report monitoring.',
+        ffcStance: 'optional',
+        modernNotes: 'Still active; the Mint replacement for budgeting features.',
+      },
+      {
+        id: 'rescuetime',
+        name: 'RescueTime',
+        cost: 'Free + Premium',
+        description: 'Personal productivity tracking — surfaces work-habit patterns.',
+        ffcStance: 'optional',
+        modernNotes: 'Workplace IT may block installation. Use only on personal machines.',
+      },
+      {
+        id: 'linkedin',
+        name: 'LinkedIn',
+        cost: 'Free + Premium',
+        description:
+          'Professional networking; functions as the durable contact record for FFC volunteers.',
+        ffcStance: 'recommended',
+        modernNotes: 'Required for proving-ground board cross-references.',
+      },
+      {
+        id: 'dragon',
+        name: 'Dragon NaturallySpeaking',
+        cost: '~$200',
+        description:
+          'Speech-to-text for accessibility — particularly useful for volunteers with dyslexia.',
+        ffcStance: 'optional',
+        modernNotes:
+          'macOS and Windows now ship comparable built-in dictation. Evaluate built-in tools first.',
+      },
+    ],
+  },
+  {
+    id: 'nonprofit-specific',
+    label: 'Nonprofit-specific tools',
+    blurb: 'Tools FFC routes partner charities to as part of standard onboarding.',
+    tools: [
+      {
+        id: 'guidestar',
+        name: 'Candid (GuideStar)',
+        cost: 'Free + paid',
+        description: 'Canonical US nonprofit directory; FFC requires at minimum the Gold seal.',
+        ffcStance: 'required',
+        modernNotes: 'See wordpress-guidestar-guide for the seal-progression runbook.',
+      },
+      {
+        id: 'techsoup',
+        name: 'TechSoup',
+        cost: 'Free + admin fees',
+        description:
+          'Validated-charity gateway to discounted software (Adobe, Microsoft, QuickBooks).',
+        ffcStance: 'required',
+        modernNotes:
+          'Charity must complete TechSoup validation before FFC routes them through the discount pipeline.',
+      },
+      {
+        id: 'volunteermatch',
+        name: 'VolunteerMatch',
+        cost: 'Free basic + paid upgrades',
+        description: 'Volunteer recruitment + LinkedIn integration.',
+        ffcStance: 'recommended',
+        modernNotes:
+          'Used in charity-validation to confirm the charity engages volunteers — even a dormant profile counts.',
+      },
+      {
+        id: 'm365-nonprofit',
+        name: 'Microsoft 365 Enterprise for Nonprofits',
+        cost: 'Free + premium tiers',
+        description:
+          'Mailbox, calendar, Teams, OneDrive, and the Office suite — FFC default productivity stack.',
+        ffcStance: 'required',
+        modernNotes:
+          'M365 admin is one of the two FFC Global Admin training tracks. See /training-plan.',
+      },
+      {
+        id: 'google-workspace',
+        name: 'Google Workspace for Nonprofits',
+        cost: 'Free + paid plans',
+        description: 'Gmail, Drive, AdWords grant.',
+        ffcStance: 'optional',
+        modernNotes:
+          "FFC default is M365; Google Workspace remains acceptable if the charity is already deeply embedded. Don't migrate them just for parity.",
+      },
+      {
+        id: 'salesforce',
+        name: 'Salesforce Nonprofit Cloud',
+        cost: 'Free up to 10 seats annually',
+        description: 'CRM for donor + program management.',
+        ffcStance: 'recommended',
+        modernNotes:
+          'Available through the Salesforce Foundation. Substantial overhead — only deploy if the charity has staff capacity to operate it.',
+      },
+      {
+        id: 'quickbooks',
+        name: 'QuickBooks Online (Nonprofit)',
+        cost: '$75/year (5 users)',
+        description:
+          'Industry-standard accounting software, available at nonprofit pricing via TechSoup.',
+        ffcStance: 'recommended',
+        modernNotes: 'Wave Accounting (below) is the free alternative for very small charities.',
+      },
+      {
+        id: 'grantstation',
+        name: 'GrantStation',
+        cost: '~$199/year',
+        description: 'Grant research and writing tooling.',
+        ffcStance: 'optional',
+        modernNotes: 'Only worth the cost if the charity has a dedicated grant writer.',
+      },
+      {
+        id: 'mailchimp',
+        name: 'MailChimp',
+        cost: 'Tiered + 15% nonprofit discount',
+        description: 'Marketing automation and email broadcasts.',
+        ffcStance: 'optional',
+        modernNotes: 'Many charities migrate to ConvertKit / Brevo as MailChimp pricing climbs.',
+      },
+    ],
+  },
+  {
+    id: 'small-business',
+    label: 'Small-business tools',
+    blurb: 'Useful when the charity has earned-revenue or consulting income alongside donations.',
+    tools: [
+      {
+        id: 'wave',
+        name: 'Wave Accounting',
+        cost: 'Free, ad-supported',
+        description: 'Basic accounting for very small charities or earned-revenue arms.',
+        ffcStance: 'optional',
+        modernNotes: 'Migrate to QuickBooks once the charity has more than one income stream.',
+      },
+      {
+        id: 'shoeboxed',
+        name: 'Shoeboxed',
+        cost: 'Free + premium',
+        description: 'Receipt scanning + OCR for charity expense tracking.',
+        ffcStance: 'optional',
+        modernNotes:
+          'M365 + OneDrive + Power Automate covers most of this need now for FFC-managed charities.',
+      },
+      {
+        id: 'fiverr',
+        name: 'Fiverr',
+        cost: '$5+/task',
+        description: 'Outsourced micro-tasks.',
+        ffcStance: 'optional',
+        modernNotes:
+          'Use sparingly — charity-relevant tasks usually need a long-term relationship.',
+      },
+      {
+        id: 'upwork',
+        name: 'Upwork',
+        cost: 'Per-project',
+        description: 'Outsourced larger freelance work.',
+        ffcStance: 'optional',
+        modernNotes: 'Vet vendors carefully — FFC volunteers are the first line for charity work.',
+      },
+    ],
+  },
+]
 
 export default function Page() {
   return (
     <LeafPageShell page={page}>
       <p>
-        <strong>Content migration in progress.</strong> This page is the ffcadmin.org
-        operations-team copy of{' '}
-        <a href={page.publicSourceUrl} target="_blank" rel="noopener noreferrer">
-          {page.publicSourceUrl}
-        </a>
-        . Body content is being migrated from the legacy WordPress source as part of issue #241.
+        FFC partners with three audiences — charities, volunteers, and the FFC operations team — and
+        each one needs a different slice of the broader nonprofit toolkit. This page is the
+        operations-team reference: which tools FFC requires, which it recommends, which it
+        tolerates, and which have been retired or replaced since the original guide was published.
       </p>
+
       <p>
-        Until the migration lands, see the public version on freeforcharity.org for the current
-        content.
+        The charity-facing curated list lives at{' '}
+        <a href={page.publicSourceUrl} target="_blank" rel="noopener noreferrer">
+          freeforcharity.org/free-for-charitys-tools-for-success/
+        </a>
+        . This page adds the FFC stance (required / recommended / optional / deprecated) plus modern
+        notes so a volunteer admin onboarding a charity knows what to push for, what to tolerate,
+        and what to skip.
       </p>
+
+      <h2>How to read the stance column</h2>
+      <ul>
+        <li>
+          <strong>Required</strong> — FFC will not complete service delivery without this in place
+          at the charity.
+        </li>
+        <li>
+          <strong>Recommended</strong> — FFC actively suggests this; deviation needs a reason.
+        </li>
+        <li>
+          <strong>Optional</strong> — Fine if the charity wants it, fine if they do not.
+        </li>
+        <li>
+          <strong>Deprecated</strong> — Was on the legacy list; we no longer recommend it.
+        </li>
+      </ul>
+
+      {categories.map((category) => (
+        <section key={category.id} id={category.id}>
+          <h2>{category.label}</h2>
+          <p>{category.blurb}</p>
+          {category.tools.map((tool) => (
+            <section key={tool.id} id={tool.id}>
+              <h3>
+                {tool.name} <em>({tool.ffcStance})</em>
+              </h3>
+              <p>
+                <strong>Cost:</strong> {tool.cost}
+              </p>
+              <p>{tool.description}</p>
+              <p>
+                <strong>Modern notes:</strong> {tool.modernNotes}
+              </p>
+            </section>
+          ))}
+        </section>
+      ))}
+
+      <h2>Cross-references</h2>
+      <ul>
+        <li>
+          <a href="/legacy-wordpress-administration/wordpress-online-impacts-onboarding/">
+            wordpress-online-impacts-onboarding
+          </a>{' '}
+          — the external-validation account checklist.
+        </li>
+        <li>
+          <a href="/legacy-wordpress-administration/wordpress-guidestar-guide/">
+            wordpress-guidestar-guide
+          </a>{' '}
+          — Candid is the most-required tool on this list.
+        </li>
+        <li>
+          <a href="/training-plan">/training-plan</a> — the FFC volunteer-side toolkit alignment.
+        </li>
+      </ul>
     </LeafPageShell>
   )
 }

--- a/src/app/legacy-wordpress-administration/wordpress-tools-for-success/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-tools-for-success/page.tsx
@@ -3,7 +3,7 @@ import LeafPageShell from '@/components/legacy-wordpress-administration/LeafPage
 import { getLegacyWpAdminPageBySlug } from '@/data/legacy-wordpress-administration'
 
 const SLUG = 'wordpress-tools-for-success'
-const page = getLegacyWpAdminPageBySlug(SLUG)!
+const page = getLegacyWpAdminPageBySlug(SLUG)
 
 export const metadata: Metadata = {
   title: page.title,

--- a/src/app/legacy-wordpress-administration/wordpress-tools-for-success/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-tools-for-success/page.tsx
@@ -1,0 +1,33 @@
+import type { Metadata } from 'next'
+import LeafPageShell from '@/components/legacy-wordpress-administration/LeafPageShell'
+import { getLegacyWpAdminPageBySlug } from '@/data/legacy-wordpress-administration'
+
+const SLUG = 'wordpress-tools-for-success'
+const page = getLegacyWpAdminPageBySlug(SLUG)!
+
+export const metadata: Metadata = {
+  title: page.title,
+  description: page.summary,
+  alternates: {
+    canonical: `https://ffcadmin.org/legacy-wordpress-administration/${SLUG}/`,
+  },
+}
+
+export default function Page() {
+  return (
+    <LeafPageShell page={page}>
+      <p>
+        <strong>Content migration in progress.</strong> This page is the ffcadmin.org
+        operations-team copy of{' '}
+        <a href={page.publicSourceUrl} target="_blank" rel="noopener noreferrer">
+          {page.publicSourceUrl}
+        </a>
+        . Body content is being migrated from the legacy WordPress source as part of issue #241.
+      </p>
+      <p>
+        Until the migration lands, see the public version on freeforcharity.org for the current
+        content.
+      </p>
+    </LeafPageShell>
+  )
+}

--- a/src/app/legacy-wordpress-administration/wordpress-training-programs/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-training-programs/page.tsx
@@ -1,0 +1,33 @@
+import type { Metadata } from 'next'
+import LeafPageShell from '@/components/legacy-wordpress-administration/LeafPageShell'
+import { getLegacyWpAdminPageBySlug } from '@/data/legacy-wordpress-administration'
+
+const SLUG = 'wordpress-training-programs'
+const page = getLegacyWpAdminPageBySlug(SLUG)!
+
+export const metadata: Metadata = {
+  title: page.title,
+  description: page.summary,
+  alternates: {
+    canonical: `https://ffcadmin.org/legacy-wordpress-administration/${SLUG}/`,
+  },
+}
+
+export default function Page() {
+  return (
+    <LeafPageShell page={page}>
+      <p>
+        <strong>Content migration in progress.</strong> This page is the ffcadmin.org
+        operations-team copy of{' '}
+        <a href={page.publicSourceUrl} target="_blank" rel="noopener noreferrer">
+          {page.publicSourceUrl}
+        </a>
+        . Body content is being migrated from the legacy WordPress source as part of issue #241.
+      </p>
+      <p>
+        Until the migration lands, see the public version on freeforcharity.org for the current
+        content.
+      </p>
+    </LeafPageShell>
+  )
+}

--- a/src/app/legacy-wordpress-administration/wordpress-training-programs/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-training-programs/page.tsx
@@ -53,7 +53,7 @@ const programs: Program[] = [
     name: 'Web Developers',
     level: 'Entry to high-level',
     description:
-      'Build and ship charity sites. The legacy curriculum centred on PHP and Divi; the modern curriculum centres on Next.js, GitHub Pages, and Cloudflare.',
+      'Build and ship charity sites. The legacy curriculum centered on PHP and Divi; the modern curriculum centers on Next.js, GitHub Pages, and Cloudflare.',
     salaryRange: '~$69,781 annually (full-time positions)',
     intakeNotes:
       'Volunteers entering through this track today should be routed to the Web Developer training guide and the WordPress-to-Next.js conversion guide.',
@@ -68,7 +68,7 @@ export default function Page() {
   return (
     <LeafPageShell page={page}>
       <p>
-        FFC&apos;s legacy training catalogue defined three volunteer tracks — Researchers, Business
+        FFC&apos;s legacy training catalog defined three volunteer tracks — Researchers, Business
         Analysts, and Web Developers — built around a &ldquo;win-win-win&rdquo; model: volunteers
         gain portfolio-grade skills, partner charities receive needed work at no cost, and FFC
         builds sector capacity.
@@ -136,7 +136,7 @@ export default function Page() {
       <h3>Eligibility?</h3>
       <p>
         Two requirements: motivation to learn and commitment to ship work that actually helps a
-        charity. Selection prioritises candidates who show up consistently to the weekly stand-ups
+        charity. Selection prioritizes candidates who show up consistently to the weekly stand-ups
         and finish their first project before chasing the next one.
       </p>
 
@@ -144,7 +144,7 @@ export default function Page() {
       <p>
         The modern FFC volunteer pipeline starts at <a href="/get-involved">/get-involved</a>,
         splits into the Global Administrator and Canva Designer paths, and progresses through the{' '}
-        <a href="/contributor-ladder">contributor ladder</a>. The legacy three-track catalogue feeds
+        <a href="/contributor-ladder">contributor ladder</a>. The legacy three-track catalog feeds
         into those paths but is no longer the primary intake.
       </p>
     </LeafPageShell>

--- a/src/app/legacy-wordpress-administration/wordpress-training-programs/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-training-programs/page.tsx
@@ -3,7 +3,7 @@ import LeafPageShell from '@/components/legacy-wordpress-administration/LeafPage
 import { getLegacyWpAdminPageBySlug } from '@/data/legacy-wordpress-administration'
 
 const SLUG = 'wordpress-training-programs'
-const page = getLegacyWpAdminPageBySlug(SLUG)!
+const page = getLegacyWpAdminPageBySlug(SLUG)
 
 export const metadata: Metadata = {
   title: page.title,

--- a/src/app/legacy-wordpress-administration/wordpress-training-programs/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-training-programs/page.tsx
@@ -11,22 +11,141 @@ export const metadata: Metadata = {
   alternates: {
     canonical: `https://ffcadmin.org/legacy-wordpress-administration/${SLUG}/`,
   },
+  keywords:
+    'FFC training programs, volunteer pipeline, researcher, business analyst, web developer, nonprofit skills',
 }
+
+interface Program {
+  id: string
+  name: string
+  level: string
+  description: string
+  salaryRange: string
+  intakeNotes: string
+  modernEquivalent: { label: string; href: string } | null
+}
+
+const programs: Program[] = [
+  {
+    id: 'researchers',
+    name: 'Researchers',
+    level: 'Entry to mid-level',
+    description:
+      'Move beyond casual web searches to professional data-collection and research methodology. Output feeds the FFC service / technology / consultant directories on freeforcharity.org.',
+    salaryRange: '$24,000 – $52,000 (average $31,000)',
+    intakeNotes:
+      'Lowest barrier to entry of the three legacy tracks. Today this work is covered by the Global Admin path and a research-flavoured contributor ladder rung.',
+    modernEquivalent: { label: 'Contributor ladder', href: '/contributor-ladder' },
+  },
+  {
+    id: 'business-analysts',
+    name: 'Business Analysts',
+    level: 'Entry to high-level',
+    description:
+      'Translate research into recommendations — pick the right tool for the charity, the right plan tier, the right vendor. Closest legacy analogue to product management.',
+    salaryRange: '~$52,898 annually',
+    intakeNotes:
+      'Required Excel, Word, and PowerPoint then. Required equivalent in Google Workspace / Microsoft 365 now. Modern FFC absorbs this into the Global Admin training plan.',
+    modernEquivalent: { label: 'Training plan', href: '/training-plan' },
+  },
+  {
+    id: 'web-developers',
+    name: 'Web Developers',
+    level: 'Entry to high-level',
+    description:
+      'Build and ship charity sites. The legacy curriculum centred on PHP and Divi; the modern curriculum centres on Next.js, GitHub Pages, and Cloudflare.',
+    salaryRange: '~$69,781 annually (full-time positions)',
+    intakeNotes:
+      'Volunteers entering through this track today should be routed to the Web Developer training guide and the WordPress-to-Next.js conversion guide.',
+    modernEquivalent: {
+      label: 'Web developer training (WordPress era)',
+      href: '/legacy-wordpress-administration/wordpress-web-developer-training',
+    },
+  },
+]
 
 export default function Page() {
   return (
     <LeafPageShell page={page}>
       <p>
-        <strong>Content migration in progress.</strong> This page is the ffcadmin.org
-        operations-team copy of{' '}
-        <a href={page.publicSourceUrl} target="_blank" rel="noopener noreferrer">
-          {page.publicSourceUrl}
-        </a>
-        . Body content is being migrated from the legacy WordPress source as part of issue #241.
+        FFC&apos;s legacy training catalogue defined three volunteer tracks — Researchers, Business
+        Analysts, and Web Developers — built around a &ldquo;win-win-win&rdquo; model: volunteers
+        gain portfolio-grade skills, partner charities receive needed work at no cost, and FFC
+        builds sector capacity.
       </p>
+
       <p>
-        Until the migration lands, see the public version on freeforcharity.org for the current
-        content.
+        The charity-facing version of this page lives at{' '}
+        <a href={page.publicSourceUrl} target="_blank" rel="noopener noreferrer">
+          freeforcharity.org/free-training-programs/
+        </a>{' '}
+        and is targeted at prospective volunteers. This page is the operations-team view: what the
+        legacy tracks were, what their modern equivalents are, and where to send incoming volunteers
+        today.
+      </p>
+
+      <h2>How to use this page</h2>
+      <p>
+        If a new volunteer asks &ldquo;which track should I follow,&rdquo; route them to the modern
+        equivalent in the table below. The legacy track descriptions remain useful for framing the
+        salary outcomes and the win-win-win pitch — those numbers come from US Bureau of Labor
+        Statistics data and still hold up.
+      </p>
+
+      <h2>The three legacy tracks</h2>
+
+      {programs.map((program) => (
+        <section key={program.id} id={program.id}>
+          <h3>{program.name}</h3>
+          <p>
+            <strong>Level:</strong> {program.level}
+          </p>
+          <p>
+            <strong>What the track did:</strong> {program.description}
+          </p>
+          <p>
+            <strong>Reference salary range:</strong> {program.salaryRange}
+          </p>
+          <p>
+            <strong>Intake notes:</strong> {program.intakeNotes}
+          </p>
+          {program.modernEquivalent && (
+            <p>
+              <strong>Modern equivalent:</strong>{' '}
+              <a href={program.modernEquivalent.href}>{program.modernEquivalent.label}</a>
+            </p>
+          )}
+        </section>
+      ))}
+
+      <h2>FAQ — legacy answers, modern context</h2>
+
+      <h3>Will employers value the experience?</h3>
+      <p>
+        Yes — every FFC engagement produces a shipped artefact (site, directory entry, audit
+        report). Volunteers leave with public links to point at, not just certificate PDFs. That has
+        been the consistent feedback from hiring managers since the legacy tracks launched.
+      </p>
+
+      <h3>Does it cost anything?</h3>
+      <p>
+        No. FFC operates on a donation-supported model. Successful charity engagements generate
+        sponsorships that fund the next intake cohort.
+      </p>
+
+      <h3>Eligibility?</h3>
+      <p>
+        Two requirements: motivation to learn and commitment to ship work that actually helps a
+        charity. Selection prioritises candidates who show up consistently to the weekly stand-ups
+        and finish their first project before chasing the next one.
+      </p>
+
+      <h2>Where to point volunteers today</h2>
+      <p>
+        The modern FFC volunteer pipeline starts at <a href="/get-involved">/get-involved</a>,
+        splits into the Global Administrator and Canva Designer paths, and progresses through the{' '}
+        <a href="/contributor-ladder">contributor ladder</a>. The legacy three-track catalogue feeds
+        into those paths but is no longer the primary intake.
       </p>
     </LeafPageShell>
   )

--- a/src/app/legacy-wordpress-administration/wordpress-volunteer-proving-ground/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-volunteer-proving-ground/page.tsx
@@ -1,0 +1,33 @@
+import type { Metadata } from 'next'
+import LeafPageShell from '@/components/legacy-wordpress-administration/LeafPageShell'
+import { getLegacyWpAdminPageBySlug } from '@/data/legacy-wordpress-administration'
+
+const SLUG = 'wordpress-volunteer-proving-ground'
+const page = getLegacyWpAdminPageBySlug(SLUG)!
+
+export const metadata: Metadata = {
+  title: page.title,
+  description: page.summary,
+  alternates: {
+    canonical: `https://ffcadmin.org/legacy-wordpress-administration/${SLUG}/`,
+  },
+}
+
+export default function Page() {
+  return (
+    <LeafPageShell page={page}>
+      <p>
+        <strong>Content migration in progress.</strong> This page is the ffcadmin.org
+        operations-team copy of{' '}
+        <a href={page.publicSourceUrl} target="_blank" rel="noopener noreferrer">
+          {page.publicSourceUrl}
+        </a>
+        . Body content is being migrated from the legacy WordPress source as part of issue #241.
+      </p>
+      <p>
+        Until the migration lands, see the public version on freeforcharity.org for the current
+        content.
+      </p>
+    </LeafPageShell>
+  )
+}

--- a/src/app/legacy-wordpress-administration/wordpress-volunteer-proving-ground/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-volunteer-proving-ground/page.tsx
@@ -3,7 +3,7 @@ import LeafPageShell from '@/components/legacy-wordpress-administration/LeafPage
 import { getLegacyWpAdminPageBySlug } from '@/data/legacy-wordpress-administration'
 
 const SLUG = 'wordpress-volunteer-proving-ground'
-const page = getLegacyWpAdminPageBySlug(SLUG)!
+const page = getLegacyWpAdminPageBySlug(SLUG)
 
 export const metadata: Metadata = {
   title: page.title,

--- a/src/app/legacy-wordpress-administration/wordpress-volunteer-proving-ground/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-volunteer-proving-ground/page.tsx
@@ -11,23 +11,255 @@ export const metadata: Metadata = {
   alternates: {
     canonical: `https://ffcadmin.org/legacy-wordpress-administration/${SLUG}/`,
   },
+  keywords:
+    'FFC volunteer proving ground, core competencies, LastPass, AI assistants, MS-900, MS-700, OneDrive, Planner, Microsoft 365',
 }
+
+interface Module {
+  id: string
+  index: number
+  name: string
+  duration: string
+  purpose: string
+  keyConcept: string
+  proficiencyTask: string
+  resources: string[]
+  modernNotes: string
+}
+
+const modules: Module[] = [
+  {
+    id: 'lastpass',
+    index: 1,
+    name: 'LastPass — Security Standard',
+    duration: '1-2 hours',
+    purpose: 'Establish secure password management as the foundation for all FFC system access.',
+    keyConcept:
+      'Volunteers handle nonprofit-client data. Protecting that data is the highest priority — never share credentials over email or text.',
+    proficiencyTask: 'Explain why sharing passwords through email or text poses security risks.',
+    resources: [
+      'LastPass 101 official video',
+      'LastPass User Training portal',
+      'LastPass Authenticator app (MFA requirement)',
+    ],
+    modernNotes:
+      'FFC is evaluating Bitwarden / 1Password Teams as the post-LastPass replacement. Either way, the password-hygiene competency stays the same.',
+  },
+  {
+    id: 'ai-assistants',
+    index: 2,
+    name: 'Introduction to AI Assistants',
+    duration: '2-4 hours',
+    purpose: 'Master generative AI tools as learning accelerators for every subsequent module.',
+    keyConcept:
+      'AI assistants enable self-directed learning — a critical volunteer skill since FFC cannot run synchronous training for every charity-side task.',
+    proficiencyTask:
+      'List four key elements of an effective AI prompt (context, role, constraints, output format).',
+    resources: [
+      'Microsoft Copilot tutorial',
+      'Google Gemini overview',
+      'Mobile app access for both platforms',
+    ],
+    modernNotes:
+      'Update: Claude and GPT-class models are now the FFC primary recommendation; Copilot / Gemini remain acceptable. Prompt-engineering principles unchanged.',
+  },
+  {
+    id: 'ms-900',
+    index: 3,
+    name: 'MS-900 — Microsoft 365 Fundamentals',
+    duration: '12-16 hours',
+    purpose: 'Foundational knowledge of M365 cloud services, apps, security, and compliance.',
+    keyConcept:
+      'FFC operational infrastructure is built on the Microsoft 365 platform. Every volunteer must understand the basics.',
+    proficiencyTask:
+      'Explain the primary difference between Microsoft 365 and Office 365 (subscription bundle vs. productivity-app suite).',
+    resources: [
+      'Microsoft Learn self-paced course',
+      'Official MS-900 study guide',
+      'Optional: certification exam funding available case-by-case',
+    ],
+    modernNotes:
+      'Required for the Global Admin training plan. See /training-plan for the full progression beyond MS-900.',
+  },
+  {
+    id: 'ms-700',
+    index: 4,
+    name: 'MS-700 — Teams Administration Fundamentals',
+    duration: '8-12 hours',
+    purpose: 'Microsoft Teams admin: teams, channels, governance, integrations.',
+    keyConcept:
+      'Teams is the central FFC collaboration hub. Volunteers must understand governance before getting admin rights.',
+    proficiencyTask:
+      'Differentiate between standard, private, and shared channels; provide a use case for each.',
+    resources: [
+      'Microsoft Teams Quick Start video training',
+      'MS-700 official learning path',
+      'MS-700 study guide',
+      'Optional: certification exam funding available case-by-case',
+    ],
+    modernNotes:
+      'Stage 2 of the Global Admin training plan. The exam itself is optional; the competency is mandatory.',
+  },
+  {
+    id: 'onedrive',
+    index: 5,
+    name: 'Microsoft OneDrive — Shared File System',
+    duration: '2 hours',
+    purpose: 'Document access, organization, and secure sharing within FFC systems.',
+    keyConcept:
+      'OneDrive is the FFC single source of truth for all official documents. No charity work in personal Drive / Dropbox.',
+    proficiencyTask:
+      'Describe the steps to share a file with "View Only" permissions, including link expiry and required-sign-in options.',
+    resources: [
+      'OneDrive video basics',
+      'OneDrive Quickstart Guide (PDF)',
+      'OneDrive Help & Learning Center',
+    ],
+    modernNotes:
+      'Pairs with SharePoint for the FFC team library. Volunteers join the shared library after completing this module.',
+  },
+  {
+    id: 'planner',
+    index: 6,
+    name: 'Microsoft Planner — Task Management in Teams',
+    duration: '2 hours',
+    purpose: 'Task creation, management, and tracking for individual + team projects.',
+    keyConcept:
+      'Planner provides clear visibility into project progress and integrates with Teams as a tab.',
+    proficiencyTask:
+      'Explain the difference between a Bucket and a Task; describe how each is used to organize a charity engagement.',
+    resources: ['Microsoft Planner video training', 'Planner integration guide for Teams'],
+    modernNotes:
+      'Project management for individual charity engagements. The FFC backlog itself is tracked in GitHub Issues / Projects.',
+  },
+  {
+    id: 'm365-apps',
+    index: 7,
+    name: 'Microsoft 365 Apps Quick Start',
+    duration: '6-8 hours',
+    purpose: 'Baseline proficiency in Word, Excel, and PowerPoint web applications.',
+    keyConcept:
+      'These apps are the universal standard for creating and sharing professional documents with partner charities.',
+    proficiencyTask:
+      'Explain how to share a document from any Microsoft 365 web app (Share button → permissions → link options).',
+    resources: ['Microsoft 365 Quick Starts official hub'],
+    modernNotes:
+      'Volunteers entering through the Canva Designer path follow a parallel competency in Canva Pro instead of PowerPoint.',
+  },
+]
+
+const totalHoursLow = modules.reduce((sum, m) => sum + parseInt(m.duration.split('-')[0], 10), 0)
+const totalHoursHigh = modules.reduce(
+  (sum, m) => sum + parseInt(m.duration.split('-')[1] ?? m.duration.split('-')[0], 10),
+  0
+)
 
 export default function Page() {
   return (
     <LeafPageShell page={page}>
       <p>
-        <strong>Content migration in progress.</strong> This page is the ffcadmin.org
-        operations-team copy of{' '}
-        <a href={page.publicSourceUrl} target="_blank" rel="noopener noreferrer">
-          {page.publicSourceUrl}
-        </a>
-        . Body content is being migrated from the legacy WordPress source as part of issue #241.
+        FFC volunteers complete seven proving-ground modules before getting admin access to
+        partner-charity systems. The program is{' '}
+        <strong>
+          {totalHoursLow}-{totalHoursHigh} hours total
+        </strong>{' '}
+        and emphasises mastery over speed — time estimates are learning guides, not deadlines.
       </p>
+
       <p>
-        Until the migration lands, see the public version on freeforcharity.org for the current
-        content.
+        Charity-facing version:{' '}
+        <a href={page.publicSourceUrl} target="_blank" rel="noopener noreferrer">
+          freeforcharity.org/ffc-volunteer-proving-ground-core-competencies/
+        </a>
+        .
       </p>
+
+      <h2>Why the proving ground exists</h2>
+      <p>
+        Rigorous training ensures only the most dedicated and capable individuals get access to FFC
+        internal systems and partner-charity data. Completing all seven modules demonstrates
+        commitment and prepares a volunteer for real-world impact.
+      </p>
+
+      <h2>The seven modules</h2>
+      <ol>
+        {modules.map((m) => (
+          <li key={m.id}>
+            <a href={`#${m.id}`}>
+              Module {m.index} — {m.name}
+            </a>{' '}
+            ({m.duration})
+          </li>
+        ))}
+      </ol>
+
+      {modules.map((module) => (
+        <section key={module.id} id={module.id}>
+          <h3>
+            Module {module.index} &mdash; {module.name}
+          </h3>
+          <p>
+            <strong>Duration:</strong> {module.duration}
+          </p>
+          <p>
+            <strong>Purpose:</strong> {module.purpose}
+          </p>
+          <p>
+            <strong>Key concept:</strong> {module.keyConcept}
+          </p>
+          <p>
+            <strong>Proficiency task:</strong> {module.proficiencyTask}
+          </p>
+          <p>
+            <strong>Resources:</strong>
+          </p>
+          <ul>
+            {module.resources.map((r) => (
+              <li key={r}>{r}</li>
+            ))}
+          </ul>
+          <p>
+            <strong>Modern notes:</strong> {module.modernNotes}
+          </p>
+        </section>
+      ))}
+
+      <h2>What comes after</h2>
+      <p>
+        Volunteers who complete the proving ground graduate into the{' '}
+        <a href="/contributor-ladder">contributor ladder</a> and pick one of the two modern training
+        paths:
+      </p>
+      <ul>
+        <li>
+          <a href="/training-plan">Global Administrator</a> — Microsoft 365 + GitHub + DNS
+          administration.
+        </li>
+        <li>
+          <a href="/canva-designer-path">Canva Designer</a> — brand identities + marketing materials
+          for charities.
+        </li>
+      </ul>
+
+      <h2>Cross-references</h2>
+      <ul>
+        <li>
+          <a href="/legacy-wordpress-administration/wordpress-training-programs/">
+            wordpress-training-programs
+          </a>{' '}
+          — the broader catalog this proving ground sits inside.
+        </li>
+        <li>
+          <a href="/legacy-wordpress-administration/wordpress-web-developer-training/">
+            wordpress-web-developer-training
+          </a>{' '}
+          — the developer-specific platform tour that follows the proving ground.
+        </li>
+        <li>
+          <a href="/contributor-ladder">/contributor-ladder</a> — modern progression path beyond the
+          proving ground.
+        </li>
+      </ul>
     </LeafPageShell>
   )
 }

--- a/src/app/legacy-wordpress-administration/wordpress-volunteer-proving-ground/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-volunteer-proving-ground/page.tsx
@@ -163,7 +163,7 @@ export default function Page() {
         <strong>
           {totalHoursLow}-{totalHoursHigh} hours total
         </strong>{' '}
-        and emphasises mastery over speed — time estimates are learning guides, not deadlines.
+        and emphasizes mastery over speed — time estimates are learning guides, not deadlines.
       </p>
 
       <p>

--- a/src/app/legacy-wordpress-administration/wordpress-web-developer-training/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-web-developer-training/page.tsx
@@ -1,0 +1,33 @@
+import type { Metadata } from 'next'
+import LeafPageShell from '@/components/legacy-wordpress-administration/LeafPageShell'
+import { getLegacyWpAdminPageBySlug } from '@/data/legacy-wordpress-administration'
+
+const SLUG = 'wordpress-web-developer-training'
+const page = getLegacyWpAdminPageBySlug(SLUG)!
+
+export const metadata: Metadata = {
+  title: page.title,
+  description: page.summary,
+  alternates: {
+    canonical: `https://ffcadmin.org/legacy-wordpress-administration/${SLUG}/`,
+  },
+}
+
+export default function Page() {
+  return (
+    <LeafPageShell page={page}>
+      <p>
+        <strong>Content migration in progress.</strong> This page is the ffcadmin.org
+        operations-team copy of{' '}
+        <a href={page.publicSourceUrl} target="_blank" rel="noopener noreferrer">
+          {page.publicSourceUrl}
+        </a>
+        . Body content is being migrated from the legacy WordPress source as part of issue #241.
+      </p>
+      <p>
+        Until the migration lands, see the public version on freeforcharity.org for the current
+        content.
+      </p>
+    </LeafPageShell>
+  )
+}

--- a/src/app/legacy-wordpress-administration/wordpress-web-developer-training/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-web-developer-training/page.tsx
@@ -11,23 +11,233 @@ export const metadata: Metadata = {
   alternates: {
     canonical: `https://ffcadmin.org/legacy-wordpress-administration/${SLUG}/`,
   },
+  keywords:
+    'FFC web developer training, WHMCS, Cloudflare DNS, Microsoft 365, InterServer, Divi, WPMUDEV, Clarity, Tawk.to, Azure AI',
 }
+
+interface PlatformModule {
+  id: string
+  index: number
+  name: string
+  purpose: string
+  setupNotes: string
+  commonChallenges: string[]
+  modernReplacement: string
+}
+
+const platformModules: PlatformModule[] = [
+  {
+    id: 'whmcs-hub',
+    index: 1,
+    name: 'FFC Hub (WHMCS)',
+    purpose:
+      'Central operations: domain orders, client records, support tickets, billing — all live in WHMCS.',
+    setupNotes:
+      'Primary contact email must be on an external domain (Outlook) rather than the charity domain. Minimum two contacts per charity for account redundancy. Domain purchases route through the charity-domain mailbox with the coupon code from onboarding confirmation.',
+    commonChallenges: [
+      'Incomplete onboarding prevents product additions; resolve through a guided screen-share with the charity.',
+      'Fraud-flagged orders require verification of US location and matching card/address details — escalate if the charity is legitimate.',
+      'Domain transfers fail due to incorrect EPP codes or active privacy settings (especially GoDaddy domains). See wordpress-domains for the transfer-in gotcha list.',
+    ],
+    modernReplacement:
+      'Still in active use; no modern replacement planned. The charity-side billing flow has not migrated.',
+  },
+  {
+    id: 'cloudflare',
+    index: 2,
+    name: 'Cloudflare (DNS & Email)',
+    purpose:
+      'DNS authority, SSL provisioning, security rulesets, and email routing infrastructure.',
+    setupNotes:
+      'Update charity nameservers to FFC Cloudflare servers (ns1.freeforcharity.org / ns2.freeforcharity.org). Configure DMARC for email security. Hook M365 connectivity through Cloudflare automated record insertion using the M365 admin credentials.',
+    commonChallenges: [
+      'Nameserver propagation can take 24 hours — do not panic if Cloudflare verification is not immediate.',
+      'DMARC misconfiguration is the most common cause of email deliverability complaints. Use the M365 connector tool to generate records rather than hand-writing them.',
+    ],
+    modernReplacement:
+      'Still the default DNS and edge layer for both WordPress sites and the Next.js static replacements. No replacement planned.',
+  },
+  {
+    id: 'm365',
+    index: 3,
+    name: 'Microsoft 365 Email Hosting',
+    purpose:
+      'Mailbox, calendar, Teams, and the productivity suite the charity actually uses day-to-day.',
+    setupNotes:
+      'Apply through the Microsoft Nonprofits program after the charity provides their Candid profile. After approval, configure accounts inside the M365 admin portal using the charity domain.',
+    commonChallenges: [
+      'Nonprofit validation rejection — re-submit with the charity Candid Public Profile link.',
+      'Tenant naming collision if the charity used the same domain previously — open a Microsoft support case to release the old tenant.',
+    ],
+    modernReplacement:
+      'Still in active use. M365 administration is one of the two Global Admin training tracks (see /training-plan).',
+  },
+  {
+    id: 'interserver',
+    index: 4,
+    name: 'InterServer / Hostinger Web Hosting',
+    purpose: 'Origin host running WordPress for the charity site.',
+    setupNotes:
+      'See wordpress-web-hosting for the per-host provisioning steps. Newer onboardings default to Hostinger; legacy sites stay on InterServer.',
+    commonChallenges: [
+      'Application denial — escalate to FFC founder for tech-sponsor letter.',
+      'PHP version drift breaking Divi — roll back to previous PHP minor and open a Divi ticket.',
+    ],
+    modernReplacement:
+      'Replaced by GitHub Pages + Cloudflare for new sites. See /guides/wordpress-to-nextjs-guide.',
+  },
+  {
+    id: 'divi',
+    index: 5,
+    name: 'Divi WordPress Theme',
+    purpose: 'Page builder + theme for charity WordPress sites. Charities author content here.',
+    setupNotes:
+      'Activate the Divi parent theme, install the FFC child layout, set theme options to match the charity brand colours. Clear the Static CSS cache before any export.',
+    commonChallenges: [
+      'Divi cached CSS interfering with Simply Static exports — clear cache via Divi > Theme Options > Builder > Advanced > Static CSS before exporting.',
+      'Visual builder broken on PHP 8.x minors — see Divi changelog for compatible version.',
+    ],
+    modernReplacement:
+      'Replaced by Tailwind v4 + React components in the Next.js stack. Divi is not used in new builds.',
+  },
+  {
+    id: 'wpmudev',
+    index: 6,
+    name: 'WPMUDEV Plugin Suite',
+    purpose:
+      'Performance (Hummingbird, Smush), security (Defender), forms (Forminator), backups (Snapshot), white-labelling (Branda).',
+    setupNotes:
+      'Install the WPMUDEV Dashboard plugin first, log in with the FFC WPMUDEV account, then add the per-charity bundle from the Hub.',
+    commonChallenges: [
+      'Plugin tokens trigger GitHub push-protection during Simply Static exports — see docs/ffc-simply-static-config.md for the export-time allowlist.',
+      'Snapshot Pro silent failures — check the Hub red badge weekly.',
+    ],
+    modernReplacement:
+      'Not needed in the Next.js stack — static export plus GitHub Pages eliminates the security / performance / backup plugin tier entirely.',
+  },
+  {
+    id: 'clarity',
+    index: 7,
+    name: 'Microsoft Clarity',
+    purpose: 'Heatmaps, session recordings, and user-behaviour analytics on the live charity site.',
+    setupNotes:
+      'Install via the Clarity WordPress plugin or paste the snippet into the Divi integration field. Site is bound to one Clarity project per charity.',
+    commonChallenges: [
+      'Project token ends up embedded in the HTML export, triggering GitHub push-protection — handle in docs/ffc-simply-static-config.md plugin exclusion list.',
+    ],
+    modernReplacement:
+      'Plug into the Next.js layout the same way — Clarity supports static sites natively.',
+  },
+  {
+    id: 'tawkto',
+    index: 8,
+    name: 'Tawk.to Live Chat',
+    purpose: 'Customer-support chat widget in the site footer.',
+    setupNotes:
+      'Install the Tawk.to plugin or paste the widget snippet. Add charity-side responders to the Tawk.to dashboard.',
+    commonChallenges: [
+      'Widget tokens are the #1 cause of GitHub push-protection failures during Simply Static exports — exclude the Tawk.to plugin from the export.',
+    ],
+    modernReplacement:
+      'Re-evaluate on a per-charity basis. Most charities adopted email + form-based contact instead post-migration.',
+  },
+  {
+    id: 'azure-ai',
+    index: 9,
+    name: 'Azure AI Language (Question Answering)',
+    purpose: 'Custom question-answering knowledge bases for charity chatbots.',
+    setupNotes:
+      'Optional integration; deploy through the Azure portal under the FFC tenant. Charity-specific knowledge base + Tawk.to integration.',
+    commonChallenges: [
+      'Cost spike if not rate-limited — set a daily budget alarm on the Azure subscription.',
+    ],
+    modernReplacement:
+      'Re-evaluating in favour of Claude / OpenAI APIs as cost-per-query drops. Not a current default.',
+  },
+]
 
 export default function Page() {
   return (
     <LeafPageShell page={page}>
       <p>
-        <strong>Content migration in progress.</strong> This page is the ffcadmin.org
-        operations-team copy of{' '}
-        <a href={page.publicSourceUrl} target="_blank" rel="noopener noreferrer">
-          {page.publicSourceUrl}
-        </a>
-        . Body content is being migrated from the legacy WordPress source as part of issue #241.
+        FFC web developers operate nine vendor platforms in series to deliver a charity WordPress
+        site end-to-end. This guide is the operations-team reference: what each platform does, how
+        to set it up, the recurring failure modes, and the modern replacement on the Next.js stack
+        where applicable.
       </p>
+
       <p>
-        Until the migration lands, see the public version on freeforcharity.org for the current
-        content.
+        Charity-facing developer narrative:{' '}
+        <a href={page.publicSourceUrl} target="_blank" rel="noopener noreferrer">
+          freeforcharity.org/free-for-charity-ffc-web-developer-training-guide/
+        </a>
+        .
       </p>
+
+      <h2>How to use this guide</h2>
+      <p>
+        Read top-to-bottom for first-time admins; jump to a specific module when triaging an active
+        charity issue. Each module documents the setup, the recurring failure modes, and what FFC
+        does today on the Next.js stack instead.
+      </p>
+
+      <h2>Platform modules</h2>
+      {platformModules.map((module) => (
+        <section key={module.id} id={module.id}>
+          <h3>
+            {module.index}. {module.name}
+          </h3>
+          <p>
+            <strong>Purpose:</strong> {module.purpose}
+          </p>
+          <p>
+            <strong>Setup notes:</strong> {module.setupNotes}
+          </p>
+          <p>
+            <strong>Common challenges:</strong>
+          </p>
+          <ul>
+            {module.commonChallenges.map((c) => (
+              <li key={c}>{c}</li>
+            ))}
+          </ul>
+          <p>
+            <strong>Modern replacement:</strong> {module.modernReplacement}
+          </p>
+        </section>
+      ))}
+
+      <h2>Resource strategy</h2>
+      <p>
+        For any platform issue: official documentation first, vendor community / forum second,
+        YouTube / third-party guides third. Tools change faster than this page can be updated, so
+        always cross-check against the vendor docs before acting.
+      </p>
+
+      <h2>Cross-references</h2>
+      <ul>
+        <li>
+          <a href="/training-plan">/training-plan</a> — the modern Global Admin training plan this
+          developer guide partially pre-dates.
+        </li>
+        <li>
+          <a href="/legacy-wordpress-administration/wordpress-hosting-techstack/">
+            wordpress-hosting-techstack
+          </a>{' '}
+          — the layered model these platforms fit into.
+        </li>
+        <li>
+          <a href="/legacy-wordpress-administration/wordpress-volunteer-proving-ground/">
+            wordpress-volunteer-proving-ground
+          </a>{' '}
+          — the proving-ground checklist developers complete before getting admin access to charity
+          sites.
+        </li>
+        <li>
+          <a href="/guides/wordpress-to-nextjs-guide">WordPress-to-Next.js conversion guide</a> —
+          what to read next once you understand the WP stack.
+        </li>
+      </ul>
     </LeafPageShell>
   )
 }

--- a/src/app/legacy-wordpress-administration/wordpress-web-developer-training/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-web-developer-training/page.tsx
@@ -92,7 +92,7 @@ const platformModules: PlatformModule[] = [
     name: 'Divi WordPress Theme',
     purpose: 'Page builder + theme for charity WordPress sites. Charities author content here.',
     setupNotes:
-      'Activate the Divi parent theme, install the FFC child layout, set theme options to match the charity brand colours. Clear the Static CSS cache before any export.',
+      'Activate the Divi parent theme, install the FFC child layout, set theme options to match the charity brand colors. Clear the Static CSS cache before any export.',
     commonChallenges: [
       'Divi cached CSS interfering with Simply Static exports — clear cache via Divi > Theme Options > Builder > Advanced > Static CSS before exporting.',
       'Visual builder broken on PHP 8.x minors — see Divi changelog for compatible version.',
@@ -119,7 +119,7 @@ const platformModules: PlatformModule[] = [
     id: 'clarity',
     index: 7,
     name: 'Microsoft Clarity',
-    purpose: 'Heatmaps, session recordings, and user-behaviour analytics on the live charity site.',
+    purpose: 'Heatmaps, session recordings, and user-behavior analytics on the live charity site.',
     setupNotes:
       'Install via the Clarity WordPress plugin or paste the snippet into the Divi integration field. Site is bound to one Clarity project per charity.',
     commonChallenges: [
@@ -152,7 +152,7 @@ const platformModules: PlatformModule[] = [
       'Cost spike if not rate-limited — set a daily budget alarm on the Azure subscription.',
     ],
     modernReplacement:
-      'Re-evaluating in favour of Claude / OpenAI APIs as cost-per-query drops. Not a current default.',
+      'Re-evaluating in favor of Claude / OpenAI APIs as cost-per-query drops. Not a current default.',
   },
 ]
 

--- a/src/app/legacy-wordpress-administration/wordpress-web-developer-training/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-web-developer-training/page.tsx
@@ -3,7 +3,7 @@ import LeafPageShell from '@/components/legacy-wordpress-administration/LeafPage
 import { getLegacyWpAdminPageBySlug } from '@/data/legacy-wordpress-administration'
 
 const SLUG = 'wordpress-web-developer-training'
-const page = getLegacyWpAdminPageBySlug(SLUG)!
+const page = getLegacyWpAdminPageBySlug(SLUG)
 
 export const metadata: Metadata = {
   title: page.title,

--- a/src/app/legacy-wordpress-administration/wordpress-web-hosting/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-web-hosting/page.tsx
@@ -1,0 +1,33 @@
+import type { Metadata } from 'next'
+import LeafPageShell from '@/components/legacy-wordpress-administration/LeafPageShell'
+import { getLegacyWpAdminPageBySlug } from '@/data/legacy-wordpress-administration'
+
+const SLUG = 'wordpress-web-hosting'
+const page = getLegacyWpAdminPageBySlug(SLUG)!
+
+export const metadata: Metadata = {
+  title: page.title,
+  description: page.summary,
+  alternates: {
+    canonical: `https://ffcadmin.org/legacy-wordpress-administration/${SLUG}/`,
+  },
+}
+
+export default function Page() {
+  return (
+    <LeafPageShell page={page}>
+      <p>
+        <strong>Content migration in progress.</strong> This page is the ffcadmin.org
+        operations-team copy of{' '}
+        <a href={page.publicSourceUrl} target="_blank" rel="noopener noreferrer">
+          {page.publicSourceUrl}
+        </a>
+        . Body content is being migrated from the legacy WordPress source as part of issue #241.
+      </p>
+      <p>
+        Until the migration lands, see the public version on freeforcharity.org for the current
+        content.
+      </p>
+    </LeafPageShell>
+  )
+}

--- a/src/app/legacy-wordpress-administration/wordpress-web-hosting/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-web-hosting/page.tsx
@@ -3,7 +3,7 @@ import LeafPageShell from '@/components/legacy-wordpress-administration/LeafPage
 import { getLegacyWpAdminPageBySlug } from '@/data/legacy-wordpress-administration'
 
 const SLUG = 'wordpress-web-hosting'
-const page = getLegacyWpAdminPageBySlug(SLUG)!
+const page = getLegacyWpAdminPageBySlug(SLUG)
 
 export const metadata: Metadata = {
   title: page.title,

--- a/src/app/legacy-wordpress-administration/wordpress-web-hosting/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-web-hosting/page.tsx
@@ -11,23 +11,187 @@ export const metadata: Metadata = {
   alternates: {
     canonical: `https://ffcadmin.org/legacy-wordpress-administration/${SLUG}/`,
   },
+  keywords:
+    'FFC web hosting, free charity hosting, InterServer nonprofit, Hostinger nonprofit, WordPress hosting, FFC operations',
 }
+
+interface Host {
+  id: string
+  name: string
+  panel: string
+  ipPattern: string
+  status: 'legacy' | 'current'
+  notes: string
+}
+
+const hosts: Host[] = [
+  {
+    id: 'interserver-da',
+    name: 'InterServer DirectAdmin',
+    panel: 'DirectAdmin',
+    ipPattern: '192.64.86.202 (shared)',
+    status: 'legacy',
+    notes:
+      'The original FFC origin host. Most charity sites pre-2024 live here. Nonprofit deal is brokered through sales@interserver.net with a copy of the IRS 501(c)(3) letter. Account creation requires the "Powered by InterServer" footer link within 30 days.',
+  },
+  {
+    id: 'interserver-rs1',
+    name: 'InterServer RS1 (managed)',
+    panel: 'DirectAdmin',
+    ipPattern: '216.158.234.18',
+    status: 'legacy',
+    notes:
+      'A handful of larger charity sites (e.g. legion-in-the-woods, technologymonastery) run on RS1 instead of the shared DA. Same nonprofit deal, same footer-link requirement.',
+  },
+  {
+    id: 'hostinger',
+    name: 'Hostinger hPanel',
+    panel: 'hPanel',
+    ipPattern: '153.92.213.212 (shared)',
+    status: 'current',
+    notes:
+      'Default host for new FFC WordPress onboardings since 2024. Nonprofit pricing applied via the Hostinger nonprofit program; footer link is "Powered by Hostinger".',
+  },
+  {
+    id: 'hostpapa',
+    name: 'HostPapa',
+    panel: 'cPanel',
+    ipPattern: '204.44.192.77',
+    status: 'legacy',
+    notes:
+      'Used for a small set of For-Profit + .com charity pairs. Not a default for new onboardings.',
+  },
+]
+
+const operationalProcedures = [
+  {
+    id: 'provisioning',
+    title: 'Provisioning a new hosting account',
+    steps: [
+      'Confirm the charity has cleared the wordpress-charity-validation gate.',
+      'Open a nonprofit account with the chosen host (Hostinger is current default) using the charity-domain mailbox.',
+      'Email host nonprofit support with the IRS letter + the registered domain.',
+      'FFC admin co-signs as tech sponsor.',
+      'Once approved, install WordPress via Softaculous / hPanel one-click installer.',
+      'Create the globaladmin@freeforcharity.org admin user on the new install.',
+      'Verify SSL provisioning, set Cloudflare DNS, run a baseline Lighthouse, save the result in the intake record.',
+    ],
+  },
+  {
+    id: 'monitoring',
+    title: 'Monitoring an existing hosting account',
+    steps: [
+      'WPMUDEV Hub dashboard surfaces uptime + Defender alerts. Check weekly.',
+      'Cloudflare zone analytics shows traffic anomalies (large 4xx spikes, sustained bot traffic).',
+      'Snapshot Pro reports red runs in the Hub; investigate before they chain.',
+      'For PHP version drift: hosts auto-upgrade minor versions; major upgrades (PHP 8.x → 8.y) require a manual smoke test on staging first.',
+    ],
+  },
+  {
+    id: 'migration-between-hosts',
+    title: 'Migrating between hosts',
+    steps: [
+      'Take a full backup on the source host (see wordpress-cpanel-backup-sop).',
+      'Spin up an empty WordPress install on the target host.',
+      'Restore the database + uploads onto the target install.',
+      'Update wp-config.php with new database credentials.',
+      'Run wp search-replace from the old hostname to the new (or the same hostname if just changing host IP).',
+      'Swap Cloudflare A record to the new origin IP only after smoke-test passes on staging.',
+      'Run Lighthouse on the new origin; investigate any > 10-point regression.',
+      'Decommission the source account 7 days after the swap (long enough to catch propagation issues, short enough that the charity is not billed twice).',
+    ],
+  },
+  {
+    id: 'static-migration',
+    title: 'Migrating off WordPress entirely',
+    steps: [
+      'Run a Simply Static export per docs/ffc-simply-static-config.md.',
+      'Convert the export into a Next.js / Tailwind site using the FFC_Single_Page_Template scaffold.',
+      'Cut DNS to GitHub Pages (185.199.108-111.153) once the static site is verified.',
+      'Keep the WordPress origin running for 30 days as a fallback (read-only).',
+      'Decommission the WP hosting account after the 30-day soak.',
+    ],
+  },
+]
 
 export default function Page() {
   return (
     <LeafPageShell page={page}>
       <p>
-        <strong>Content migration in progress.</strong> This page is the ffcadmin.org
-        operations-team copy of{' '}
-        <a href={page.publicSourceUrl} target="_blank" rel="noopener noreferrer">
-          {page.publicSourceUrl}
-        </a>
-        . Body content is being migrated from the legacy WordPress source as part of issue #241.
+        FFC operates WordPress hosting for partner charities across two active hosts (Hostinger,
+        InterServer) and two legacy hosts (HostPapa, older InterServer RS1 boxes). This page is the
+        operations-team reference for provisioning, monitoring, migrating, and eventually retiring
+        those accounts.
       </p>
+
       <p>
-        Until the migration lands, see the public version on freeforcharity.org for the current
-        content.
+        The charity-facing &ldquo;why free hosting&rdquo; pitch lives at{' '}
+        <a href={page.publicSourceUrl} target="_blank" rel="noopener noreferrer">
+          freeforcharity.org/free-charity-web-hosting/
+        </a>{' '}
+        — keep that page for prospective charity applicants. This page is for the FFC admin actually
+        running the hosting.
       </p>
+
+      <h2>Active hosts</h2>
+      {hosts.map((host) => (
+        <section key={host.id} id={host.id}>
+          <h3>
+            {host.name} {host.status === 'legacy' && <em>(legacy)</em>}
+            {host.status === 'current' && <em>(current default)</em>}
+          </h3>
+          <p>
+            <strong>Control panel:</strong> {host.panel}
+          </p>
+          <p>
+            <strong>Origin IP pattern:</strong> <code>{host.ipPattern}</code>
+          </p>
+          <p>{host.notes}</p>
+        </section>
+      ))}
+
+      <h2>Operational procedures</h2>
+      {operationalProcedures.map((proc) => (
+        <section key={proc.id} id={proc.id}>
+          <h3>{proc.title}</h3>
+          <ol>
+            {proc.steps.map((step) => (
+              <li key={step}>{step}</li>
+            ))}
+          </ol>
+        </section>
+      ))}
+
+      <h2>Source of truth for per-charity mapping</h2>
+      <p>
+        The full list of FFC-managed charity domains, the host each lives on, and the migration
+        status is at <a href="/sites-list">/sites-list</a> — refreshed automatically from{' '}
+        <code>docs/SITES_LIST.md</code> on every push to main.
+      </p>
+
+      <h2>Cross-references</h2>
+      <ul>
+        <li>
+          <a href="/legacy-wordpress-administration/wordpress-hosting-techstack/">
+            wordpress-hosting-techstack
+          </a>{' '}
+          — the layered model these hosts fit into.
+        </li>
+        <li>
+          <a href="/legacy-wordpress-administration/wordpress-cpanel-backup-sop/">
+            wordpress-cpanel-backup-sop
+          </a>{' '}
+          — what to run before risky host operations.
+        </li>
+        <li>
+          <a href="/legacy-wordpress-administration/wordpress-domains/">wordpress-domains</a> — DNS
+          and registrar side.
+        </li>
+        <li>
+          <a href="/guides/wordpress-to-nextjs-guide">WordPress-to-Next.js conversion guide</a> —
+          the modern destination for charity sites.
+        </li>
+      </ul>
     </LeafPageShell>
   )
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,6 +1,7 @@
 import type { MetadataRoute } from 'next'
 import { blogPosts } from '@/data/blog'
 import { guides } from '@/data/guides'
+import { LEGACY_WP_ADMIN_BASE, LEGACY_WP_ADMIN_PAGES } from '@/data/legacy-wordpress-administration'
 
 export const dynamic = 'force-static'
 
@@ -67,6 +68,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.7,
     },
     { url: `${SITE_URL}/guides/`, lastModified: now, changeFrequency: 'monthly', priority: 0.8 },
+    {
+      url: `${SITE_URL}${LEGACY_WP_ADMIN_BASE}/`,
+      lastModified: now,
+      changeFrequency: 'monthly',
+      priority: 0.7,
+    },
     { url: `${SITE_URL}/blog/`, lastModified: now, changeFrequency: 'weekly', priority: 0.8 },
     {
       url: `${SITE_URL}/privacy-policy/`,
@@ -98,5 +105,13 @@ export default function sitemap(): MetadataRoute.Sitemap {
     priority: 0.6,
   }))
 
-  return [...corePages, ...guidePages, ...blogPages]
+  // Legacy WordPress Administration leaf pages
+  const legacyWpAdminPages: MetadataRoute.Sitemap = LEGACY_WP_ADMIN_PAGES.map((page) => ({
+    url: `${SITE_URL}${LEGACY_WP_ADMIN_BASE}/${page.slug}/`,
+    lastModified: now,
+    changeFrequency: 'monthly' as const,
+    priority: 0.6,
+  }))
+
+  return [...corePages, ...guidePages, ...blogPages, ...legacyWpAdminPages]
 }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -240,46 +240,53 @@ export default function Footer() {
             </ul>
           </div>
 
-          {/* For Nonprofits */}
+          {/* For Charities & Donors (sister site) */}
           <div>
-            <h3 className="text-white text-lg font-bold mb-4">For Nonprofits</h3>
+            <h3 className="text-white text-lg font-bold mb-4">For Charities &amp; Donors</h3>
             <p className="text-sm text-gray-400 mb-3">
-              Looking for a free website for your 501(c)(3)?
+              Apply for a free site, donate, or read the public-facing FFC pages.
             </p>
             <ul className="space-y-2 text-sm">
               <li>
                 <a
-                  href="https://freeforcharity.org"
+                  href="https://freeforcharity.org/submit-information/"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="inline-flex items-center hover:text-white transition-colors"
                   style={{ color: 'var(--color-ffc-teal)' }}
                 >
-                  Apply at freeforcharity.org
-                  <svg
-                    className="w-3 h-3 ml-1"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                    aria-hidden="true"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
-                    />
-                  </svg>
+                  Apply for a free site →
                 </a>
               </li>
               <li>
                 <a
-                  href="https://freeforcharity.org/donate"
+                  href="https://freeforcharity.org/donate/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center hover:text-white transition-colors"
+                  style={{ color: 'var(--color-ffc-orange)' }}
+                >
+                  Donate →
+                </a>
+              </li>
+              <li>
+                <a
+                  href="https://freeforcharity.org/"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="text-gray-400 hover:text-white transition-colors"
                 >
-                  Support Our Mission
+                  freeforcharity.org home
+                </a>
+              </li>
+              <li>
+                <a
+                  href="https://freeforcharity.org/about-us/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-gray-400 hover:text-white transition-colors"
+                >
+                  About FFC
                 </a>
               </li>
             </ul>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -467,7 +467,7 @@ export default function Footer() {
               <a
                 href="https://freeforcharity.org"
                 target="_blank"
-                rel="noopener"
+                rel="noopener noreferrer"
                 className="hover:opacity-80 transition-opacity"
                 style={{ color: 'var(--color-ffc-teal)' }}
               >

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -225,6 +225,29 @@ export default function Navigation() {
             <Link href="/sites-list" className={`${linkClass('/sites-list')} whitespace-nowrap`}>
               Sites List
             </Link>
+
+            <a
+              href="https://freeforcharity.org/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-medium text-amber-700 hover:text-amber-900 inline-flex items-center whitespace-nowrap transition-colors"
+            >
+              For Charities &amp; Donors
+              <svg
+                className="ml-1 w-3 h-3"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
+                />
+              </svg>
+            </a>
           </div>
 
           {/* Mobile menu button */}
@@ -344,6 +367,16 @@ export default function Navigation() {
             >
               Sites List
             </Link>
+
+            <a
+              href="https://freeforcharity.org/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="block px-3 py-2 rounded-md text-amber-700 font-medium hover:bg-amber-50 transition-colors"
+              onClick={() => setIsMenuOpen(false)}
+            >
+              For Charities &amp; Donors ↗
+            </a>
           </div>
         )}
       </div>

--- a/src/components/SisterSiteBanner.tsx
+++ b/src/components/SisterSiteBanner.tsx
@@ -71,7 +71,7 @@ export default function SisterSiteBanner() {
         <button
           type="button"
           onClick={dismiss}
-          className="self-end sm:self-auto inline-flex items-center text-amber-900/80 hover:text-amber-900 text-xs px-2 py-1 rounded hover:bg-amber-100 transition-colors"
+          className="self-end sm:self-auto inline-flex items-center text-amber-900/80 hover:text-amber-900 text-xs px-2 py-1 rounded hover:bg-amber-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-600 focus-visible:ring-offset-2 focus-visible:ring-offset-amber-50"
           aria-label="Dismiss this notice"
         >
           Dismiss

--- a/src/components/SisterSiteBanner.tsx
+++ b/src/components/SisterSiteBanner.tsx
@@ -1,0 +1,96 @@
+'use client'
+
+import { useSyncExternalStore, useState } from 'react'
+
+const DISMISS_KEY = 'ffc-sister-site-banner-dismissed-v1'
+
+function subscribe(callback: () => void) {
+  if (typeof window === 'undefined') return () => {}
+  window.addEventListener('storage', callback)
+  return () => window.removeEventListener('storage', callback)
+}
+
+function getDismissedFromStorage(): boolean {
+  try {
+    return window.localStorage.getItem(DISMISS_KEY) === '1'
+  } catch {
+    // localStorage unavailable (private mode); show the banner so the
+    // wrong-audience signpost still reaches the visitor.
+    return false
+  }
+}
+
+/**
+ * Top-of-page banner that routes wrong-audience visitors (charities
+ * looking for a free site, donors looking to give) to freeforcharity.org.
+ *
+ * Dismissible — once dismissed, localStorage holds the choice across
+ * visits and across tabs (via the `storage` event). Rendered above
+ * Navigation in the root layout. Returns null during SSR so the page
+ * does not flash the banner before localStorage is read.
+ */
+export default function SisterSiteBanner() {
+  const dismissedFromStorage = useSyncExternalStore(
+    subscribe,
+    getDismissedFromStorage,
+    () => true // server snapshot — hide during SSR / static pre-render
+  )
+  const [locallyDismissed, setLocallyDismissed] = useState(false)
+  const isVisible = !dismissedFromStorage && !locallyDismissed
+
+  const dismiss = () => {
+    try {
+      window.localStorage.setItem(DISMISS_KEY, '1')
+    } catch {
+      // Ignored — dismissal will not persist across visits.
+    }
+    setLocallyDismissed(true)
+  }
+
+  if (!isVisible) return null
+
+  return (
+    <div
+      role="region"
+      aria-label="Sister site routing"
+      className="bg-amber-50 border-b border-amber-200 text-amber-900"
+    >
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-2.5 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 text-sm">
+        <p>
+          <strong>Looking for a free FFC site or want to donate?</strong> This site is for
+          volunteers and admins.{' '}
+          <a
+            href="https://freeforcharity.org/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-semibold underline hover:no-underline"
+          >
+            Visit freeforcharity.org →
+          </a>
+        </p>
+        <button
+          type="button"
+          onClick={dismiss}
+          className="self-end sm:self-auto inline-flex items-center text-amber-900/80 hover:text-amber-900 text-xs px-2 py-1 rounded hover:bg-amber-100 transition-colors"
+          aria-label="Dismiss this notice"
+        >
+          Dismiss
+          <svg
+            className="ml-1 w-3 h-3"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M6 18L18 6M6 6l12 12"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/SisterSiteBanner.tsx
+++ b/src/components/SisterSiteBanner.tsx
@@ -71,7 +71,7 @@ export default function SisterSiteBanner() {
         <button
           type="button"
           onClick={dismiss}
-          className="self-end sm:self-auto inline-flex items-center text-amber-900/80 hover:text-amber-900 text-xs px-2 py-1 rounded hover:bg-amber-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-600 focus-visible:ring-offset-2 focus-visible:ring-offset-amber-50"
+          className="self-end sm:self-auto inline-flex items-center text-amber-900/80 hover:text-amber-900 text-sm px-3 py-2 rounded hover:bg-amber-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-600 focus-visible:ring-offset-2 focus-visible:ring-offset-amber-50"
           aria-label="Dismiss this notice"
         >
           Dismiss

--- a/src/components/legacy-wordpress-administration/CategoryGrid.tsx
+++ b/src/components/legacy-wordpress-administration/CategoryGrid.tsx
@@ -1,0 +1,40 @@
+import Link from 'next/link'
+import {
+  LEGACY_WP_ADMIN_CATEGORIES,
+  getLegacyWpAdminHref,
+  getLegacyWpAdminPagesByCategory,
+} from '@/data/legacy-wordpress-administration'
+
+/**
+ * Hub-landing card grid grouped by category. Used only on the
+ * /legacy-wordpress-administration/ root page.
+ */
+export default function CategoryGrid() {
+  return (
+    <div className="space-y-12">
+      {LEGACY_WP_ADMIN_CATEGORIES.map((category) => {
+        const pages = getLegacyWpAdminPagesByCategory(category.id)
+        return (
+          <section key={category.id} id={category.id}>
+            <div className="mb-4">
+              <h2 className="text-2xl font-bold text-gray-900">{category.label}</h2>
+              <p className="text-gray-600 text-sm mt-1">{category.description}</p>
+            </div>
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+              {pages.map((page) => (
+                <Link
+                  key={page.slug}
+                  href={getLegacyWpAdminHref(page.slug)}
+                  className="block bg-white rounded-lg border border-gray-200 p-5 hover:border-blue-400 hover:shadow-md transition-all"
+                >
+                  <h3 className="text-base font-semibold text-gray-900 mb-2">{page.title}</h3>
+                  <p className="text-sm text-gray-600">{page.summary}</p>
+                </Link>
+              ))}
+            </div>
+          </section>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/components/legacy-wordpress-administration/CategoryGrid.tsx
+++ b/src/components/legacy-wordpress-administration/CategoryGrid.tsx
@@ -25,7 +25,7 @@ export default function CategoryGrid() {
                 <Link
                   key={page.slug}
                   href={getLegacyWpAdminHref(page.slug)}
-                  className="block bg-white rounded-lg border border-gray-200 p-5 hover:border-blue-400 hover:shadow-md transition-all"
+                  className="block bg-white rounded-lg border border-gray-200 p-5 hover:border-blue-400 hover:shadow-md transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
                 >
                   <h3 className="text-base font-semibold text-gray-900 mb-2">{page.title}</h3>
                   <p className="text-sm text-gray-600">{page.summary}</p>

--- a/src/components/legacy-wordpress-administration/LeafPageShell.tsx
+++ b/src/components/legacy-wordpress-administration/LeafPageShell.tsx
@@ -27,10 +27,16 @@ export default function LeafPageShell({ page, children }: LeafPageShellProps) {
       <PageHeader page={page} />
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10 grid grid-cols-1 lg:grid-cols-[16rem_minmax(0,1fr)] gap-10">
-        <aside className="lg:sticky lg:top-20 lg:self-start">
+        {/* Mobile: article reads first; desktop: sidebar in column 1, article in column 2. */}
+        <article className="prose prose-slate max-w-none lg:col-start-2 lg:row-start-1">
+          {children}
+        </article>
+        <aside
+          aria-label="Section navigation"
+          className="lg:col-start-1 lg:row-start-1 lg:sticky lg:top-20 lg:self-start"
+        >
           <Sidebar />
         </aside>
-        <article className="prose prose-slate max-w-none">{children}</article>
       </div>
 
       <section className="bg-white border-t border-gray-200">

--- a/src/components/legacy-wordpress-administration/LeafPageShell.tsx
+++ b/src/components/legacy-wordpress-administration/LeafPageShell.tsx
@@ -28,7 +28,8 @@ export default function LeafPageShell({ page, children }: LeafPageShellProps) {
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10 grid grid-cols-1 lg:grid-cols-[16rem_minmax(0,1fr)] gap-10">
         {/* Mobile: article reads first; desktop: sidebar in column 1, article in column 2. */}
-        <article className="prose prose-slate max-w-none lg:col-start-2 lg:row-start-1">
+        {/* Cap prose at 65ch on mobile/tablet for readability; let it fill the column on desktop. */}
+        <article className="prose prose-slate max-w-prose lg:max-w-none lg:col-start-2 lg:row-start-1">
           {children}
         </article>
         <aside

--- a/src/components/legacy-wordpress-administration/LeafPageShell.tsx
+++ b/src/components/legacy-wordpress-administration/LeafPageShell.tsx
@@ -34,7 +34,7 @@ export default function LeafPageShell({ page, children }: LeafPageShellProps) {
         </article>
         <aside
           aria-label="Section navigation"
-          className="lg:col-start-1 lg:row-start-1 lg:sticky lg:top-20 lg:self-start"
+          className="lg:col-start-1 lg:row-start-1 lg:sticky lg:top-20 lg:self-start lg:max-h-[calc(100vh-5rem)] lg:overflow-y-auto lg:border-r lg:border-gray-200 lg:pr-4"
         >
           <Sidebar />
         </aside>

--- a/src/components/legacy-wordpress-administration/LeafPageShell.tsx
+++ b/src/components/legacy-wordpress-administration/LeafPageShell.tsx
@@ -1,0 +1,58 @@
+import type { ReactNode } from 'react'
+import Link from 'next/link'
+import PageHeader from './PageHeader'
+import Sidebar from './Sidebar'
+import {
+  LEGACY_WP_ADMIN_BASE,
+  type LegacyWpAdminPage,
+} from '@/data/legacy-wordpress-administration'
+
+interface LeafPageShellProps {
+  page: LegacyWpAdminPage
+  children: ReactNode
+}
+
+/**
+ * Shared shell for every /legacy-wordpress-administration/<slug>/page.tsx:
+ *
+ *   <PageHeader />         full-width hero + audience callout
+ *   <Sidebar /> <article>  category-grouped left rail + page body
+ *   <BottomCtas />         hub / migration guide links
+ *
+ * Pages pass their migrated body content as children.
+ */
+export default function LeafPageShell({ page, children }: LeafPageShellProps) {
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <PageHeader page={page} />
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10 grid grid-cols-1 lg:grid-cols-[16rem_minmax(0,1fr)] gap-10">
+        <aside className="lg:sticky lg:top-20 lg:self-start">
+          <Sidebar />
+        </aside>
+        <article className="prose prose-slate max-w-none">{children}</article>
+      </div>
+
+      <section className="bg-white border-t border-gray-200">
+        <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-10 grid gap-4 sm:grid-cols-2 text-sm">
+          <Link
+            href={LEGACY_WP_ADMIN_BASE}
+            className="block rounded-lg border border-gray-200 p-4 hover:border-blue-400 hover:shadow-md transition-all"
+          >
+            <p className="font-semibold text-gray-900">← Back to section hub</p>
+            <p className="text-gray-600">
+              Browse all WordPress Operations, Charity Onboarding, and Volunteer Programs guides.
+            </p>
+          </Link>
+          <Link
+            href="/guides/wordpress-to-nextjs-guide"
+            className="block rounded-lg border border-gray-200 p-4 hover:border-blue-400 hover:shadow-md transition-all"
+          >
+            <p className="font-semibold text-gray-900">Ready to move off WordPress? →</p>
+            <p className="text-gray-600">Read the WordPress-to-Next.js conversion guide.</p>
+          </Link>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/components/legacy-wordpress-administration/PageHeader.tsx
+++ b/src/components/legacy-wordpress-administration/PageHeader.tsx
@@ -35,10 +35,12 @@ export default function PageHeader({ page }: PageHeaderProps) {
       <header className="bg-gradient-to-r from-slate-700 to-slate-900 text-white py-12 px-4 sm:px-6 lg:px-8">
         <div className="max-w-5xl mx-auto">
           {category && (
-            <p className="text-xs uppercase tracking-wider text-slate-300 mb-2">{category.label}</p>
+            <p className="text-xs uppercase tracking-wider text-slate-100 mb-2 font-semibold">
+              {category.label}
+            </p>
           )}
           <h1 className="text-3xl md:text-4xl font-bold mb-3">{page.title}</h1>
-          <p className="text-slate-200 text-lg max-w-3xl">{page.summary}</p>
+          <p className="text-slate-100 text-lg max-w-3xl">{page.summary}</p>
         </div>
       </header>
 

--- a/src/components/legacy-wordpress-administration/PageHeader.tsx
+++ b/src/components/legacy-wordpress-administration/PageHeader.tsx
@@ -1,0 +1,88 @@
+import Link from 'next/link'
+import Breadcrumbs from '@/components/Breadcrumbs'
+import {
+  LEGACY_WP_ADMIN_BASE,
+  LEGACY_WP_ADMIN_CATEGORIES,
+  type LegacyWpAdminPage,
+} from '@/data/legacy-wordpress-administration'
+
+interface PageHeaderProps {
+  page: LegacyWpAdminPage
+}
+
+/**
+ * Shared header for every /legacy-wordpress-administration/* page.
+ *
+ * Renders breadcrumbs (Home → Legacy WP Admin → Category → Page), the
+ * page title, the audience callout ("apply for a free site →
+ * freeforcharity.org"), and the public-version cross-link to the
+ * matching freeforcharity.org URL.
+ */
+export default function PageHeader({ page }: PageHeaderProps) {
+  const category = LEGACY_WP_ADMIN_CATEGORIES.find((c) => c.id === page.category)
+
+  return (
+    <>
+      <Breadcrumbs
+        items={[
+          { label: 'Home', href: '/' },
+          { label: 'Legacy WordPress Administration', href: LEGACY_WP_ADMIN_BASE },
+          ...(category ? [{ label: category.label }] : []),
+          { label: page.title },
+        ]}
+      />
+
+      <header className="bg-gradient-to-r from-slate-700 to-slate-900 text-white py-12 px-4 sm:px-6 lg:px-8">
+        <div className="max-w-5xl mx-auto">
+          {category && (
+            <p className="text-xs uppercase tracking-wider text-slate-300 mb-2">{category.label}</p>
+          )}
+          <h1 className="text-3xl md:text-4xl font-bold mb-3">{page.title}</h1>
+          <p className="text-slate-200 text-lg max-w-3xl">{page.summary}</p>
+        </div>
+      </header>
+
+      <aside
+        className="bg-blue-50 border-y border-blue-100"
+        aria-label="Section context and cross-links"
+      >
+        <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-4 grid gap-3 sm:grid-cols-2 text-sm">
+          <p className="text-blue-900">
+            <strong>Looking to apply for a free FFC site?</strong>{' '}
+            <a
+              href="https://freeforcharity.org/submit-information/"
+              className="underline hover:no-underline"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Apply at freeforcharity.org →
+            </a>
+          </p>
+          <p className="text-blue-900 sm:text-right">
+            <a
+              href={page.publicSourceUrl}
+              className="underline hover:no-underline"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Public version for charity visitors →
+            </a>
+          </p>
+        </div>
+        {page.relatedFfcAdminPaths && page.relatedFfcAdminPaths.length > 0 && (
+          <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 pb-4 text-sm text-blue-900">
+            Related on ffcadmin.org:{' '}
+            {page.relatedFfcAdminPaths.map((path, idx) => (
+              <span key={path}>
+                {idx > 0 && ', '}
+                <Link href={path} className="underline hover:no-underline">
+                  {path}
+                </Link>
+              </span>
+            ))}
+          </div>
+        )}
+      </aside>
+    </>
+  )
+}

--- a/src/components/legacy-wordpress-administration/Sidebar.tsx
+++ b/src/components/legacy-wordpress-administration/Sidebar.tsx
@@ -1,0 +1,72 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import {
+  LEGACY_WP_ADMIN_BASE,
+  LEGACY_WP_ADMIN_CATEGORIES,
+  getLegacyWpAdminHref,
+  getLegacyWpAdminPagesByCategory,
+} from '@/data/legacy-wordpress-administration'
+
+/**
+ * Category-grouped left-rail navigation shared by every page in
+ * /legacy-wordpress-administration/. Highlights the current leaf based
+ * on `usePathname()`.
+ *
+ * Styled as left rail on desktop (lg+); the layout collapses it into a
+ * top-of-page list on smaller screens by stacking the grid columns.
+ */
+export default function Sidebar() {
+  const pathname = usePathname() ?? ''
+
+  const isActive = (href: string) =>
+    pathname === href || pathname === `${href}/` || pathname.startsWith(`${href}/`)
+
+  return (
+    <nav aria-label="Legacy WordPress Administration" className="space-y-6 text-sm">
+      <Link
+        href={LEGACY_WP_ADMIN_BASE}
+        className={
+          isActive(LEGACY_WP_ADMIN_BASE) && pathname.replace(/\/$/, '') === LEGACY_WP_ADMIN_BASE
+            ? 'block font-bold text-blue-700'
+            : 'block font-semibold text-gray-700 hover:text-blue-700 transition-colors'
+        }
+      >
+        ← Section hub
+      </Link>
+
+      {LEGACY_WP_ADMIN_CATEGORIES.map((category) => {
+        const pages = getLegacyWpAdminPagesByCategory(category.id)
+        return (
+          <section key={category.id}>
+            <h2 className="text-xs uppercase tracking-wider text-gray-500 font-semibold mb-2">
+              {category.label}
+            </h2>
+            <ul className="space-y-1">
+              {pages.map((page) => {
+                const href = getLegacyWpAdminHref(page.slug)
+                const active = isActive(href)
+                return (
+                  <li key={page.slug}>
+                    <Link
+                      href={href}
+                      aria-current={active ? 'page' : undefined}
+                      className={
+                        active
+                          ? 'block px-2 py-1.5 rounded bg-blue-50 text-blue-700 font-semibold'
+                          : 'block px-2 py-1.5 rounded text-gray-700 hover:bg-gray-50 hover:text-blue-700 transition-colors'
+                      }
+                    >
+                      {page.shortLabel}
+                    </Link>
+                  </li>
+                )
+              })}
+            </ul>
+          </section>
+        )
+      })}
+    </nav>
+  )
+}

--- a/src/components/legacy-wordpress-administration/Sidebar.tsx
+++ b/src/components/legacy-wordpress-administration/Sidebar.tsx
@@ -31,8 +31,8 @@ export default function Sidebar() {
         aria-current={isOnHub ? 'page' : undefined}
         className={
           isOnHub
-            ? 'block font-bold text-blue-700'
-            : 'block font-semibold text-gray-700 hover:text-blue-700 transition-colors'
+            ? 'block font-bold text-blue-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 rounded'
+            : 'block font-semibold text-gray-700 hover:text-blue-700 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 rounded'
         }
       >
         ← Section hub
@@ -56,8 +56,8 @@ export default function Sidebar() {
                       aria-current={active ? 'page' : undefined}
                       className={
                         active
-                          ? 'block px-3 py-2.5 rounded bg-blue-50 text-blue-700 font-semibold'
-                          : 'block px-3 py-2.5 rounded text-gray-700 hover:bg-gray-50 hover:text-blue-700 transition-colors'
+                          ? 'block px-3 py-2.5 rounded bg-blue-50 text-blue-700 font-semibold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2'
+                          : 'block px-3 py-2.5 rounded text-gray-700 hover:bg-gray-50 hover:text-blue-700 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2'
                       }
                     >
                       {page.shortLabel}

--- a/src/components/legacy-wordpress-administration/Sidebar.tsx
+++ b/src/components/legacy-wordpress-administration/Sidebar.tsx
@@ -19,16 +19,18 @@ import {
  */
 export default function Sidebar() {
   const pathname = usePathname() ?? ''
+  const normalizedPath = pathname.replace(/\/$/, '')
 
-  const isActive = (href: string) =>
-    pathname === href || pathname === `${href}/` || pathname.startsWith(`${href}/`)
+  const isOnHub = normalizedPath === LEGACY_WP_ADMIN_BASE
+  const isLeafActive = (href: string) => normalizedPath === href
 
   return (
     <nav aria-label="Legacy WordPress Administration" className="space-y-6 text-sm">
       <Link
         href={LEGACY_WP_ADMIN_BASE}
+        aria-current={isOnHub ? 'page' : undefined}
         className={
-          isActive(LEGACY_WP_ADMIN_BASE) && pathname.replace(/\/$/, '') === LEGACY_WP_ADMIN_BASE
+          isOnHub
             ? 'block font-bold text-blue-700'
             : 'block font-semibold text-gray-700 hover:text-blue-700 transition-colors'
         }
@@ -46,7 +48,7 @@ export default function Sidebar() {
             <ul className="space-y-1">
               {pages.map((page) => {
                 const href = getLegacyWpAdminHref(page.slug)
-                const active = isActive(href)
+                const active = isLeafActive(href)
                 return (
                   <li key={page.slug}>
                     <Link

--- a/src/components/legacy-wordpress-administration/Sidebar.tsx
+++ b/src/components/legacy-wordpress-administration/Sidebar.tsx
@@ -56,8 +56,8 @@ export default function Sidebar() {
                       aria-current={active ? 'page' : undefined}
                       className={
                         active
-                          ? 'block px-2 py-1.5 rounded bg-blue-50 text-blue-700 font-semibold'
-                          : 'block px-2 py-1.5 rounded text-gray-700 hover:bg-gray-50 hover:text-blue-700 transition-colors'
+                          ? 'block px-3 py-2.5 rounded bg-blue-50 text-blue-700 font-semibold'
+                          : 'block px-3 py-2.5 rounded text-gray-700 hover:bg-gray-50 hover:text-blue-700 transition-colors'
                       }
                     >
                       {page.shortLabel}

--- a/src/data/legacy-wordpress-administration.ts
+++ b/src/data/legacy-wordpress-administration.ts
@@ -15,6 +15,19 @@
 
 export const LEGACY_WP_ADMIN_BASE = '/legacy-wordpress-administration'
 
+/**
+ * FFC founder escalation contact. Single source of truth so that role
+ * changes only need to land here. Avoid hardcoding in leaf page bodies.
+ */
+export const FFC_FOUNDER_CONTACT = {
+  name: 'Clarke Moyer',
+  role: 'FFC founder',
+  email: 'clarkemoyer@freeforcharity.org',
+  phone: '520-222-8104',
+  phoneHref: 'tel:5202228104',
+  escalationCadence: 'unresolved within 48 hours',
+} as const
+
 export type LegacyWpAdminCategoryId =
   | 'wordpress-operations'
   | 'charity-onboarding'
@@ -107,6 +120,15 @@ export const LEGACY_WP_ADMIN_PAGES: LegacyWpAdminPage[] = [
     publicSourceUrl: 'https://freeforcharity.org/online-impacts-onboarding-guide/',
   },
   {
+    slug: 'wordpress-service-delivery-stages',
+    title: 'FFC Service Delivery Stages',
+    shortLabel: 'Service Delivery Stages',
+    summary:
+      'The intake → validation → build → handoff lifecycle FFC follows for every charity engagement.',
+    category: 'charity-onboarding',
+    publicSourceUrl: 'https://freeforcharity.org/free-for-charity-ffc-service-delivery-stages/',
+  },
+  {
     slug: 'wordpress-charity-validation',
     title: 'Charity Validation Guide (WordPress era)',
     shortLabel: 'Charity Validation',
@@ -124,15 +146,6 @@ export const LEGACY_WP_ADMIN_PAGES: LegacyWpAdminPage[] = [
       'How FFC maintains Candid (GuideStar) profiles and the seal-of-transparency renewal cycle.',
     category: 'charity-onboarding',
     publicSourceUrl: 'https://freeforcharity.org/guidestar-guide/',
-  },
-  {
-    slug: 'wordpress-service-delivery-stages',
-    title: 'FFC Service Delivery Stages',
-    shortLabel: 'Service Delivery Stages',
-    summary:
-      'The intake → validation → build → handoff lifecycle FFC follows for every charity engagement.',
-    category: 'charity-onboarding',
-    publicSourceUrl: 'https://freeforcharity.org/free-for-charity-ffc-service-delivery-stages/',
   },
   {
     slug: 'wordpress-training-programs',

--- a/src/data/legacy-wordpress-administration.ts
+++ b/src/data/legacy-wordpress-administration.ts
@@ -1,0 +1,191 @@
+/**
+ * Single source of truth for the /legacy-wordpress-administration/ section.
+ *
+ * Used by:
+ *   - src/app/legacy-wordpress-administration/page.tsx (hub landing)
+ *   - src/components/legacy-wordpress-administration/Sidebar.tsx
+ *   - src/components/legacy-wordpress-administration/CategoryGrid.tsx
+ *   - src/components/legacy-wordpress-administration/PageHeader.tsx
+ *   - src/app/sitemap.ts
+ *
+ * Adding a page: append a row to LEGACY_WP_ADMIN_PAGES and create
+ * src/app/legacy-wordpress-administration/<slug>/page.tsx using the
+ * shared PageHeader pattern.
+ */
+
+export const LEGACY_WP_ADMIN_BASE = '/legacy-wordpress-administration'
+
+export type LegacyWpAdminCategoryId =
+  | 'wordpress-operations'
+  | 'charity-onboarding'
+  | 'volunteer-programs'
+
+export interface LegacyWpAdminCategory {
+  id: LegacyWpAdminCategoryId
+  label: string
+  description: string
+}
+
+export const LEGACY_WP_ADMIN_CATEGORIES: LegacyWpAdminCategory[] = [
+  {
+    id: 'wordpress-operations',
+    label: 'WordPress Operations',
+    description: 'Hosting, domains, cPanel, and the layered WordPress stack FFC operates.',
+  },
+  {
+    id: 'charity-onboarding',
+    label: 'Charity Onboarding',
+    description: 'Validation, GuideStar maintenance, and the service-delivery lifecycle.',
+  },
+  {
+    id: 'volunteer-programs',
+    label: 'Volunteer Programs',
+    description: 'Training programs, web-developer paths, tools, and proving-ground competencies.',
+  },
+]
+
+export interface LegacyWpAdminPage {
+  /** URL slug under /legacy-wordpress-administration/ — always prefixed `wordpress-`. */
+  slug: string
+  /** Display title used in nav, breadcrumbs, and the page <h1>. */
+  title: string
+  /** Short label used in the sidebar (the `wordpress-` prefix is dropped here). */
+  shortLabel: string
+  /** Card / hub-grid description, ~1 sentence. */
+  summary: string
+  category: LegacyWpAdminCategoryId
+  /** Public-facing canonical page on freeforcharity.org. */
+  publicSourceUrl: string
+  /** Optional cross-link from another section of ffcadmin.org (e.g. /training-plan/). */
+  relatedFfcAdminPaths?: string[]
+}
+
+export const LEGACY_WP_ADMIN_PAGES: LegacyWpAdminPage[] = [
+  {
+    slug: 'wordpress-hosting-techstack',
+    title: 'WordPress Hosting Techstack',
+    shortLabel: 'Hosting Techstack',
+    summary:
+      'The layered hosting stack behind FFC WordPress sites — Cloudflare, the origin host, cPanel/Hostinger, and the plugin floor.',
+    category: 'wordpress-operations',
+    publicSourceUrl: 'https://freeforcharity.org/techstack/',
+    relatedFfcAdminPaths: ['/tech-stack'],
+  },
+  {
+    slug: 'wordpress-web-hosting',
+    title: 'WordPress Web Hosting Operations',
+    shortLabel: 'Web Hosting Ops',
+    summary:
+      'Operational procedures for provisioning, maintaining, and migrating FFC WordPress hosting accounts.',
+    category: 'wordpress-operations',
+    publicSourceUrl: 'https://freeforcharity.org/free-charity-web-hosting/',
+  },
+  {
+    slug: 'wordpress-domains',
+    title: 'WordPress Domain Administration',
+    shortLabel: 'Domain Admin',
+    summary:
+      'DNS handoff, registrar workflows, and Cloudflare configuration for FFC-managed WordPress domains.',
+    category: 'wordpress-operations',
+    publicSourceUrl: 'https://freeforcharity.org/domains/',
+  },
+  {
+    slug: 'wordpress-cpanel-backup-sop',
+    title: 'cPanel Backup SOP',
+    shortLabel: 'cPanel Backup SOP',
+    summary:
+      'Standard operating procedure for cPanel full and partial backups across FFC WordPress hosts.',
+    category: 'wordpress-operations',
+    publicSourceUrl: 'https://freeforcharity.org/ffcadmin-free-for-charity-cpanel-backup-sop/',
+  },
+  {
+    slug: 'wordpress-online-impacts-onboarding',
+    title: 'Online Impacts Onboarding (WordPress)',
+    shortLabel: 'Online Impacts Onboarding',
+    summary: 'Onboarding playbook for charities arriving through the Online Impacts program.',
+    category: 'wordpress-operations',
+    publicSourceUrl: 'https://freeforcharity.org/online-impacts-onboarding-guide/',
+  },
+  {
+    slug: 'wordpress-charity-validation',
+    title: 'Charity Validation Guide (WordPress era)',
+    shortLabel: 'Charity Validation',
+    summary:
+      'Comprehensive validation process FFC uses to confirm 501(c)(3) status and mutual benefit before service delivery.',
+    category: 'charity-onboarding',
+    publicSourceUrl:
+      'https://freeforcharity.org/charity-validation-guide-ensuring-mutual-benefit-through-comprehensive-validation-processes/',
+  },
+  {
+    slug: 'wordpress-guidestar-guide',
+    title: 'GuideStar / Candid Maintenance Guide',
+    shortLabel: 'GuideStar Guide',
+    summary:
+      'How FFC maintains Candid (GuideStar) profiles and the seal-of-transparency renewal cycle.',
+    category: 'charity-onboarding',
+    publicSourceUrl: 'https://freeforcharity.org/guidestar-guide/',
+  },
+  {
+    slug: 'wordpress-service-delivery-stages',
+    title: 'FFC Service Delivery Stages',
+    shortLabel: 'Service Delivery Stages',
+    summary:
+      'The intake → validation → build → handoff lifecycle FFC follows for every charity engagement.',
+    category: 'charity-onboarding',
+    publicSourceUrl: 'https://freeforcharity.org/free-for-charity-ffc-service-delivery-stages/',
+  },
+  {
+    slug: 'wordpress-training-programs',
+    title: 'Free Training Programs (WordPress era)',
+    shortLabel: 'Training Programs',
+    summary:
+      'Catalog of training programs FFC volunteers complete on the way to charity-site delivery.',
+    category: 'volunteer-programs',
+    publicSourceUrl: 'https://freeforcharity.org/free-training-programs/',
+    relatedFfcAdminPaths: ['/training-plan'],
+  },
+  {
+    slug: 'wordpress-web-developer-training',
+    title: 'FFC Web Developer Training Guide',
+    shortLabel: 'Web Developer Training',
+    summary:
+      'Skills, certifications, and project milestones for FFC volunteer web developers (WordPress-era).',
+    category: 'volunteer-programs',
+    publicSourceUrl:
+      'https://freeforcharity.org/free-for-charity-ffc-web-developer-training-guide/',
+    relatedFfcAdminPaths: ['/training-plan'],
+  },
+  {
+    slug: 'wordpress-tools-for-success',
+    title: "Free For Charity's Tools for Success",
+    shortLabel: 'Tools for Success',
+    summary:
+      'The full toolset (productivity, design, communication, finance) FFC issues to partner charities and volunteers.',
+    category: 'volunteer-programs',
+    publicSourceUrl: 'https://freeforcharity.org/free-for-charitys-tools-for-success/',
+  },
+  {
+    slug: 'wordpress-volunteer-proving-ground',
+    title: 'FFC Volunteer Proving Ground: Core Competencies',
+    shortLabel: 'Volunteer Proving Ground',
+    summary:
+      'Core-competency checklist volunteers complete to advance through the FFC contributor ladder.',
+    category: 'volunteer-programs',
+    publicSourceUrl: 'https://freeforcharity.org/ffc-volunteer-proving-ground-core-competencies/',
+    relatedFfcAdminPaths: ['/contributor-ladder'],
+  },
+]
+
+export function getLegacyWpAdminPagesByCategory(
+  category: LegacyWpAdminCategoryId
+): LegacyWpAdminPage[] {
+  return LEGACY_WP_ADMIN_PAGES.filter((p) => p.category === category)
+}
+
+export function getLegacyWpAdminPageBySlug(slug: string): LegacyWpAdminPage | undefined {
+  return LEGACY_WP_ADMIN_PAGES.find((p) => p.slug === slug)
+}
+
+export function getLegacyWpAdminHref(slug: string): string {
+  return `${LEGACY_WP_ADMIN_BASE}/${slug}`
+}

--- a/src/data/legacy-wordpress-administration.ts
+++ b/src/data/legacy-wordpress-administration.ts
@@ -176,16 +176,21 @@ export const LEGACY_WP_ADMIN_PAGES: LegacyWpAdminPage[] = [
   },
 ]
 
+/** Slug literal union derived from LEGACY_WP_ADMIN_PAGES. */
+export type LegacyWpAdminSlug = (typeof LEGACY_WP_ADMIN_PAGES)[number]['slug']
+
 export function getLegacyWpAdminPagesByCategory(
   category: LegacyWpAdminCategoryId
 ): LegacyWpAdminPage[] {
   return LEGACY_WP_ADMIN_PAGES.filter((p) => p.category === category)
 }
 
-export function getLegacyWpAdminPageBySlug(slug: string): LegacyWpAdminPage | undefined {
-  return LEGACY_WP_ADMIN_PAGES.find((p) => p.slug === slug)
+export function getLegacyWpAdminPageBySlug(slug: LegacyWpAdminSlug): LegacyWpAdminPage {
+  // Slug is constrained to known values at the type level, so this lookup
+  // is total. The non-null assertion documents that contract.
+  return LEGACY_WP_ADMIN_PAGES.find((p) => p.slug === slug)!
 }
 
-export function getLegacyWpAdminHref(slug: string): string {
+export function getLegacyWpAdminHref(slug: LegacyWpAdminSlug): string {
   return `${LEGACY_WP_ADMIN_BASE}/${slug}`
 }

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -62,6 +62,11 @@ export const resourcesDropdown: NavDropdown = {
       description: 'Step-by-step technical guides for common tasks.',
     },
     {
+      label: 'Legacy WP Admin',
+      href: '/legacy-wordpress-administration',
+      description: 'WordPress-era operations, SOPs, and procedures for partner charities.',
+    },
+    {
       label: 'Blog',
       href: '/blog',
       description: 'News, volunteer spotlights, and FFC stories.',


### PR DESCRIPTION
## Summary

DNS cutover plan + complete `/legacy-wordpress-administration/` section (hub + 12 fully-populated leaf pages) + donor/applicant routing surfaces (banner, nav, footer) + Cloudflare Bulk Redirect CSV. All six structural items from the parent tracking issue #240 are addressed; the cross-repo companion (#246) and cutover-day Search Console steps remain external.

## What's in this PR

### Plan (#247)

`docs/dns-cutover-site-plan.md` — audience boundary rules, page-by-page disposition of the 38 WordPress pages, section structure (URL tree / categories / file layout / hub layout / leaf template / nav / sitemap / canonicals), Cloudflare Bulk Redirect map, cutover-day checklist.

### Legacy WP Admin scaffolding + content (#241)

**Architecture:**
- `src/data/legacy-wordpress-administration.ts` — single source of truth (12 pages × 3 categories, freeforcharity.org cross-links, related ffcadmin.org paths).
- `src/components/legacy-wordpress-administration/` — `PageHeader`, `Sidebar`, `CategoryGrid`, `LeafPageShell`.
- `src/app/legacy-wordpress-administration/page.tsx` — hub landing.
- `scripts/generate-legacy-wp-admin-stubs.ts` — idempotent scaffolder.
- `src/app/sitemap.ts` — hub + 12 leaves at priority 0.6.
- `src/data/navigation.ts` — "Legacy WP Admin" entry under Resources.

**12 populated leaf pages** under `src/app/legacy-wordpress-administration/wordpress-*/page.tsx`:

| Category | Pages |
| --- | --- |
| WordPress Operations | `wordpress-hosting-techstack`, `wordpress-web-hosting`, `wordpress-domains`, `wordpress-cpanel-backup-sop`, `wordpress-online-impacts-onboarding` |
| Charity Onboarding | `wordpress-charity-validation`, `wordpress-guidestar-guide`, `wordpress-service-delivery-stages` |
| Volunteer Programs | `wordpress-training-programs`, `wordpress-web-developer-training`, `wordpress-tools-for-success`, `wordpress-volunteer-proving-ground` |

Each leaf carries metadata + self-canonical, audience callout, "Public version for charity visitors →" cross-link to the matching freeforcharity.org URL, body content rewritten in operations-team voice, and cross-references to related Legacy WP Admin leaves and modern equivalents (`/training-plan/`, `/contributor-ladder/`, `/tech-stack/`, `/guides/wordpress-to-nextjs-guide`).

**Tests:**
- `__tests__/legacy-wordpress-administration.test.ts` — 11 tests guarding the data file contract (slug prefix, uniqueness, category counts 5/3/4, public-source URL shape, helper round-trips).
- `__tests__/navigation-coverage.test.js` — section added to discoverability checklist.

### Donor/applicant routing (#243)

- `src/components/SisterSiteBanner.tsx` — dismissible top-of-page bar above Navigation. Uses `useSyncExternalStore` for cross-tab persistence.
- `src/components/Navigation.tsx` — "For Charities & Donors ↗" external entry in desktop and mobile menus.
- `src/components/Footer.tsx` — "For Nonprofits" column renamed to "For Charities & Donors", expanded link set.
- `__tests__/components/SisterSiteBanner.test.tsx` — 4 tests (first-visit render, outbound link safety attrs, dismissal persistence, localStorage-throws fallback).

### Cloudflare Bulk Redirect CSV (#244)

- `docs/cloudflare-bulk-redirects-cutover.csv` — 6 same-domain 301 redirects for WP-only drops.

### Sitemap (#245 partial)

Sitemap entries for the new section are landed. Cutover-day Search Console steps remain in the plan doc for execution on cutover day.

## Out of scope (follow-ups)

- #246 — companion changes in `FreeForCharity/FreeForCharity.org`.
- Cutover-day execution (DNS flip, sitemap submission, Cloudflare CSV load, WP origin shutdown).

## Test plan

- [x] `pnpm run format:check` — clean
- [x] `pnpm run lint` — 6 pre-existing warnings, 0 errors, 0 new warnings
- [x] `pnpm run type-check` — clean
- [x] `pnpm test` — 302 / 302 passing (added 15)
- [x] `pnpm run build` — all 13 new routes prerendered as static content
- [x] Sitemap inspection — 13 `legacy-wordpress-administration` URLs present
- [x] All 12 leaf pages render with populated content + proper canonical + audience callout
- [ ] **`/ultrareview 247`** recommended before merge — the structural + content surface is large; a multi-agent review catches more than per-commit CI does
- [ ] Reviewer sanity-check: slug naming, audience framing, category groupings, banner UX
- [ ] Reviewer sanity-check: per-leaf content matches FFC operational reality (some pages were authored from general practice when the WP source returned 404 — flagged in commit messages)

Refs #240 #241 #243 #244 #245 #246.