### PR TITLE
style: align legacy WP admin section padding to py-16 site rhythm

### DIFF
--- a/src/app/legacy-wordpress-administration/page.tsx
+++ b/src/app/legacy-wordpress-administration/page.tsx
@@ -84,14 +84,14 @@ export default function LegacyWordPressAdministrationHubPage() {
       </section>
 
       {/* Category card grid */}
-      <section className="py-12 px-4 sm:px-6 lg:px-8">
+      <section className="py-16 px-4 sm:px-6 lg:px-8">
         <div className="max-w-7xl mx-auto">
           <CategoryGrid />
         </div>
       </section>
 
       {/* Why "Legacy"? */}
-      <section className="py-12 px-4 sm:px-6 lg:px-8 bg-white border-t border-gray-200">
+      <section className="py-16 px-4 sm:px-6 lg:px-8 bg-white border-t border-gray-200">
         <div className="max-w-3xl mx-auto">
           <h2 className="text-2xl font-bold text-gray-900 mb-4">Why &ldquo;Legacy&rdquo;?</h2>
           <p className="text-gray-700 mb-3">
@@ -109,7 +109,7 @@ export default function LegacyWordPressAdministrationHubPage() {
       </section>
 
       {/* Bottom CTAs */}
-      <section className="py-12 px-4 sm:px-6 lg:px-8">
+      <section className="py-16 px-4 sm:px-6 lg:px-8">
         <div className="max-w-5xl mx-auto grid gap-4 sm:grid-cols-2">
           <Link
             href="/guides/wordpress-to-nextjs-guide"

--- a/src/components/legacy-wordpress-administration/LeafPageShell.tsx
+++ b/src/components/legacy-wordpress-administration/LeafPageShell.tsx
@@ -26,7 +26,7 @@ export default function LeafPageShell({ page, children }: LeafPageShellProps) {
     <div className="min-h-screen bg-gray-50">
       <PageHeader page={page} />
 
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10 grid grid-cols-1 lg:grid-cols-[16rem_minmax(0,1fr)] gap-10">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16 grid grid-cols-1 lg:grid-cols-[16rem_minmax(0,1fr)] gap-10">
         {/* Mobile: article reads first; desktop: sidebar in column 1, article in column 2. */}
         {/* Cap prose at 65ch on mobile/tablet for readability; let it fill the column on desktop. */}
         <article className="prose prose-slate max-w-prose lg:max-w-none lg:col-start-2 lg:row-start-1">
@@ -41,7 +41,7 @@ export default function LeafPageShell({ page, children }: LeafPageShellProps) {
       </div>
 
       <section className="bg-white border-t border-gray-200">
-        <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-10 grid gap-4 sm:grid-cols-2 text-sm">
+        <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-16 grid gap-4 sm:grid-cols-2 text-sm">
           <Link
             href={LEGACY_WP_ADMIN_BASE}
             className="block rounded-lg border border-gray-200 p-4 hover:border-blue-400 hover:shadow-md transition-all"

--- a/src/components/legacy-wordpress-administration/PageHeader.tsx
+++ b/src/components/legacy-wordpress-administration/PageHeader.tsx
@@ -32,7 +32,7 @@ export default function PageHeader({ page }: PageHeaderProps) {
         ]}
       />
 
-      <header className="bg-gradient-to-r from-slate-700 to-slate-900 text-white py-12 px-4 sm:px-6 lg:px-8">
+      <header className="bg-gradient-to-r from-slate-700 to-slate-900 text-white py-16 px-4 sm:px-6 lg:px-8">
         <div className="max-w-5xl mx-auto">
           {category && (
             <p className="text-xs uppercase tracking-wider text-slate-100 mb-2 font-semibold">


### PR DESCRIPTION
Fixes #266. Refs #248.

## Summary

Brand review of PR #247 flagged inconsistent vertical spacing in the new section (`py-12` / `py-10`) versus the rest of the site (`py-16`).

Mechanical six-class swap.

## Changes

- `PageHeader` hero: `py-12` → `py-16`
- `LeafPageShell` main grid: `py-10` → `py-16`
- `LeafPageShell` bottom CTA strip: `py-10` → `py-16`
- Hub `page.tsx` category grid + "Why Legacy?" + bottom CTAs: `py-12` → `py-16`

## Test plan

- [x] `pnpm test` — 326/326 passing
- [x] `pnpm run build` — clean
- [ ] Side-by-side spot-check vs `/tech-stack` and `/training-plan` after merge

## Base

Targets `claude/dns-cutover-site-plan-CXbhu` (PR #247's branch).

---
_Generated by [Claude Code](https://claude.ai/code/session_013XCaDVNuaqa86rmdiaoZYw)_