### PR TITLE
feat: vendor URL data file with lastVerified timestamps

### DIFF
--- a/__tests__/vendor-urls.test.ts
+++ b/__tests__/vendor-urls.test.ts
@@ -1,0 +1,34 @@
+import { VENDOR_URLS, VENDOR_URL_FRESHNESS_DAYS, staleVendorUrls } from '@/data/vendor-urls'
+
+describe('Vendor URL registry', () => {
+  test('every entry has a non-empty URL and ISO lastVerified date', () => {
+    for (const [key, entry] of Object.entries(VENDOR_URLS)) {
+      expect(entry.url).toMatch(/^(https?:\/\/|mailto:|tel:)/)
+      expect(entry.lastVerified).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+      expect(entry.description.length).toBeGreaterThan(0)
+      // Sanity: the key should not be empty.
+      expect(key.length).toBeGreaterThan(0)
+    }
+  })
+
+  test('freshness window is reasonable', () => {
+    // Months-long not days-long not years-long.
+    expect(VENDOR_URL_FRESHNESS_DAYS).toBeGreaterThanOrEqual(30)
+    expect(VENDOR_URL_FRESHNESS_DAYS).toBeLessThanOrEqual(365)
+  })
+
+  test('staleVendorUrls reports nothing for a recently-verified registry', () => {
+    // Today minus 30 days — all entries should still be fresh assuming
+    // every lastVerified in the registry is within the freshness window.
+    const today = new Date('2026-06-23')
+    const stale = staleVendorUrls(today)
+    expect(stale).toEqual([])
+  })
+
+  test('staleVendorUrls reports entries when the clock advances past freshness', () => {
+    // 200 days after the verification cluster — all should be stale.
+    const today = new Date('2026-12-15')
+    const stale = staleVendorUrls(today)
+    expect(stale.length).toBe(Object.keys(VENDOR_URLS).length)
+  })
+})

--- a/src/app/legacy-wordpress-administration/wordpress-domains/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-domains/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import LeafPageShell from '@/components/legacy-wordpress-administration/LeafPageShell'
 import { getLegacyWpAdminPageBySlug } from '@/data/legacy-wordpress-administration'
+import { VENDOR_URLS } from '@/data/vendor-urls'
 
 const SLUG = 'wordpress-domains'
 const page = getLegacyWpAdminPageBySlug(SLUG)
@@ -28,8 +29,7 @@ const fourStepFlow: Step[] = [
     index: 1,
     id: 'cloudflare-signup',
     title: 'Charity creates Cloudflare account',
-    description:
-      'Direct the charity to https://dash.cloudflare.com/sign-up using their charity-domain Outlook mailbox. They must keep this tab open through the entire flow.',
+    description: `Direct the charity to ${VENDOR_URLS.cloudflareSignup.url} using their charity-domain Outlook mailbox. They must keep this tab open through the entire flow.`,
     adminCheck:
       'Confirm the account uses the charity-domain mailbox (not a personal Gmail). Cloudflare verification emails land in the same mailbox; personal addresses cause silent failures later.',
   },
@@ -99,14 +99,18 @@ export default function Page() {
       <ul>
         <li>
           <strong>501(c)(3) charities</strong> complete the standard onboarding via{' '}
-          <a href="https://freeforcharity.org/501c3/" target="_blank" rel="noopener noreferrer">
+          <a href={VENDOR_URLS.freeforcharity501c3.url} target="_blank" rel="noopener noreferrer">
             freeforcharity.org/501c3
           </a>{' '}
           before being issued a coupon.
         </li>
         <li>
           <strong>Pre-501(c)(3) organizations</strong> use the alternate flow at{' '}
-          <a href="https://freeforcharity.org/pre501c3/" target="_blank" rel="noopener noreferrer">
+          <a
+            href={VENDOR_URLS.freeforcharityPre501c3.url}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             freeforcharity.org/pre501c3
           </a>{' '}
           which trades a smaller toolkit for a faster path to a domain.

--- a/src/data/vendor-urls.ts
+++ b/src/data/vendor-urls.ts
@@ -1,0 +1,96 @@
+/**
+ * Centralized vendor URL registry.
+ *
+ * Goal: when a vendor restructures their docs / product URL, the fix
+ * is a single line in this file instead of a grep across every leaf
+ * that referenced them.
+ *
+ * Each entry carries a `lastVerified` date. The weekly linkinator
+ * workflow (.github/workflows/linkinator-legacy-wp-admin.yml) scans
+ * the rendered site for 4xx/5xx and flags stale URLs; this `lastVerified`
+ * field is the human-tracked counterpart.
+ *
+ * Adding a vendor: append an entry. Bumping a verification date: edit
+ * just the `lastVerified` value when a URL has been re-confirmed.
+ *
+ * Refs issue #269.
+ */
+
+export interface VendorUrl {
+  url: string
+  /** ISO date (YYYY-MM-DD) when the URL was last manually confirmed. */
+  lastVerified: string
+  /** What this URL is, in case the slug becomes unclear. */
+  description: string
+}
+
+export const VENDOR_URLS = {
+  candid: {
+    url: 'https://candid.org/',
+    lastVerified: '2026-05-24',
+    description: 'Candid (formerly GuideStar) — canonical US nonprofit registry.',
+  },
+  techsoup: {
+    url: 'https://www.techsoup.org/',
+    lastVerified: '2026-05-24',
+    description: 'TechSoup — discounted software for validated nonprofits.',
+  },
+  volunteermatch: {
+    url: 'https://www.volunteermatch.org/',
+    lastVerified: '2026-05-24',
+    description: 'VolunteerMatch — volunteer-recruitment platform.',
+  },
+  cloudflareSignup: {
+    url: 'https://dash.cloudflare.com/sign-up',
+    lastVerified: '2026-05-24',
+    description: 'Cloudflare account signup — first step in the FFC domain flow.',
+  },
+  microsoftLearnHome: {
+    url: 'https://learn.microsoft.com/',
+    lastVerified: '2026-05-24',
+    description: 'Microsoft Learn — MS-900 / MS-700 study material.',
+  },
+  interserverSales: {
+    url: 'mailto:sales@interserver.net',
+    lastVerified: '2026-05-24',
+    description: 'InterServer nonprofit sales contact.',
+  },
+  onlineImpacts: {
+    url: 'https://onlineimpacts.org/',
+    lastVerified: '2026-05-24',
+    description: 'Online Impacts — charity-services partner that pre-dated FFC.',
+  },
+  freeforcharity501c3: {
+    url: 'https://freeforcharity.org/501c3/',
+    lastVerified: '2026-05-24',
+    description: '501(c)(3) charity onboarding entry point on the marketing site.',
+  },
+  freeforcharityPre501c3: {
+    url: 'https://freeforcharity.org/pre501c3/',
+    lastVerified: '2026-05-24',
+    description: 'Pre-501(c)(3) onboarding entry point.',
+  },
+  freeforcharitySubmit: {
+    url: 'https://freeforcharity.org/submit-information/',
+    lastVerified: '2026-05-24',
+    description: 'Charity application form — the primary CTA target.',
+  },
+} as const satisfies Record<string, VendorUrl>
+
+export type VendorUrlKey = keyof typeof VENDOR_URLS
+
+/** How stale a vendor URL can get before the periodic check should flag it. */
+export const VENDOR_URL_FRESHNESS_DAYS = 90
+
+/**
+ * Returns vendor URLs whose lastVerified is older than the freshness
+ * window. Used by the linkinator workflow + ad-hoc audit scripts.
+ */
+export function staleVendorUrls(today: Date = new Date()): VendorUrlKey[] {
+  const cutoff = new Date(today)
+  cutoff.setDate(cutoff.getDate() - VENDOR_URL_FRESHNESS_DAYS)
+  const cutoffStr = cutoff.toISOString().slice(0, 10)
+  return (Object.keys(VENDOR_URLS) as VendorUrlKey[]).filter(
+    (key) => VENDOR_URLS[key].lastVerified < cutoffStr
+  )
+}


### PR DESCRIPTION
Fixes #269. Refs #248.

## Summary

Link-rot review of PR #247 flagged scattered vendor URLs hardcoded across multiple leaves. This adds `src/data/vendor-urls.ts` as the single source of truth with `lastVerified` ISO dates per entry.

## Adds

- `src/data/vendor-urls.ts` — 9 vendor entries (Candid, TechSoup, VolunteerMatch, Cloudflare signup, Microsoft Learn, InterServer sales, Online Impacts, freeforcharity 501c3 / pre501c3 / submit-information).
- `staleVendorUrls()` helper returning entries past a 90-day freshness window — pairs with the weekly linkinator workflow from #251.
- `__tests__/vendor-urls.test.ts` — 4 unit tests guarding entry shape, freshness window sanity, and the stale-detector behaviour.

## Migration pattern

`wordpress-domains` migrated as the reference:
- Cloudflare signup URL pulled from `VENDOR_URLS.cloudflareSignup.url`
- freeforcharity 501c3 + pre501c3 entry-point URLs pulled from the matching entries

Remaining leaves migrate incrementally as they're touched for other work; the data file is the source of truth from this PR forward.

## Test plan

- [x] `pnpm test` — 330 / 330 passing (+4 new)
- [x] `pnpm run build` — clean

## Base

Targets `claude/dns-cutover-site-plan-CXbhu` (PR #247's branch).

---
_Generated by [Claude Code](https://claude.ai/code/session_013XCaDVNuaqa86rmdiaoZYw)_