### PR TITLE
refactor: wire FFC_FOUNDER_CONTACT into legacy WP admin leaves

### DIFF
--- a/src/app/legacy-wordpress-administration/wordpress-domains/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-domains/page.tsx
@@ -1,6 +1,9 @@
 import type { Metadata } from 'next'
 import LeafPageShell from '@/components/legacy-wordpress-administration/LeafPageShell'
-import { getLegacyWpAdminPageBySlug } from '@/data/legacy-wordpress-administration'
+import {
+  FFC_FOUNDER_CONTACT,
+  getLegacyWpAdminPageBySlug,
+} from '@/data/legacy-wordpress-administration'
 
 const SLUG = 'wordpress-domains'
 const page = getLegacyWpAdminPageBySlug(SLUG)
@@ -179,8 +182,9 @@ export default function Page() {
 
       <h2>Support contact</h2>
       <p>
-        Clarke Moyer (FFC founder): clarkemoyer@freeforcharity.org,{' '}
-        <a href="tel:5202228104">520-222-8104</a>.
+        {FFC_FOUNDER_CONTACT.name} ({FFC_FOUNDER_CONTACT.role}):{' '}
+        <a href={`mailto:${FFC_FOUNDER_CONTACT.email}`}>{FFC_FOUNDER_CONTACT.email}</a>,{' '}
+        <a href={FFC_FOUNDER_CONTACT.phoneHref}>{FFC_FOUNDER_CONTACT.phone}</a>.
       </p>
     </LeafPageShell>
   )

--- a/src/app/legacy-wordpress-administration/wordpress-hosting-techstack/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-hosting-techstack/page.tsx
@@ -1,6 +1,9 @@
 import type { Metadata } from 'next'
 import LeafPageShell from '@/components/legacy-wordpress-administration/LeafPageShell'
-import { getLegacyWpAdminPageBySlug } from '@/data/legacy-wordpress-administration'
+import {
+  FFC_FOUNDER_CONTACT,
+  getLegacyWpAdminPageBySlug,
+} from '@/data/legacy-wordpress-administration'
 
 const SLUG = 'wordpress-hosting-techstack'
 const page = getLegacyWpAdminPageBySlug(SLUG)
@@ -146,8 +149,10 @@ export default function Page() {
       </p>
 
       <p>
-        If a charity issue is unresolved within 48 hours of escalating, text founder Clarke Moyer at{' '}
-        <a href="tel:5202228104">520-222-8104</a> — same cadence as the charity-facing page.
+        If a charity issue is {FFC_FOUNDER_CONTACT.escalationCadence}, text{' '}
+        {FFC_FOUNDER_CONTACT.name} ({FFC_FOUNDER_CONTACT.role}) at{' '}
+        <a href={FFC_FOUNDER_CONTACT.phoneHref}>{FFC_FOUNDER_CONTACT.phone}</a> — same cadence as
+        the charity-facing page.
       </p>
 
       <h2>The six layers</h2>

--- a/src/app/legacy-wordpress-administration/wordpress-online-impacts-onboarding/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-online-impacts-onboarding/page.tsx
@@ -1,6 +1,9 @@
 import type { Metadata } from 'next'
 import LeafPageShell from '@/components/legacy-wordpress-administration/LeafPageShell'
-import { getLegacyWpAdminPageBySlug } from '@/data/legacy-wordpress-administration'
+import {
+  FFC_FOUNDER_CONTACT,
+  getLegacyWpAdminPageBySlug,
+} from '@/data/legacy-wordpress-administration'
 
 const SLUG = 'wordpress-online-impacts-onboarding'
 const page = getLegacyWpAdminPageBySlug(SLUG)
@@ -241,8 +244,9 @@ export default function Page() {
       <h2>Support contacts</h2>
       <ul>
         <li>
-          Clarke Moyer (FFC founder) — clarkemoyer@freeforcharity.org,{' '}
-          <a href="tel:5202228104">520-222-8104</a>
+          {FFC_FOUNDER_CONTACT.name} ({FFC_FOUNDER_CONTACT.role}) —{' '}
+          <a href={`mailto:${FFC_FOUNDER_CONTACT.email}`}>{FFC_FOUNDER_CONTACT.email}</a>,{' '}
+          <a href={FFC_FOUNDER_CONTACT.phoneHref}>{FFC_FOUNDER_CONTACT.phone}</a>
         </li>
         <li>
           Online Impacts founder — contact via{' '}


### PR DESCRIPTION
Fixes #249. Refs #248.

## Summary

PR #247 added `FFC_FOUNDER_CONTACT` to `src/data/legacy-wordpress-administration.ts` but didn't migrate the three leaves that hardcoded the founder phone + email. This PR completes that migration.

## Changes

- `wordpress-hosting-techstack` — 48-hour escalation paragraph reads from the constant.
- `wordpress-domains` — Support-contact paragraph rendered from the constant.
- `wordpress-online-impacts-onboarding` — Support-contacts list pulls the founder entry from the constant.

After this PR, founder role changes are a single edit in the data file. Verified with `grep -r '520-222-8104\|clarkemoyer@freeforcharity' src/app/legacy-wordpress-administration/` — empty result.

## Test plan

- [x] `pnpm test` — 326 / 326 passing
- [x] `pnpm run build` — clean

## Base

Targets `claude/dns-cutover-site-plan-CXbhu` (PR #247's branch). Rebases onto main after #247 merges.

---
_Generated by [Claude Code](https://claude.ai/code/session_013XCaDVNuaqa86rmdiaoZYw)_