### PR TITLE
feat: add Before-you-start callouts to procedural legacy leaves

### DIFF
--- a/src/app/legacy-wordpress-administration/wordpress-cpanel-backup-sop/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-cpanel-backup-sop/page.tsx
@@ -104,6 +104,25 @@ export default function Page() {
         before risky operations, on quarterly verification cadence, and during rescue scenarios.
       </p>
 
+      <aside className="not-prose my-6 rounded-lg border-l-4 border-amber-400 bg-amber-50 p-4 text-amber-900">
+        <p className="font-semibold mb-2">Before you start</p>
+        <ul className="list-disc list-inside space-y-1 text-sm">
+          <li>cPanel / DirectAdmin / hPanel login for the charity site (FFC password manager).</li>
+          <li>WPMUDEV Hub access for Snapshot Pro status.</li>
+          <li>
+            Workstation with <code>wp-cli</code> installed for the restore step.
+          </li>
+          <li>Block ~90 minutes of uninterrupted time — full backups can take 30-90 minutes.</li>
+          <li>
+            New to FFC&apos;s hosting layers? Read{' '}
+            <a href="/legacy-wordpress-administration/wordpress-hosting-techstack/">
+              wordpress-hosting-techstack
+            </a>{' '}
+            first.
+          </li>
+        </ul>
+      </aside>
+
       <p>
         The charity-facing version of this page on{' '}
         <a href={page.publicSourceUrl} target="_blank" rel="noopener noreferrer">

--- a/src/app/legacy-wordpress-administration/wordpress-online-impacts-onboarding/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-online-impacts-onboarding/page.tsx
@@ -172,6 +172,28 @@ export default function Page() {
         starts.
       </p>
 
+      <aside className="not-prose my-6 rounded-lg border-l-4 border-amber-400 bg-amber-50 p-4 text-amber-900">
+        <p className="font-semibold mb-2">Before you start</p>
+        <ul className="list-disc list-inside space-y-1 text-sm">
+          <li>FFC Hub (WHMCS) admin access for issuing the onboarding product.</li>
+          <li>Microsoft 365 nonprofit tenant ready to receive the new charity domain.</li>
+          <li>
+            The charity has already completed the validation gate (see{' '}
+            <a href="/legacy-wordpress-administration/wordpress-charity-validation/">
+              wordpress-charity-validation
+            </a>
+            ).
+          </li>
+          <li>
+            New to FFC&apos;s overall lifecycle? Read{' '}
+            <a href="/legacy-wordpress-administration/wordpress-service-delivery-stages/">
+              wordpress-service-delivery-stages
+            </a>{' '}
+            first — Online Impacts onboarding is Stage 5 of that broader flow.
+          </li>
+        </ul>
+      </aside>
+
       <p>
         The charity-facing version of this guide lives at{' '}
         <a href={page.publicSourceUrl} target="_blank" rel="noopener noreferrer">


### PR DESCRIPTION
Fixes #259. Refs #248.

## Summary

IA review of PR #247 found `wordpress-cpanel-backup-sop` and `wordpress-online-impacts-onboarding` drop the reader straight into runbook mode without orienting them. Adds a "Before you start" aside at the top of each — required access, prior reading, time budget.

## Changes

- `wordpress-cpanel-backup-sop`: panel login, WPMUDEV Hub, wp-cli, 90-min time block, pointer to wordpress-hosting-techstack.
- `wordpress-online-impacts-onboarding`: WHMCS admin, M365 tenant ready, validation gate cleared, pointer to wordpress-service-delivery-stages.

Other procedural leaves (`wordpress-domains`, `wordpress-charity-validation`) already include similar context via their two-pathway / when-to-run framing.

## Test plan

- [x] `pnpm test` — 326/326 passing
- [x] `pnpm run build` — clean

## Base

Targets `claude/dns-cutover-site-plan-CXbhu` (PR #247's branch).

---
_Generated by [Claude Code](https://claude.ai/code/session_013XCaDVNuaqa86rmdiaoZYw)_