### PR TITLE
fix: improve information scent on wordpress-domains

### DIFF
--- a/src/app/legacy-wordpress-administration/wordpress-domains/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-domains/page.tsx
@@ -83,8 +83,10 @@ export default function Page() {
     <LeafPageShell page={page}>
       <p>
         FFC issues free .org domains to validated partner charities through its eNom Platinum
-        reseller account. The flow is four steps for the charity and four matching checks for the
-        FFC admin. This page documents both sides.
+        reseller account. This page covers <strong>two scenarios in equal depth</strong>:
+        <strong> registering a new .org</strong> (the dominant flow) and{' '}
+        <strong>transferring an existing domain</strong> from another registrar (the gotcha-heavy
+        alternative).
       </p>
 
       <p>
@@ -94,6 +96,23 @@ export default function Page() {
         </a>
         .
       </p>
+
+      <h2>Which pathway applies</h2>
+      <p>
+        Use the table below to pick the right entry point. Both scenarios share the same four-step
+        flow once the registrar question is settled.
+      </p>
+
+      <ul>
+        <li>
+          <strong>Charity does not yet have a domain</strong> → start at the four-step registration
+          flow.
+        </li>
+        <li>
+          <strong>Charity has a domain on another registrar</strong> (GoDaddy, Namecheap, etc.) →
+          read the transfer-in gotchas first, then run the four-step flow.
+        </li>
+      </ul>
 
       <h2>Two pathways into the domain flow</h2>
       <ul>

--- a/src/data/legacy-wordpress-administration.ts
+++ b/src/data/legacy-wordpress-administration.ts
@@ -98,7 +98,7 @@ export const LEGACY_WP_ADMIN_PAGES: LegacyWpAdminPage[] = [
     title: 'WordPress Domain Administration',
     shortLabel: 'Domain Admin',
     summary:
-      'DNS handoff, registrar workflows, and Cloudflare configuration for FFC-managed WordPress domains.',
+      "FFC's free-.org registration flow plus the transfer-in gotchas for charities arriving with an existing domain.",
     category: 'wordpress-operations',
     publicSourceUrl: 'https://freeforcharity.org/domains/',
   },


### PR DESCRIPTION
Fixes #260. Refs #248.

## Summary

IA review of PR #247 found `wordpress-domains` didn't signal whether it covered registering a new domain or transferring an existing one. Both flows ARE covered but a first-time reader couldn't tell.

## Changes

1. **Summary in data file** — leads with both scenarios so the sidebar / hub / SERP snippet conveys scope.
2. **Intro paragraph** — calls out both scenarios in bold up front.
3. **New "Which pathway applies" section** — one-line decision tree above the existing pathway / four-step flow content.

## Test plan

- [x] `pnpm test` — 326/326 passing
- [x] `pnpm run build` — clean

## Base

Targets `claude/dns-cutover-site-plan-CXbhu` (PR #247's branch).

---
_Generated by [Claude Code](https://claude.ai/code/session_013XCaDVNuaqa86rmdiaoZYw)_