### PR TITLE
feat: emit HowTo structured data on SOP-flavored legacy leaves

### DIFF
--- a/src/app/legacy-wordpress-administration/wordpress-cpanel-backup-sop/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-cpanel-backup-sop/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next'
+import HowToSchema from '@/components/legacy-wordpress-administration/HowToSchema'
 import LeafPageShell from '@/components/legacy-wordpress-administration/LeafPageShell'
 import { getLegacyWpAdminPageBySlug } from '@/data/legacy-wordpress-administration'
 
@@ -98,6 +99,15 @@ const partialBackupTriggers = [
 export default function Page() {
   return (
     <LeafPageShell page={page}>
+      <HowToSchema
+        name={page.title}
+        description={page.summary}
+        url={`https://ffcadmin.org/legacy-wordpress-administration/${SLUG}/`}
+        steps={fullBackupSteps.map((s) => ({
+          name: s.name,
+          text: s.details.join(' '),
+        }))}
+      />
       <p>
         Every FFC-managed WordPress site is backed up automatically by WPMUDEV Snapshot Pro on a
         daily cadence. This SOP covers the <em>manual</em> backup path — what an FFC admin runs

--- a/src/app/legacy-wordpress-administration/wordpress-domains/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-domains/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next'
+import HowToSchema from '@/components/legacy-wordpress-administration/HowToSchema'
 import LeafPageShell from '@/components/legacy-wordpress-administration/LeafPageShell'
 import { getLegacyWpAdminPageBySlug } from '@/data/legacy-wordpress-administration'
 
@@ -81,6 +82,15 @@ const transferGotchas = [
 export default function Page() {
   return (
     <LeafPageShell page={page}>
+      <HowToSchema
+        name={page.title}
+        description={page.summary}
+        url={`https://ffcadmin.org/legacy-wordpress-administration/${SLUG}/`}
+        steps={fourStepFlow.map((s) => ({
+          name: s.title,
+          text: `${s.description} Admin check: ${s.adminCheck}`,
+        }))}
+      />
       <p>
         FFC issues free .org domains to validated partner charities through its eNom Platinum
         reseller account. The flow is four steps for the charity and four matching checks for the

--- a/src/app/legacy-wordpress-administration/wordpress-online-impacts-onboarding/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-online-impacts-onboarding/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next'
+import HowToSchema from '@/components/legacy-wordpress-administration/HowToSchema'
 import LeafPageShell from '@/components/legacy-wordpress-administration/LeafPageShell'
 import { getLegacyWpAdminPageBySlug } from '@/data/legacy-wordpress-administration'
 
@@ -165,6 +166,15 @@ const resourceSteps = [domainSteps, hostingSteps, wpInstallSteps]
 export default function Page() {
   return (
     <LeafPageShell page={page}>
+      <HowToSchema
+        name={page.title}
+        description={page.summary}
+        url={`https://ffcadmin.org/legacy-wordpress-administration/${SLUG}/`}
+        steps={onboardingSteps.map((s) => ({
+          name: s.title,
+          text: `${s.description} Admin action: ${s.adminAction}`,
+        }))}
+      />
       <p>
         Online Impacts charities transitioning into the FFC support footprint follow a structured
         onboarding sequence. The flow exists because Online Impacts and FFC have slightly different

--- a/src/app/legacy-wordpress-administration/wordpress-service-delivery-stages/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-service-delivery-stages/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next'
+import HowToSchema from '@/components/legacy-wordpress-administration/HowToSchema'
 import LeafPageShell from '@/components/legacy-wordpress-administration/LeafPageShell'
 import { getLegacyWpAdminPageBySlug } from '@/data/legacy-wordpress-administration'
 
@@ -124,6 +125,15 @@ const stages: Stage[] = [
 export default function Page() {
   return (
     <LeafPageShell page={page}>
+      <HowToSchema
+        name={page.title}
+        description={page.summary}
+        url={`https://ffcadmin.org/legacy-wordpress-administration/${SLUG}/`}
+        steps={stages.map((s) => ({
+          name: s.name,
+          text: `${s.description} Exit gate: ${s.exitGate}`,
+        }))}
+      />
       <p>
         FFC delivers a charity website through an eight-stage lifecycle. Each stage has a clear exit
         gate, a clear owner role, and a documented way to handle the typical blockers. This page is

--- a/src/components/legacy-wordpress-administration/HowToSchema.tsx
+++ b/src/components/legacy-wordpress-administration/HowToSchema.tsx
@@ -1,0 +1,51 @@
+/**
+ * Emits schema.org HowTo or Article JSON-LD for a leaf page.
+ *
+ * Used by SOP-flavored leaves under /legacy-wordpress-administration/
+ * to qualify for Google rich-result eligibility (per SEO review on
+ * issue #254).
+ *
+ * Render once per leaf, near the top of the JSX body. Next.js inlines
+ * the `<script type="application/ld+json">` into the static HTML.
+ */
+
+interface HowToStep {
+  /** Short step name; shows in search-result rich snippets. */
+  name: string
+  /** Longer step text; one paragraph is the sweet spot. */
+  text: string
+}
+
+interface HowToSchemaProps {
+  /** Page name — usually `page.title`. */
+  name: string
+  /** One-sentence description — usually `page.summary`. */
+  description: string
+  /** Canonical URL for the page — usually the leaf's canonical. */
+  url: string
+  /** Ordered step list. */
+  steps: HowToStep[]
+}
+
+export default function HowToSchema({ name, description, url, steps }: HowToSchemaProps) {
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'HowTo',
+    name,
+    description,
+    url,
+    step: steps.map((s, i) => ({
+      '@type': 'HowToStep',
+      position: i + 1,
+      name: s.name,
+      text: s.text,
+    })),
+  }
+
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+    />
+  )
+}


### PR DESCRIPTION
Fixes #254. Refs #248.

## Summary

Adds `schema.org/HowTo` JSON-LD to the four SOP-flavored legacy leaves so they qualify for Google rich-result eligibility. Each schema derives from the page's existing step array so it stays in sync without duplication.

## Changes

- New `src/components/legacy-wordpress-administration/HowToSchema.tsx` — reusable JSON-LD emitter.
- Wired into four leaves:
  - `wordpress-cpanel-backup-sop` (5 steps from `fullBackupSteps`)
  - `wordpress-domains` (4 steps from `fourStepFlow`)
  - `wordpress-online-impacts-onboarding` (4 steps from `onboardingSteps`)
  - `wordpress-service-delivery-stages` (8 stages from `stages`)

## Test plan

- [x] `pnpm test` — 326/326 passing
- [x] `pnpm run build` — clean
- [x] Verified `<script type="application/ld+json">` containing HowTo schema appears in `out/legacy-wordpress-administration/wordpress-cpanel-backup-sop/index.html`
- [ ] Validate with Google's Rich Results Test after merge: https://search.google.com/test/rich-results

## Base

Targets `claude/dns-cutover-site-plan-CXbhu` (PR #247's branch).

---
_Generated by [Claude Code](https://claude.ai/code/session_013XCaDVNuaqa86rmdiaoZYw)_