### PR TITLE
chore: normalize line endings to LF via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,18 @@
+* text=auto eol=lf
+
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.webp binary
+*.ico binary
+*.pdf binary
+*.zip binary
+*.gz binary
+*.woff binary
+*.woff2 binary
+*.ttf binary
+*.eot binary
+*.mp3 binary
+*.mp4 binary
+*.webm binary


### PR DESCRIPTION
## What

Adds a top-level `.gitattributes` that forces LF line endings on disk for every text file in this repo, regardless of the contributor's OS or global `core.autocrlf` setting.

## Why

Windows contributors currently see 50-100 phantom modified files immediately after a fresh `git clone` because Git for Windows auto-converts LF -> CRLF on checkout. That breaks `prettier --check` (which enforces `endOfLine: 'lf'`), which then breaks the Husky pre-commit hook on every file. Contributors end up using `--no-verify`, defeating the hook for everyone going forward in that session.

This file overrides that conversion for this specific repo.

## Behavior change

- None for existing repo content. The index is already LF; `git add --renormalize .` is a no-op.
- Fresh clones on Windows will now have a clean `git status`.
- `npm run format:check` will pass without anyone running `npm run format` first.

## Pilot

FreeForCharity/FFC-EX-mitchellnchistory.org#89 (CI green; merge pending). This PR uses identical content.

## Tracking

Refs FreeForCharity/FFC-Cloudflare-Automation#393.
