### PR TITLE
fix(seo): restore brand suffix on legacy WP admin titles, all under 60 chars

### DIFF
--- a/src/app/legacy-wordpress-administration/layout.tsx
+++ b/src/app/legacy-wordpress-administration/layout.tsx
@@ -4,12 +4,14 @@ import type { ReactNode } from 'react'
 const SITE_URL = 'https://ffcadmin.org'
 
 export const metadata: Metadata = {
-  // Use just the page title on leaves (no section suffix) so the
-  // global '%s | Free For Charity Admin' template from layout.tsx
-  // applies once — keeps titles within Google's ~60-char cutoff.
+  // Leaf titles use the short "FFC Admin" brand suffix (not the root
+  // layout's longer "Free For Charity Admin") so the longest leaf
+  // title stays under Google's ~60-char SERP cutoff while still
+  // carrying brand identity. The root template does not apply here
+  // because this template is the closest one to the leaf segments.
   title: {
-    default: 'Legacy WordPress Administration',
-    template: '%s',
+    default: 'Legacy WordPress Administration | FFC Admin',
+    template: '%s | FFC Admin',
   },
   description:
     'Operations and SOP reference for FFC volunteers, admins, and partner charities still running their own WordPress.',

--- a/src/app/legacy-wordpress-administration/page.tsx
+++ b/src/app/legacy-wordpress-administration/page.tsx
@@ -7,7 +7,9 @@ import { LEGACY_WP_ADMIN_CATEGORIES } from '@/data/legacy-wordpress-administrati
 const SITE_URL = 'https://ffcadmin.org'
 
 export const metadata: Metadata = {
-  title: 'Legacy WordPress Administration',
+  // Absolute title keeps the hub consistent with the leaves' "FFC Admin"
+  // suffix instead of inheriting the root layout's longer brand string.
+  title: { absolute: 'Legacy WordPress Administration | FFC Admin' },
   description:
     'Operations and SOP reference for FFC volunteers, admins, and partner charities still running their own WordPress — hosting, domains, charity onboarding, and volunteer programs.',
   alternates: {


### PR DESCRIPTION
## Summary

Visual inspection of the live site after the section shipped revealed the leaf `<title>`s had no brand suffix (e.g. "cPanel Backup SOP") while the hub kept the long "| Free For Charity Admin". This restores a consistent, SEO-correct brand suffix.

## Fix

- Section `layout.tsx` template: `%s` → `%s | FFC Admin`
- Hub `page.tsx`: absolute title `Legacy WordPress Administration | FFC Admin`

The short "FFC Admin" form keeps the longest title (59 chars) under Google's ~60-char SERP cutoff while restoring brand identity and hub/leaf consistency.

## Measured rendered `<title>` lengths (all ≤ 59)

| Len | Title |
| --- | --- |
| 29 | cPanel Backup SOP \| FFC Admin |
| 39 | WordPress Hosting Techstack \| FFC Admin |
| 39 | FFC Service Delivery Stages \| FFC Admin |
| 43 | Legacy WordPress Administration \| FFC Admin (hub) |
| 43 | WordPress Domain Administration \| FFC Admin |
| 44 | WordPress Web Hosting Operations \| FFC Admin |
| 44 | FFC Web Developer Training Guide \| FFC Admin |
| 48 | GuideStar / Candid Maintenance Guide \| FFC Admin |
| 49 | Online Impacts Onboarding (WordPress) \| FFC Admin |
| 50 | Free Training Programs (WordPress era) \| FFC Admin |
| 52 | Charity Validation Guide (WordPress era) \| FFC Admin |
| 53 | Free For Charity's Tools for Success \| FFC Admin (apostrophe entity) |
| 59 | FFC Volunteer Proving Ground: Core Competencies \| FFC Admin |

## Test plan

- [x] `pnpm run build` — clean, all 13 titles measured from `out/`
- [x] `pnpm test` — 333 / 333 passing
- [x] `pnpm run lint` — 0 errors

Refs #248.

---
_Generated by [Claude Code](https://claude.ai/code/session_013XCaDVNuaqa86rmdiaoZYw)_