### PR TITLE
feat: cross-link existing pages into legacy WP admin section

### DIFF
--- a/src/app/contributor-ladder/page.tsx
+++ b/src/app/contributor-ladder/page.tsx
@@ -427,6 +427,27 @@ export default function ContributorLadder() {
           </div>
         </div>
       </section>
+
+      {/* Legacy reference */}
+      <section className="py-12 px-4 sm:px-6 lg:px-8 bg-gray-50 border-t border-gray-200">
+        <div className="max-w-4xl mx-auto text-center">
+          <p className="text-sm uppercase tracking-wider text-gray-500 font-semibold mb-2">
+            Legacy reference
+          </p>
+          <p className="text-gray-700">
+            The WordPress-era proving-ground curriculum is preserved at{' '}
+            <a
+              href="/legacy-wordpress-administration/wordpress-volunteer-proving-ground"
+              className="text-blue-600 underline hover:text-blue-800"
+            >
+              wordpress-volunteer-proving-ground
+            </a>{' '}
+            — seven core competencies (LastPass, AI assistants, MS-900, MS-700, OneDrive, Planner,
+            M365 Apps) covering 33–46 hours of self-study. Use it as supplemental reading when
+            moving through the modern contributor ladder.
+          </p>
+        </div>
+      </section>
     </div>
   )
 }

--- a/src/app/guides/wordpress-to-nextjs-guide/page.tsx
+++ b/src/app/guides/wordpress-to-nextjs-guide/page.tsx
@@ -1940,6 +1940,17 @@ export default function WordPressToNextJSGuide() {
               ffcadmin.org/guides/wordpress-to-nextjs-guide
             </a>
           </p>
+          <p className="mt-4 text-sm text-gray-600">
+            For the WordPress side that this guide migrates <em>away</em> from, see the{' '}
+            <a
+              href="/legacy-wordpress-administration"
+              className="text-blue-600 underline hover:text-blue-800"
+            >
+              Legacy WordPress Administration hub
+            </a>{' '}
+            — operations runbook covering hosting, domains, charity onboarding, and the legacy
+            volunteer training curriculum that this conversion guide replaces.
+          </p>
         </div>
       </main>
     </div>

--- a/src/app/tech-stack/page.tsx
+++ b/src/app/tech-stack/page.tsx
@@ -1115,6 +1115,17 @@ export default function TechStack() {
                   520‑222‑8104
                 </a>
               </p>
+              <p className="mt-4 text-sm text-gray-600">
+                Still running WordPress? The legacy hosting layered model is preserved at{' '}
+                <a
+                  href="/legacy-wordpress-administration/wordpress-hosting-techstack"
+                  className="text-blue-600 hover:text-blue-800 underline"
+                >
+                  wordpress-hosting-techstack
+                </a>{' '}
+                — vendor-by-vendor escalation paths for InterServer, Hostinger, WPMUDEV, Divi,
+                Cloudflare, and Microsoft 365.
+              </p>
             </div>
           </div>
         </div>

--- a/src/app/training-plan/page.tsx
+++ b/src/app/training-plan/page.tsx
@@ -426,6 +426,33 @@ export default function TrainingPlan() {
             )}
           </section>
         ))}
+
+        {/* Legacy reference */}
+        <section className="mt-12 p-6 bg-gray-50 border border-gray-200 rounded-lg">
+          <p className="text-sm uppercase tracking-wider text-gray-500 font-semibold mb-2">
+            Legacy reference
+          </p>
+          <p className="text-gray-700 mb-3">
+            The legacy three-track FFC training catalog (Researcher / Business Analyst / Web
+            Developer) lives at{' '}
+            <a
+              href="/legacy-wordpress-administration/wordpress-training-programs"
+              className="text-blue-600 underline hover:text-blue-800"
+            >
+              wordpress-training-programs
+            </a>{' '}
+            — useful for the salary anchors and the win-win-win pitch. The WordPress-era
+            developer-specific curriculum (WHMCS, Cloudflare, M365, InterServer, Divi, WPMUDEV,
+            Clarity, Tawk.to, Azure AI) is preserved at{' '}
+            <a
+              href="/legacy-wordpress-administration/wordpress-web-developer-training"
+              className="text-blue-600 underline hover:text-blue-800"
+            >
+              wordpress-web-developer-training
+            </a>{' '}
+            with per-module modern equivalents called out.
+          </p>
+        </section>
       </main>
     </div>
   )


### PR DESCRIPTION
Fixes #252. Refs #248.

## Summary

Distributes inbound link equity from four established high-traffic pages into the new legacy-wordpress-administration leaves. Without this, the new leaves are reachable only through the section sidebar or hub — search engines find them but they get no PageRank boost from neighbouring content.

Each cross-link uses descriptive anchor text and a sentence of context so the relevance signal is natural.

## Changes

| Source page | Adds link to |
| --- | --- |
| `/contributor-ladder/` | `wordpress-volunteer-proving-ground` (legacy seven-module curriculum) |
| `/tech-stack/` | `wordpress-hosting-techstack` (vendor-by-vendor escalation paths) |
| `/training-plan/` | `wordpress-training-programs` + `wordpress-web-developer-training` |
| `/guides/wordpress-to-nextjs-guide/` | `/legacy-wordpress-administration/` (hub) — the side this guide migrates away from |

Each callout is styled as a small "Legacy reference" block near the bottom of the page so it doesn't interrupt primary content flow.

## Test plan

- [x] `pnpm test` — 326 / 326 passing
- [x] `pnpm run build` — clean
- [x] Cross-reference test still passes (these new links point at existing legacy slugs)

## Base

Targets `claude/dns-cutover-site-plan-CXbhu` (PR #247's branch).

---
_Generated by [Claude Code](https://claude.ai/code/session_013XCaDVNuaqa86rmdiaoZYw)_