### PR TITLE
fix: clarify Snapshot Pro vs Shipper Pro across legacy WP admin leaves

### DIFF
--- a/src/app/legacy-wordpress-administration/wordpress-hosting-techstack/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-hosting-techstack/page.tsx
@@ -64,7 +64,7 @@ const layers: Layer[] = [
     vendor: 'WPMUDEV',
     metaphor: 'Essential utilities (electricity, water, HVAC).',
     responsibility:
-      'Security (Defender Pro), performance (Hummingbird, Smush Pro), backups (Snapshot Pro / Shipper Pro), and the WPMUDEV Dashboard plugin that ties everything together.',
+      'Security (Defender Pro), performance (Hummingbird, Smush Pro), backups (Snapshot Pro), migration tooling (Shipper Pro), and the WPMUDEV Dashboard plugin that ties everything together.',
     escalationOrder: [
       'WPMUDEV in-product help and documentation.',
       'FFC Global Admin for hub-level account access.',

--- a/src/app/legacy-wordpress-administration/wordpress-service-delivery-stages/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-service-delivery-stages/page.tsx
@@ -100,7 +100,7 @@ const stages: Stage[] = [
     index: 7,
     name: 'Plugin & Theme Deployment',
     description:
-      'Install the WPMUDEV Dashboard plugin, Defender (security), Hummingbird / Smush (performance), Snapshot (backups). Deploy Divi parent theme and the FFC child layout.',
+      'Install the WPMUDEV Dashboard plugin, Defender (security), Hummingbird / Smush (performance), Snapshot Pro (backups). Deploy Divi parent theme and the FFC child layout.',
     exitGate:
       'WPMUDEV Dashboard reports green across security, performance, backup. Divi child theme is active.',
     blockerHandling:

--- a/src/app/legacy-wordpress-administration/wordpress-web-developer-training/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-web-developer-training/page.tsx
@@ -105,7 +105,7 @@ const platformModules: PlatformModule[] = [
     index: 6,
     name: 'WPMUDEV Plugin Suite',
     purpose:
-      'Performance (Hummingbird, Smush), security (Defender), forms (Forminator), backups (Snapshot), white-labelling (Branda).',
+      'Performance (Hummingbird, Smush Pro), security (Defender Pro), forms (Forminator), backups (Snapshot Pro), migration tooling (Shipper Pro), white-labelling (Branda).',
     setupNotes:
       'Install the WPMUDEV Dashboard plugin first, log in with the FFC WPMUDEV account, then add the per-charity bundle from the Hub.',
     commonChallenges: [


### PR DESCRIPTION
Fixes #253. Refs #248.

## Summary

WPMUDEV ships Snapshot Pro (backup) and Shipper Pro (migration) as distinct products. The PR #247 wording listed them together as if alternatives. This stacks on top of #247 to fix the wording across the four affected leaves.

## Changes

| Leaf | Before | After |
| --- | --- | --- |
| `wordpress-hosting-techstack` | "backups (Snapshot Pro / Shipper Pro)" | "backups (Snapshot Pro), migration tooling (Shipper Pro)" |
| `wordpress-service-delivery-stages` | "Snapshot (backups)" | "Snapshot Pro (backups)" |
| `wordpress-web-developer-training` | "backups (Snapshot)" | "backups (Snapshot Pro), migration tooling (Shipper Pro)" + Pro suffix on Smush / Defender |

`wordpress-cpanel-backup-sop` already used "Snapshot Pro" consistently — no change.

## Test plan

- [x] `pnpm test` — 326/326 passing
- [x] `pnpm run build` — clean

## Base

This PR targets `claude/dns-cutover-site-plan-CXbhu` (the parent #247 branch) so it can land cleanly atop those changes. Once #247 merges, this PR will need a quick rebase onto main — or you can squash-merge into #247 first.

---
_Generated by [Claude Code](https://claude.ai/code/session_013XCaDVNuaqa86rmdiaoZYw)_