### PR TITLE
chore: weekly linkinator workflow for /legacy-wordpress-administration/

### DIFF
--- a/.github/workflows/linkinator-legacy-wp-admin.yml
+++ b/.github/workflows/linkinator-legacy-wp-admin.yml
@@ -1,0 +1,89 @@
+name: Weekly Linkinator — /legacy-wordpress-administration/
+
+# Scans the legacy WP admin section for broken vendor URLs.
+#
+# The main CI linkinator (in ci.yml) skips ALL external URLs by policy,
+# so vendor link rot in this section would otherwise go undetected for
+# months. This workflow runs once a week and surfaces 4xx/5xx as an
+# issue or workflow failure so a human can triage.
+#
+# Tracking issue: #251.
+
+on:
+  schedule:
+    # Mondays 13:00 UTC.
+    - cron: '0 13 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  scan:
+    name: Scan vendor URLs in the legacy WP admin section
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
+        with:
+          version: 9.0.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build static site
+        run: pnpm run build
+
+      - name: Run linkinator with a config that DOES scan external URLs
+        id: linkinator
+        run: |
+          set +e
+          pnpm exec linkinator ./out/legacy-wordpress-administration \
+            --config .linkinatorrc-legacy-wp-admin.json \
+            --format json \
+            > link-report.json
+          status=$?
+          # Print a short summary regardless of outcome.
+          echo "=== Linkinator summary ==="
+          jq -r '
+            "Total links scanned: \(.links | length)\n" +
+            "Passing: \([.links[] | select(.state == \"OK\")] | length)\n" +
+            "Broken (4xx/5xx): \([.links[] | select(.status >= 400 and .status < 600)] | length)"
+          ' link-report.json || true
+
+          # Emit a structured list of broken URLs if any exist.
+          if jq -e '[.links[] | select(.status >= 400 and .status < 600)] | length > 0' link-report.json >/dev/null 2>&1; then
+            echo ""
+            echo "=== Broken URLs ==="
+            jq -r '.links[] | select(.status >= 400 and .status < 600) | "  [\(.status)] \(.url) (from \(.parent))"' link-report.json
+            echo "broken=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "broken=false" >> "$GITHUB_OUTPUT"
+          fi
+          exit 0
+
+      - name: Upload link report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: linkinator-legacy-wp-admin-report
+          path: link-report.json
+          retention-days: 30
+
+      - name: Fail the workflow if broken links were found
+        if: steps.linkinator.outputs.broken == 'true'
+        run: |
+          echo "::error::Broken vendor URLs detected in /legacy-wordpress-administration/. See workflow logs + uploaded artifact."
+          exit 1

--- a/.linkinatorrc-legacy-wp-admin.json
+++ b/.linkinatorrc-legacy-wp-admin.json
@@ -1,0 +1,12 @@
+{
+  "recurse": true,
+  "skip": [
+    "https://widgets.guidestar.org/*",
+    "https://www.googletagmanager.com/*",
+    "https://policies.google.com/*",
+    "https://privacy.microsoft.com/*",
+    "https://tools.google.com/*",
+    "^tel:.*",
+    "^mailto:.*"
+  ]
+}


### PR DESCRIPTION
Fixes #251. Refs #248.

## Summary

Adds a weekly GitHub Actions workflow that scans `/legacy-wordpress-administration/*` for broken vendor URLs.

The main CI linkinator (`.linkinatorrc.json`) skips all external URLs by policy. Vendor link rot in the new section (Microsoft Learn, WPMUDEV, Cloudflare, eNom, candid.org, etc.) would therefore go undetected for months — exactly the rot pattern flagged by the link-rot review on PR #247.

## Files

- `.linkinatorrc-legacy-wp-admin.json` — section-specific config that explicitly allows external URLs.
- `.github/workflows/linkinator-legacy-wp-admin.yml` — Monday 13:00 UTC + on-demand workflow. Scopes the scan to `out/legacy-wordpress-administration/`, fails the run on any 4xx/5xx, uploads a 30-day JSON report.

## Test plan

- [x] Existing `workflow-dependencies.test.js` passes (validates GitHub Actions versions).
- [x] Prettier formatting clean.
- [ ] First scheduled run will exercise the workflow end-to-end after merge.

## Base

Targets `claude/dns-cutover-site-plan-CXbhu` (PR #247's branch).

---
_Generated by [Claude Code](https://claude.ai/code/session_013XCaDVNuaqa86rmdiaoZYw)_