### PR TITLE
feat: add developer environment setup guides (Antigravity + VS Code)

### DIFF
--- a/__tests__/navigation-coverage.test.js
+++ b/__tests__/navigation-coverage.test.js
@@ -15,6 +15,7 @@ describe('Navigation Coverage', () => {
   const applicationPages = [
     { path: '/', name: 'Home' },
     { path: '/get-involved', name: 'Get Involved' },
+    { path: '/developer-environment-setup', name: 'Developer Environment Setup' },
     { path: '/tech-stack', name: 'Tech Stack' },
     { path: '/contributor-ladder', name: 'Contributor Ladder' },
     { path: '/documentation', name: 'Documentation' },

--- a/src/app/developer-environment-setup/google-antigravity/page.tsx
+++ b/src/app/developer-environment-setup/google-antigravity/page.tsx
@@ -271,8 +271,10 @@ export default function GoogleAntigravitySetupGuide() {
             <p>pnpm --version</p>
           </div>
           <p className="text-gray-600 text-xs mt-3">
-            If you already have Node but not pnpm, the quickest manual install is{' '}
-            <code className="bg-gray-200 px-1 rounded">npm install -g pnpm</code> — or just let the
+            If you already have Node but not pnpm, install the major version our repos pin in{' '}
+            <code className="bg-gray-200 px-1 rounded">package.json</code> with{' '}
+            <code className="bg-gray-200 px-1 rounded">npm install -g pnpm@9</code> (or run{' '}
+            <code className="bg-gray-200 px-1 rounded">corepack enable</code>) — or just let the
             agent handle it with the prompt above.
           </p>
         </section>
@@ -506,13 +508,15 @@ export default function GoogleAntigravitySetupGuide() {
               <p className="text-sm text-gray-700">
                 Have the agent run <code className="bg-gray-200 px-1 rounded">pnpm run format</code>
                 , <code className="bg-gray-200 px-1 rounded">pnpm run lint</code>,{' '}
-                <code className="bg-gray-200 px-1 rounded">pnpm test</code>,{' '}
-                <code className="bg-gray-200 px-1 rounded">pnpm run build</code>, and{' '}
-                <code className="bg-gray-200 px-1 rounded">pnpm run test:e2e</code>.
+                <code className="bg-gray-200 px-1 rounded">pnpm run build</code>,{' '}
+                <code className="bg-gray-200 px-1 rounded">pnpm test</code>, and{' '}
+                <code className="bg-gray-200 px-1 rounded">pnpm run test:e2e</code> — in that order,
+                which matches CI (build before tests, since some tests check the build output).
               </p>
               <PromptBox accent="emerald">
-                &ldquo;Run the full pre-commit checklist in order: <code>pnpm run format</code>,{' '}
-                <code>pnpm run lint</code>, <code>pnpm test</code>, <code>pnpm run build</code>, and{' '}
+                &ldquo;Run the full pre-commit checklist in this order, which matches CI:{' '}
+                <code>pnpm run format</code>, <code>pnpm run lint</code>,{' '}
+                <code>pnpm run build</code>, <code>pnpm test</code>, and{' '}
                 <code>pnpm run test:e2e</code>. Do not cancel anything. Fix any failures and re-run
                 until everything passes.&rdquo;
               </PromptBox>

--- a/src/app/developer-environment-setup/google-antigravity/page.tsx
+++ b/src/app/developer-environment-setup/google-antigravity/page.tsx
@@ -1,0 +1,633 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import Breadcrumbs from '@/components/Breadcrumbs'
+
+export const metadata: Metadata = {
+  title: 'Google Antigravity Setup',
+  description:
+    "Set up Google Antigravity, Google's agent-first IDE, for Free For Charity website development. Install it, sign in with a Google account, connect GitHub, and enable the Playwright and GitHub MCP servers so the AI agent can open issues, make PRs, and merge changes.",
+  keywords:
+    'Google Antigravity, agent IDE, Gemini, MCP servers, Playwright MCP, GitHub MCP, AI coding agent, Free For Charity, developer environment',
+}
+
+interface GuideSection {
+  id: string
+  number: string
+  title: string
+  icon: string
+}
+
+const sections: GuideSection[] = [
+  { id: 'overview', number: '1', title: 'What Antigravity Is', icon: '🚀' },
+  { id: 'install', number: '2', title: 'Download and Install', icon: '⬇️' },
+  { id: 'sign-in', number: '3', title: 'Sign In with Google', icon: '🔑' },
+  { id: 'tour', number: '4', title: 'Tour: Editor and Agent Manager', icon: '🧭' },
+  { id: 'core-tools', number: '5', title: 'Install Git, Node, and pnpm', icon: '🔧' },
+  { id: 'github', number: '6', title: 'Connect to GitHub', icon: '🐙' },
+  { id: 'mcp', number: '7', title: 'Enable MCP Servers', icon: '🔌' },
+  { id: 'clone', number: '8', title: 'Clone a Template Repo', icon: '📦' },
+  { id: 'first-change', number: '9', title: 'Your First Issue to Merge', icon: '🔁' },
+  { id: 'security', number: '10', title: 'Security and Good Habits', icon: '🛡️' },
+  { id: 'troubleshooting', number: '11', title: 'Troubleshooting', icon: '🩺' },
+]
+
+export default function GoogleAntigravitySetupGuide() {
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Breadcrumbs
+        items={[
+          { label: 'Home', href: '/' },
+          { label: 'Developer Environment Setup', href: '/developer-environment-setup' },
+          { label: 'Google Antigravity' },
+        ]}
+      />
+
+      {/* Header */}
+      <div className="bg-gradient-to-r from-emerald-600 to-teal-700 text-white py-16 px-4 sm:px-6 lg:px-8">
+        <div className="max-w-5xl mx-auto">
+          <div className="flex items-center mb-4">
+            <span className="text-5xl mr-4" aria-hidden="true">
+              🚀
+            </span>
+            <div>
+              <h1 className="text-3xl md:text-4xl font-bold">Google Antigravity Setup</h1>
+              <p className="text-emerald-100 text-sm mt-1">
+                Google&apos;s agent-first IDE for FFC website development
+              </p>
+            </div>
+          </div>
+          <p className="text-emerald-50 text-lg max-w-3xl">
+            Antigravity is a free, agent-first code editor built on the VS Code foundation. Its
+            built-in Gemini agents can plan work, write code, run our tests, and open pull requests
+            for you. This guide gets you from zero to opening your first FFC pull request.
+          </p>
+          <div className="mt-6 flex flex-wrap gap-3">
+            <span className="bg-white/15 px-3 py-1 rounded-full text-sm font-medium">
+              Free public preview
+            </span>
+            <span className="bg-white/15 px-3 py-1 rounded-full text-sm font-medium">
+              Sign in with Google
+            </span>
+            <span className="bg-white/15 px-3 py-1 rounded-full text-sm font-medium">
+              ~30 minutes
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <main className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        {/* TOC */}
+        <div className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-10">
+          <h2 className="text-2xl font-bold text-gray-900 mb-6">On this page</h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+            {sections.map((section) => (
+              <a
+                key={section.id}
+                href={`#${section.id}`}
+                className="flex items-center p-2 rounded-lg hover:bg-emerald-50 transition-colors group"
+              >
+                <span className="text-xl mr-3" aria-hidden="true">
+                  {section.icon}
+                </span>
+                <span className="text-sm font-medium text-gray-700 group-hover:text-emerald-700">
+                  <span className="text-emerald-600 font-bold mr-1">{section.number}.</span>
+                  {section.title}
+                </span>
+              </a>
+            ))}
+          </div>
+        </div>
+
+        {/* 1. Overview */}
+        <section id="overview" className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
+          <div className="flex items-center mb-6">
+            <span className="text-4xl mr-4" aria-hidden="true">
+              🚀
+            </span>
+            <h2 className="text-2xl font-bold text-gray-900">1. What Antigravity Is</h2>
+          </div>
+          <p className="text-gray-700 mb-4">
+            Google Antigravity reuses the open-source VS Code foundation, so the layout will feel
+            familiar, but it puts an <strong>AI agent</strong> at the center instead of the text
+            cursor. You describe a task in plain English and a Gemini-powered agent plans it, edits
+            files, runs commands, and reports back. FFC already maintains an{' '}
+            <a
+              href="https://github.com/FreeForCharity/FFC-IN-Antigravity-Static-site-agent"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-emerald-700 underline hover:text-emerald-900"
+            >
+              Antigravity static-site agent
+            </a>{' '}
+            repository, so this editor is a first-class part of our toolchain.
+          </p>
+          <div className="bg-emerald-50 border-l-4 border-emerald-600 p-4 rounded">
+            <p className="text-emerald-900 text-sm">
+              <strong>Why we like it for volunteers:</strong> the free public preview signs in with
+              an ordinary Google account, and the agent can do almost everything in this guide for
+              you once it is connected. When in doubt, ask the agent.
+            </p>
+          </div>
+        </section>
+
+        {/* 2. Install */}
+        <section id="install" className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
+          <div className="flex items-center mb-6">
+            <span className="text-4xl mr-4" aria-hidden="true">
+              ⬇️
+            </span>
+            <h2 className="text-2xl font-bold text-gray-900">2. Download and Install</h2>
+          </div>
+          <ol className="space-y-3 text-sm text-gray-700 list-decimal ml-5">
+            <li>
+              Go to{' '}
+              <a
+                href="https://antigravity.google"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-emerald-700 underline hover:text-emerald-900"
+              >
+                antigravity.google
+              </a>{' '}
+              and download the installer for your operating system (Windows, macOS, or a supported
+              Linux distribution).
+            </li>
+            <li>Run the installer and accept the defaults.</li>
+            <li>
+              Make sure you also have <strong>Google Chrome</strong> installed — Antigravity uses it
+              for the browser-driving agent features.
+            </li>
+            <li>Launch Antigravity.</li>
+          </ol>
+          <div className="mt-4 bg-blue-50 border-l-4 border-blue-600 p-4 rounded">
+            <p className="text-blue-900 text-sm">
+              <strong>Tip:</strong> Because Antigravity is a VS Code fork, when it offers to import
+              settings or asks about a color theme and keybindings, the VS Code defaults are a safe
+              choice.
+            </p>
+          </div>
+        </section>
+
+        {/* 3. Sign in */}
+        <section id="sign-in" className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
+          <div className="flex items-center mb-6">
+            <span className="text-4xl mr-4" aria-hidden="true">
+              🔑
+            </span>
+            <h2 className="text-2xl font-bold text-gray-900">3. Sign In with Google</h2>
+          </div>
+          <ol className="space-y-3 text-sm text-gray-700 list-decimal ml-5">
+            <li>
+              On first launch, Antigravity prompts you to sign in. Choose to sign in with Google.
+            </li>
+            <li>
+              Your browser opens. Sign in with your <strong>personal Gmail/Google account</strong> —
+              the free preview does not require a credit card or a paid plan.
+            </li>
+            <li>
+              After authentication, the browser shows a success message and hands you back to the
+              Antigravity app.
+            </li>
+          </ol>
+          <div className="mt-4 bg-amber-50 border-l-4 border-amber-500 p-4 rounded">
+            <p className="text-amber-900 text-sm">
+              <strong>If sign-in stalls</strong> (&ldquo;unexpected issue setting up your
+              account&rdquo;), close Antigravity completely, make sure Chrome is your default
+              browser or is at least installed, and try again. This is a common preview hiccup and
+              usually resolves on a second attempt.
+            </p>
+          </div>
+        </section>
+
+        {/* 4. Tour */}
+        <section id="tour" className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
+          <div className="flex items-center mb-6">
+            <span className="text-4xl mr-4" aria-hidden="true">
+              🧭
+            </span>
+            <h2 className="text-2xl font-bold text-gray-900">4. Tour: Editor and Agent Manager</h2>
+          </div>
+          <p className="text-gray-700 mb-4">
+            Antigravity has two primary surfaces. Knowing which is which saves a lot of confusion.
+          </p>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <div className="border border-gray-200 rounded-lg p-5">
+              <h3 className="font-bold text-gray-900 mb-2">📝 The Editor</h3>
+              <p className="text-sm text-gray-700">
+                The familiar VS Code-style window: file tree, open files, terminal, and source
+                control. Use it to read code, review the agent&apos;s changes, and run commands
+                yourself when you want to.
+              </p>
+            </div>
+            <div className="border border-gray-200 rounded-lg p-5">
+              <h3 className="font-bold text-gray-900 mb-2">🤖 The Agent Manager</h3>
+              <p className="text-sm text-gray-700">
+                Where you give the agent tasks and watch it work across plans, edits, and test runs.
+                This is where most of your FFC work happens: describe the issue, approve the plan,
+                and review the result.
+              </p>
+            </div>
+          </div>
+          <div className="mt-4 bg-blue-50 border-l-4 border-blue-600 p-4 rounded">
+            <p className="text-blue-900 text-sm">
+              Newer builds may be branded <strong>Antigravity 2.0</strong> and ship a companion{' '}
+              <strong>Antigravity CLI</strong>. They share the same agent harness and settings, so
+              this guide applies to both.
+            </p>
+          </div>
+        </section>
+
+        {/* 5. Core tools */}
+        <section id="core-tools" className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
+          <div className="flex items-center mb-6">
+            <span className="text-4xl mr-4" aria-hidden="true">
+              🔧
+            </span>
+            <h2 className="text-2xl font-bold text-gray-900">5. Install Git, Node, and pnpm</h2>
+          </div>
+          <p className="text-gray-700 mb-4">
+            FFC sites are Next.js projects, so you need Git, Node.js 20+ and pnpm. The easiest path
+            is to let the agent check and guide you.
+          </p>
+          <div className="bg-gray-900 text-gray-100 p-4 rounded-lg text-sm font-mono overflow-x-auto mb-4">
+            <p className="text-emerald-400"># Open the Editor terminal and verify versions</p>
+            <p>git --version</p>
+            <p>node --version &nbsp;&nbsp;# should be v20 or newer</p>
+            <p>pnpm --version</p>
+          </div>
+          <p className="text-gray-700 mb-2 text-sm">
+            If any command is &ldquo;not found,&rdquo; ask the Agent Manager:
+          </p>
+          <div className="bg-emerald-50 border border-emerald-200 rounded-lg p-4 text-sm text-emerald-900 italic">
+            &ldquo;Git / Node / pnpm is not installed on my [Windows/macOS/Linux] machine. Give me
+            the exact commands to install Node.js 20 LTS and pnpm, then verify the versions.&rdquo;
+          </div>
+          <p className="text-gray-600 text-xs mt-3">
+            If you already have Node, install pnpm with{' '}
+            <code className="bg-gray-200 px-1 rounded">npm install -g pnpm</code>.
+          </p>
+        </section>
+
+        {/* 6. GitHub */}
+        <section id="github" className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
+          <div className="flex items-center mb-6">
+            <span className="text-4xl mr-4" aria-hidden="true">
+              🐙
+            </span>
+            <h2 className="text-2xl font-bold text-gray-900">6. Connect to GitHub</h2>
+          </div>
+          <p className="text-gray-700 mb-4">
+            You connect to GitHub in two complementary ways: once for Git (so you can push branches)
+            and once for the GitHub MCP server (so the agent can manage issues and PRs — covered in
+            the next section).
+          </p>
+          <div className="space-y-5">
+            <div className="border-l-4 border-emerald-600 pl-4">
+              <h3 className="font-bold text-gray-900 mb-2">6.1 — Confirm org membership</h3>
+              <p className="text-sm text-gray-700">
+                Make sure a maintainer has added you to the{' '}
+                <a
+                  href="https://github.com/FreeForCharity"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-emerald-700 underline hover:text-emerald-900"
+                >
+                  FreeForCharity
+                </a>{' '}
+                GitHub organization. Accept the email invitation before continuing.
+              </p>
+            </div>
+            <div className="border-l-4 border-emerald-600 pl-4">
+              <h3 className="font-bold text-gray-900 mb-2">
+                6.2 — Sign in to GitHub in the editor
+              </h3>
+              <p className="text-sm text-gray-700 mb-2">
+                Use the built-in GitHub sign-in (Accounts / Source Control panel) and authorize in
+                the browser. This stores credentials securely so Git can push without pasting
+                passwords. You can confirm in the terminal:
+              </p>
+              <div className="bg-gray-900 text-gray-100 p-3 rounded-lg text-sm font-mono">
+                git config --global user.name &quot;Your Name&quot;
+                <br />
+                git config --global user.email &quot;you@example.com&quot;
+              </div>
+            </div>
+          </div>
+          <div className="mt-4 bg-amber-50 border-l-4 border-amber-500 p-4 rounded">
+            <p className="text-amber-900 text-sm">
+              Prefer the editor&apos;s built-in GitHub sign-in over a raw Personal Access Token
+              where possible. If a token is ever required, scope it narrowly and never commit it.
+            </p>
+          </div>
+        </section>
+
+        {/* 7. MCP */}
+        <section id="mcp" className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
+          <div className="flex items-center mb-6">
+            <span className="text-4xl mr-4" aria-hidden="true">
+              🔌
+            </span>
+            <h2 className="text-2xl font-bold text-gray-900">7. Enable MCP Servers</h2>
+          </div>
+          <p className="text-gray-700 mb-4">
+            MCP (Model Context Protocol) servers give the agent extra abilities. For FFC work you
+            need at least <strong>Playwright</strong> (browser testing) and <strong>GitHub</strong>{' '}
+            (issues and PRs). Antigravity offers two ways to add them.
+          </p>
+
+          <div className="space-y-6">
+            <div className="border-l-4 border-emerald-600 pl-4">
+              <h3 className="font-bold text-gray-900 mb-2">Option A — MCP Store (easiest)</h3>
+              <p className="text-sm text-gray-700">
+                Open the <strong>MCP Store</strong> from the Agent Manager / settings, search for
+                the server you want (for example <em>Playwright</em> or <em>GitHub</em>), and click{' '}
+                <strong>Install</strong>. Antigravity walks you through any sign-in the server
+                needs.
+              </p>
+            </div>
+
+            <div className="border-l-4 border-emerald-600 pl-4">
+              <h3 className="font-bold text-gray-900 mb-2">Option B — Edit the MCP config</h3>
+              <p className="text-sm text-gray-700 mb-2">
+                Open Antigravity&apos;s MCP configuration (Settings &rarr; search &ldquo;MCP&rdquo;
+                &rarr; <em>Edit configuration</em>). Antigravity uses the{' '}
+                <code className="bg-gray-200 px-1 rounded">mcpServers</code> key (the same style as
+                other VS Code-derived agent editors):
+              </p>
+              <div className="bg-gray-900 text-gray-100 p-4 rounded-lg text-xs font-mono overflow-x-auto">
+                <pre>{`{
+  "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": ["@playwright/mcp@latest"]
+    },
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"]
+    }
+  }
+}`}</pre>
+              </div>
+              <p className="text-sm text-gray-700 mt-2">
+                After saving, reload the agent. The new tools appear in the agent&apos;s tool list.
+              </p>
+            </div>
+          </div>
+
+          <div className="mt-5 bg-blue-50 border-l-4 border-blue-600 p-4 rounded">
+            <p className="text-blue-900 text-sm">
+              <strong>Let the agent do it:</strong> you can paste the JSON above into the Agent
+              Manager and say &ldquo;Add these MCP servers to my Antigravity configuration and
+              reload.&rdquo; First Playwright run will download a browser — that is expected.
+            </p>
+          </div>
+          <div className="mt-3 bg-amber-50 border-l-4 border-amber-500 p-4 rounded">
+            <p className="text-amber-900 text-sm">
+              The GitHub MCP server authenticates with a token. Provide it through the editor&apos;s
+              secure prompt or an environment variable —{' '}
+              <strong>never hard-code a token in the JSON file</strong>, which lives in your repo or
+              home folder.
+            </p>
+          </div>
+        </section>
+
+        {/* 8. Clone */}
+        <section id="clone" className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
+          <div className="flex items-center mb-6">
+            <span className="text-4xl mr-4" aria-hidden="true">
+              📦
+            </span>
+            <h2 className="text-2xl font-bold text-gray-900">8. Clone a Template Repo</h2>
+          </div>
+          <p className="text-gray-700 mb-4">
+            Practice on a real FFC repository. The{' '}
+            <a
+              href="https://github.com/FreeForCharity/FFC_Single_Page_Template"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-emerald-700 underline hover:text-emerald-900"
+            >
+              FFC_Single_Page_Template
+            </a>{' '}
+            is the starting point for new charity sites and ships the full toolchain.
+          </p>
+          <div className="bg-gray-900 text-gray-100 p-4 rounded-lg text-sm font-mono overflow-x-auto">
+            <p className="text-emerald-400"># Clone, install, and verify the toolchain</p>
+            <p>git clone https://github.com/FreeForCharity/FFC_Single_Page_Template.git</p>
+            <p>cd FFC_Single_Page_Template</p>
+            <p>pnpm install</p>
+            <p>pnpm run build</p>
+            <p>pnpm run test:e2e &nbsp;&nbsp;# exercises the Playwright setup</p>
+          </div>
+          <div className="mt-4 bg-blue-50 border-l-4 border-blue-600 p-4 rounded">
+            <p className="text-blue-900 text-sm">
+              In the Editor choose <strong>Open Folder</strong> and select the cloned directory, or
+              ask the agent: &ldquo;Clone FFC_Single_Page_Template, install dependencies, and run
+              the build and tests.&rdquo; Do not cancel the build or E2E tests — they can take a
+              minute.
+            </p>
+          </div>
+        </section>
+
+        {/* 9. First change */}
+        <section id="first-change" className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
+          <div className="flex items-center mb-6">
+            <span className="text-4xl mr-4" aria-hidden="true">
+              🔁
+            </span>
+            <h2 className="text-2xl font-bold text-gray-900">9. Your First Issue to Merge</h2>
+          </div>
+          <p className="text-gray-700 mb-4">
+            With the agent, GitHub MCP, and Playwright MCP connected, you can run the full FFC
+            contribution loop. Try a small, safe change such as fixing a typo.
+          </p>
+          <div className="space-y-4">
+            <div className="border-l-4 border-emerald-600 pl-4">
+              <h3 className="font-bold text-gray-900 mb-1">Step 1 — Pick or open an issue</h3>
+              <p className="text-sm text-gray-700">
+                Ask the agent to list open issues on the repo, or to open a new one describing your
+                change.
+              </p>
+            </div>
+            <div className="border-l-4 border-emerald-600 pl-4">
+              <h3 className="font-bold text-gray-900 mb-1">Step 2 — Branch and edit</h3>
+              <p className="text-sm text-gray-700">
+                Tell the agent to create a branch (never commit to{' '}
+                <code className="bg-gray-200 px-1 rounded">main</code>) and make the change. Review
+                the diff in the Editor.
+              </p>
+            </div>
+            <div className="border-l-4 border-emerald-600 pl-4">
+              <h3 className="font-bold text-gray-900 mb-1">Step 3 — Run the checks</h3>
+              <p className="text-sm text-gray-700">
+                Have the agent run <code className="bg-gray-200 px-1 rounded">pnpm run format</code>
+                , <code className="bg-gray-200 px-1 rounded">pnpm run lint</code>,{' '}
+                <code className="bg-gray-200 px-1 rounded">pnpm test</code>,{' '}
+                <code className="bg-gray-200 px-1 rounded">pnpm run build</code>, and{' '}
+                <code className="bg-gray-200 px-1 rounded">pnpm run test:e2e</code>.
+              </p>
+            </div>
+            <div className="border-l-4 border-emerald-600 pl-4">
+              <h3 className="font-bold text-gray-900 mb-1">Step 4 — Open a PR and merge</h3>
+              <p className="text-sm text-gray-700">
+                Using the GitHub MCP server, the agent commits with a{' '}
+                <a
+                  href="https://www.conventionalcommits.org/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-emerald-700 underline hover:text-emerald-900"
+                >
+                  Conventional Commit
+                </a>{' '}
+                message, pushes the branch, and opens a PR linked to the issue with{' '}
+                <code className="bg-gray-200 px-1 rounded">Fixes #NNN</code>. Once CI passes and a
+                maintainer approves, the PR merges into the repository.
+              </p>
+            </div>
+          </div>
+          <div className="mt-4 bg-green-50 border-l-4 border-green-600 p-4 rounded">
+            <p className="text-green-900 text-sm">
+              That is the whole loop. Every future change — on any FFC charity or website repo —
+              follows these same four steps.
+            </p>
+          </div>
+        </section>
+
+        {/* 10. Security */}
+        <section id="security" className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
+          <div className="flex items-center mb-6">
+            <span className="text-4xl mr-4" aria-hidden="true">
+              🛡️
+            </span>
+            <h2 className="text-2xl font-bold text-gray-900">10. Security and Good Habits</h2>
+          </div>
+          <ul className="space-y-2 text-sm text-gray-700">
+            <li className="flex items-start">
+              <span className="text-red-500 mr-2 mt-0.5">&#10005;</span>
+              <span>
+                Never paste tokens, passwords, or API keys into chat, code, commits, or the MCP
+                config file.
+              </span>
+            </li>
+            <li className="flex items-start">
+              <span className="text-emerald-600 mr-2 mt-0.5">&#10003;</span>
+              <span>
+                Use the editor&apos;s secure credential prompts or a local{' '}
+                <code className="bg-gray-200 px-1 rounded">.env</code> file (already git-ignored).
+              </span>
+            </li>
+            <li className="flex items-start">
+              <span className="text-emerald-600 mr-2 mt-0.5">&#10003;</span>
+              <span>
+                Always review the agent&apos;s diff and the commands it wants to run before
+                approving.
+              </span>
+            </li>
+            <li className="flex items-start">
+              <span className="text-emerald-600 mr-2 mt-0.5">&#10003;</span>
+              <span>Work on a branch and open a PR — never push directly to main.</span>
+            </li>
+          </ul>
+          <div className="mt-4 bg-amber-50 border-l-4 border-amber-500 p-4 rounded">
+            <p className="text-amber-900 text-sm">
+              See the FFC{' '}
+              <a
+                href="https://github.com/FreeForCharity/FFC-IN-ffcadmin.org/blob/main/.claude/rules/01-security.md"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-amber-900 underline"
+              >
+                security rules
+              </a>{' '}
+              for the full policy.
+            </p>
+          </div>
+        </section>
+
+        {/* 11. Troubleshooting */}
+        <section id="troubleshooting" className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
+          <div className="flex items-center mb-6">
+            <span className="text-4xl mr-4" aria-hidden="true">
+              🩺
+            </span>
+            <h2 className="text-2xl font-bold text-gray-900">11. Troubleshooting</h2>
+          </div>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm border-collapse">
+              <thead>
+                <tr className="bg-gray-100">
+                  <th className="text-left p-3 font-semibold text-gray-900 border border-gray-200">
+                    Symptom
+                  </th>
+                  <th className="text-left p-3 font-semibold text-gray-900 border border-gray-200">
+                    Fix
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td className="p-3 border border-gray-200">Sign-in fails or loops</td>
+                  <td className="p-3 border border-gray-200">
+                    Fully quit and reopen; ensure Chrome is installed; retry. It usually works on
+                    the second attempt.
+                  </td>
+                </tr>
+                <tr className="bg-gray-50">
+                  <td className="p-3 border border-gray-200">MCP tools not showing</td>
+                  <td className="p-3 border border-gray-200">
+                    Reload the agent after editing the config; confirm{' '}
+                    <code className="bg-gray-200 px-1 rounded">mcpServers</code> (not{' '}
+                    <code className="bg-gray-200 px-1 rounded">servers</code>) is the root key.
+                  </td>
+                </tr>
+                <tr>
+                  <td className="p-3 border border-gray-200">Playwright cannot launch a browser</td>
+                  <td className="p-3 border border-gray-200">
+                    Run{' '}
+                    <code className="bg-gray-200 px-1 rounded">pnpm exec playwright install</code>{' '}
+                    once to download browsers.
+                  </td>
+                </tr>
+                <tr className="bg-gray-50">
+                  <td className="p-3 border border-gray-200">Push rejected</td>
+                  <td className="p-3 border border-gray-200">
+                    Confirm FreeForCharity org membership and that you are on a branch, not{' '}
+                    <code className="bg-gray-200 px-1 rounded">main</code>.
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        {/* Footer nav */}
+        <div className="bg-gradient-to-br from-gray-50 to-emerald-50 rounded-xl shadow-lg p-6 md:p-8 border border-gray-200">
+          <h2 className="text-xl font-bold text-gray-900 mb-4">Related</h2>
+          <ul className="space-y-2 text-sm text-gray-700">
+            <li>
+              <Link
+                href="/developer-environment-setup"
+                className="text-emerald-700 underline hover:text-emerald-900"
+              >
+                &larr; Back to Developer Environment Setup
+              </Link>
+            </li>
+            <li>
+              <Link
+                href="/developer-environment-setup/vscode"
+                className="text-emerald-700 underline hover:text-emerald-900"
+              >
+                Prefer VS Code? Read the VS Code setup guide
+              </Link>
+            </li>
+            <li>
+              <Link href="/testing" className="text-emerald-700 underline hover:text-emerald-900">
+                How Playwright fits into our testing strategy
+              </Link>
+            </li>
+          </ul>
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/src/app/developer-environment-setup/google-antigravity/page.tsx
+++ b/src/app/developer-environment-setup/google-antigravity/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
 import Breadcrumbs from '@/components/Breadcrumbs'
+import PromptBox from '@/components/PromptBox'
 
 export const metadata: Metadata = {
   title: 'Google Antigravity Setup',
@@ -246,25 +247,33 @@ export default function GoogleAntigravitySetupGuide() {
             <h2 className="text-2xl font-bold text-gray-900">5. Install Git, Node, and pnpm</h2>
           </div>
           <p className="text-gray-700 mb-4">
-            FFC sites are Next.js projects, so you need Git, Node.js 20+ and pnpm. The easiest path
-            is to let the agent check and guide you.
+            FFC sites are Next.js projects, so you need Git, Node.js 20+ and pnpm.{' '}
+            <strong>The recommended way to install them is to let the agent do it for you.</strong>{' '}
+            Open the Agent Manager and paste the prompt below — the agent will detect your operating
+            system, run the installs, and verify the versions.
           </p>
-          <div className="bg-gray-900 text-gray-100 p-4 rounded-lg text-sm font-mono overflow-x-auto mb-4">
-            <p className="text-emerald-400"># Open the Editor terminal and verify versions</p>
+          <PromptBox accent="emerald">
+            &ldquo;Set up my machine for Free For Charity Next.js development. Check whether Git,
+            Node.js 20 LTS or newer, and pnpm are installed. For anything missing, install it using
+            the right method for my operating system, then run <code>git --version</code>,{' '}
+            <code>node --version</code>, and <code>pnpm --version</code> and show me the output to
+            confirm everything works.&rdquo;
+          </PromptBox>
+          <p className="text-gray-700 mt-4 mb-2 text-sm">
+            Prefer to check by hand first? Open the Editor terminal and run:
+          </p>
+          <div className="bg-gray-900 text-gray-100 p-4 rounded-lg text-sm font-mono overflow-x-auto">
+            <p className="text-emerald-400">
+              # Verify versions (the agent can install anything missing)
+            </p>
             <p>git --version</p>
             <p>node --version &nbsp;&nbsp;# should be v20 or newer</p>
             <p>pnpm --version</p>
           </div>
-          <p className="text-gray-700 mb-2 text-sm">
-            If any command is &ldquo;not found,&rdquo; ask the Agent Manager:
-          </p>
-          <div className="bg-emerald-50 border border-emerald-200 rounded-lg p-4 text-sm text-emerald-900 italic">
-            &ldquo;Git / Node / pnpm is not installed on my [Windows/macOS/Linux] machine. Give me
-            the exact commands to install Node.js 20 LTS and pnpm, then verify the versions.&rdquo;
-          </div>
           <p className="text-gray-600 text-xs mt-3">
-            If you already have Node, install pnpm with{' '}
-            <code className="bg-gray-200 px-1 rounded">npm install -g pnpm</code>.
+            If you already have Node but not pnpm, the quickest manual install is{' '}
+            <code className="bg-gray-200 px-1 rounded">npm install -g pnpm</code> — or just let the
+            agent handle it with the prompt above.
           </p>
         </section>
 
@@ -313,6 +322,12 @@ export default function GoogleAntigravitySetupGuide() {
               </div>
             </div>
           </div>
+          <PromptBox accent="emerald">
+            &ldquo;Help me connect this editor to GitHub. Set my global Git <code>user.name</code>{' '}
+            and <code>user.email</code>, confirm I am signed in to GitHub, and verify I have access
+            to the FreeForCharity organization. Walk me through any browser authorization that is
+            needed.&rdquo;
+          </PromptBox>
           <div className="mt-4 bg-amber-50 border-l-4 border-amber-500 p-4 rounded">
             <p className="text-amber-900 text-sm">
               Prefer the editor&apos;s built-in GitHub sign-in over a raw Personal Access Token
@@ -374,13 +389,20 @@ export default function GoogleAntigravitySetupGuide() {
             </div>
           </div>
 
-          <div className="mt-5 bg-blue-50 border-l-4 border-blue-600 p-4 rounded">
-            <p className="text-blue-900 text-sm">
-              <strong>Let the agent do it:</strong> you can paste the JSON above into the Agent
-              Manager and say &ldquo;Add these MCP servers to my Antigravity configuration and
-              reload.&rdquo; First Playwright run will download a browser — that is expected.
-            </p>
-          </div>
+          <p className="text-gray-700 mt-5 mb-1 text-sm">
+            <strong>Recommended:</strong> let the agent add the servers for you. Paste this into the
+            Agent Manager:
+          </p>
+          <PromptBox accent="emerald">
+            &ldquo;Add the Playwright and GitHub MCP servers to my Antigravity configuration. Use{' '}
+            <code>npx @playwright/mcp@latest</code> for Playwright and{' '}
+            <code>npx -y @modelcontextprotocol/server-github</code> for GitHub under the{' '}
+            <code>mcpServers</code> key. Then reload so the new tools are available, and confirm
+            they are connected.&rdquo;
+          </PromptBox>
+          <p className="text-gray-600 text-xs mt-2">
+            The first Playwright run downloads a browser — that is expected.
+          </p>
           <div className="mt-3 bg-amber-50 border-l-4 border-amber-500 p-4 rounded">
             <p className="text-amber-900 text-sm">
               The GitHub MCP server authenticates with a token. Provide it through the editor&apos;s
@@ -411,6 +433,20 @@ export default function GoogleAntigravitySetupGuide() {
             </a>{' '}
             is the starting point for new charity sites and ships the full toolchain.
           </p>
+          <p className="text-gray-700 mb-1 text-sm">
+            <strong>Recommended:</strong> have the agent clone and verify the repo. Paste this into
+            the Agent Manager:
+          </p>
+          <PromptBox accent="emerald">
+            &ldquo;Clone the repository{' '}
+            <code>https://github.com/FreeForCharity/FFC_Single_Page_Template.git</code>, open it,
+            install dependencies with <code>pnpm install</code>, then run{' '}
+            <code>pnpm run build</code> and <code>pnpm run test:e2e</code>. Do not cancel
+            long-running commands. Tell me if anything fails and how to fix it.&rdquo;
+          </PromptBox>
+          <p className="text-gray-700 mt-4 mb-2 text-sm">
+            Prefer to do it by hand? The equivalent commands are:
+          </p>
           <div className="bg-gray-900 text-gray-100 p-4 rounded-lg text-sm font-mono overflow-x-auto">
             <p className="text-emerald-400"># Clone, install, and verify the toolchain</p>
             <p>git clone https://github.com/FreeForCharity/FFC_Single_Page_Template.git</p>
@@ -421,10 +457,8 @@ export default function GoogleAntigravitySetupGuide() {
           </div>
           <div className="mt-4 bg-blue-50 border-l-4 border-blue-600 p-4 rounded">
             <p className="text-blue-900 text-sm">
-              In the Editor choose <strong>Open Folder</strong> and select the cloned directory, or
-              ask the agent: &ldquo;Clone FFC_Single_Page_Template, install dependencies, and run
-              the build and tests.&rdquo; Do not cancel the build or E2E tests — they can take a
-              minute.
+              In the Editor you can also choose <strong>Open Folder</strong> to open the cloned
+              directory. Do not cancel the build or E2E tests — they can take a minute.
             </p>
           </div>
         </section>
@@ -448,6 +482,11 @@ export default function GoogleAntigravitySetupGuide() {
                 Ask the agent to list open issues on the repo, or to open a new one describing your
                 change.
               </p>
+              <PromptBox accent="emerald">
+                &ldquo;Using the GitHub MCP server, list the open issues on this repository. If
+                there is no issue for the small change I want to make, open a new issue titled
+                &lsquo;&lt;short title&gt;&rsquo; describing it.&rdquo;
+              </PromptBox>
             </div>
             <div className="border-l-4 border-emerald-600 pl-4">
               <h3 className="font-bold text-gray-900 mb-1">Step 2 — Branch and edit</h3>
@@ -456,6 +495,11 @@ export default function GoogleAntigravitySetupGuide() {
                 <code className="bg-gray-200 px-1 rounded">main</code>) and make the change. Review
                 the diff in the Editor.
               </p>
+              <PromptBox accent="emerald">
+                &ldquo;Create a new branch for issue #&lt;number&gt; (do not commit to{' '}
+                <code>main</code>), then make the change it describes. When you are done, show me
+                the full diff so I can review it before we go further.&rdquo;
+              </PromptBox>
             </div>
             <div className="border-l-4 border-emerald-600 pl-4">
               <h3 className="font-bold text-gray-900 mb-1">Step 3 — Run the checks</h3>
@@ -466,6 +510,12 @@ export default function GoogleAntigravitySetupGuide() {
                 <code className="bg-gray-200 px-1 rounded">pnpm run build</code>, and{' '}
                 <code className="bg-gray-200 px-1 rounded">pnpm run test:e2e</code>.
               </p>
+              <PromptBox accent="emerald">
+                &ldquo;Run the full pre-commit checklist in order: <code>pnpm run format</code>,{' '}
+                <code>pnpm run lint</code>, <code>pnpm test</code>, <code>pnpm run build</code>, and{' '}
+                <code>pnpm run test:e2e</code>. Do not cancel anything. Fix any failures and re-run
+                until everything passes.&rdquo;
+              </PromptBox>
             </div>
             <div className="border-l-4 border-emerald-600 pl-4">
               <h3 className="font-bold text-gray-900 mb-1">Step 4 — Open a PR and merge</h3>
@@ -483,6 +533,11 @@ export default function GoogleAntigravitySetupGuide() {
                 <code className="bg-gray-200 px-1 rounded">Fixes #NNN</code>. Once CI passes and a
                 maintainer approves, the PR merges into the repository.
               </p>
+              <PromptBox accent="emerald">
+                &ldquo;Commit the changes with a Conventional Commit message, push the branch, and
+                open a pull request that links the issue with &lsquo;Fixes #&lt;number&gt;&rsquo;.
+                Then watch the CI checks and fix anything that fails until they are green.&rdquo;
+              </PromptBox>
             </div>
           </div>
           <div className="mt-4 bg-green-50 border-l-4 border-green-600 p-4 rounded">

--- a/src/app/developer-environment-setup/page.tsx
+++ b/src/app/developer-environment-setup/page.tsx
@@ -68,7 +68,7 @@ const loopSteps: Step[] = [
     number: '2',
     title: 'Branch & build',
     description:
-      'The agent creates a branch, edits files, and runs the local checks (format, lint, test, build) for you.',
+      'The agent creates a branch, edits files, and runs the local checks (format, lint, build, test) for you.',
   },
   {
     number: '3',
@@ -267,8 +267,12 @@ export default function DeveloperEnvironmentSetupPage() {
                 <li className="flex items-start">
                   <span className="text-blue-600 mr-2 font-bold">3.</span>
                   <span>
-                    <strong>pnpm</strong> &mdash; package manager (
-                    <code className="bg-gray-200 px-1 rounded">npm install -g pnpm</code>)
+                    <strong>pnpm</strong> &mdash; package manager. Our repos pin pnpm 9 via{' '}
+                    <code className="bg-gray-200 px-1 rounded">package.json</code>, so install the
+                    matching major with{' '}
+                    <code className="bg-gray-200 px-1 rounded">npm install -g pnpm@9</code> (or run{' '}
+                    <code className="bg-gray-200 px-1 rounded">corepack enable</code> to use the
+                    pinned version automatically)
                   </span>
                 </li>
                 <li className="flex items-start">
@@ -429,7 +433,7 @@ export default function DeveloperEnvironmentSetupPage() {
           <div className="mt-6 bg-green-50 border-l-4 border-green-600 p-4 rounded">
             <p className="text-green-900 text-sm">
               <strong>Never push directly to main.</strong> Every change goes through a branch and a
-              pull request, and CI checks (format, lint, tests, build, Playwright) must pass before
+              pull request, and CI checks (format, lint, build, tests, Playwright) must pass before
               merge. Your AI agent follows this rule automatically when it is set up correctly.
             </p>
           </div>

--- a/src/app/developer-environment-setup/page.tsx
+++ b/src/app/developer-environment-setup/page.tsx
@@ -1,0 +1,561 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import Breadcrumbs from '@/components/Breadcrumbs'
+
+export const metadata: Metadata = {
+  title: 'Developer Environment Setup',
+  description:
+    'Set up your individual developer environment for Free For Charity website development and digital infrastructure. Choose Google Antigravity or Microsoft VS Code, connect to GitHub, and enable MCP servers so AI agents can open issues, make PRs, and merge changes.',
+  keywords:
+    'developer environment, Google Antigravity, VS Code, MCP servers, Playwright, GitHub, AI agents, Free For Charity, nonprofit web development',
+}
+
+interface EnvironmentCard {
+  href: string
+  name: string
+  tagline: string
+  bestFor: string
+  gradient: string
+  emoji: string
+  bullets: string[]
+}
+
+const environments: EnvironmentCard[] = [
+  {
+    href: '/developer-environment-setup/google-antigravity',
+    name: 'Google Antigravity',
+    tagline: "Google's agent-first IDE",
+    bestFor: 'Volunteers who want an AI agent to drive most of the work',
+    gradient: 'from-emerald-500 to-teal-600',
+    emoji: '🚀',
+    bullets: [
+      'Free public preview — sign in with a personal Google/Gmail account',
+      'Built on the VS Code foundation, with a dedicated Agent Manager',
+      'Built-in Gemini agents plan, write, test, and open PRs for you',
+      'MCP Store for one-click server installs (Playwright, GitHub, and more)',
+    ],
+  },
+  {
+    href: '/developer-environment-setup/vscode',
+    name: 'Microsoft VS Code',
+    tagline: 'The industry-standard editor',
+    bestFor: 'Volunteers who want a familiar, widely documented editor',
+    gradient: 'from-blue-500 to-indigo-600',
+    emoji: '🧩',
+    bullets: [
+      'Free and open source on Windows, macOS, and Linux',
+      'GitHub Copilot free tier provides the built-in AI agent',
+      'MCP servers configured through .vscode/mcp.json (shared in the repo)',
+      'Huge extension ecosystem and the largest community knowledge base',
+    ],
+  },
+]
+
+interface Step {
+  number: string
+  title: string
+  description: string
+}
+
+const loopSteps: Step[] = [
+  {
+    number: '1',
+    title: 'Pick up an Issue',
+    description:
+      'Every change starts from a GitHub Issue. Your AI agent can read the issue, ask clarifying questions, and plan the work.',
+  },
+  {
+    number: '2',
+    title: 'Branch & build',
+    description:
+      'The agent creates a branch, edits files, and runs the local checks (format, lint, test, build) for you.',
+  },
+  {
+    number: '3',
+    title: 'Open a Pull Request',
+    description:
+      'With the GitHub MCP server connected, the agent opens a PR, links it to the issue, and watches CI.',
+  },
+  {
+    number: '4',
+    title: 'Review & merge',
+    description:
+      'You review the diff, the agent fixes any CI failures, and once checks pass the change merges into the charity or website repository.',
+  },
+]
+
+export default function DeveloperEnvironmentSetupPage() {
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Breadcrumbs
+        items={[{ label: 'Home', href: '/' }, { label: 'Developer Environment Setup' }]}
+      />
+
+      {/* Hero */}
+      <div className="bg-gradient-to-r from-emerald-600 to-blue-700 text-white py-16 px-4 sm:px-6 lg:px-8">
+        <div className="max-w-5xl mx-auto">
+          <div className="flex items-center mb-4">
+            <span className="text-5xl mr-4" aria-hidden="true">
+              💻
+            </span>
+            <div>
+              <h1 className="text-3xl md:text-4xl font-bold">Developer Environment Setup</h1>
+              <p className="text-emerald-100 text-sm mt-1">
+                For Free For Charity website development &amp; digital infrastructure
+              </p>
+            </div>
+          </div>
+          <p className="text-emerald-50 text-lg max-w-3xl">
+            This is the starting point for every Free For Charity volunteer developer. Set up your
+            own computer once, connect it to GitHub, and enable the AI agents and MCP servers our
+            template repositories rely on. From there you can open issues, make pull requests, and
+            merge changes into FFC charity and website repositories — with an AI agent doing most of
+            the heavy lifting.
+          </p>
+          <div className="mt-6 flex flex-wrap gap-3">
+            <span className="bg-white/15 px-3 py-1 rounded-full text-sm font-medium">
+              100% free tooling
+            </span>
+            <span className="bg-white/15 px-3 py-1 rounded-full text-sm font-medium">
+              AI-agent assisted
+            </span>
+            <span className="bg-white/15 px-3 py-1 rounded-full text-sm font-medium">
+              Last updated: May 2026
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <main className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        {/* What is this */}
+        <section className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
+          <h2 className="text-2xl font-bold text-gray-900 mb-4">What you are setting up</h2>
+          <p className="text-gray-700 mb-4">
+            A Free For Charity development environment is a code editor on your own computer that is
+            connected to GitHub and supercharged with an AI agent. The agent can read our code, run
+            our tests, and talk to GitHub on your behalf through <strong>MCP servers</strong> (Model
+            Context Protocol) — small connectors that give the agent superpowers such as driving a
+            browser for Playwright tests or opening pull requests.
+          </p>
+          <div className="bg-emerald-50 border-l-4 border-emerald-600 p-4 rounded">
+            <p className="text-emerald-900 text-sm">
+              <strong>The big idea:</strong> You do not need to be a senior engineer. Both editors
+              below ship with a free AI agent. Your job is to install the environment once, point it
+              at our repositories, and then <em>describe what you want in plain English</em>. The
+              agent writes the code, runs the checks, and prepares the pull request.
+            </p>
+          </div>
+        </section>
+
+        {/* Choose your environment */}
+        <section className="mb-8">
+          <h2 className="text-2xl font-bold text-gray-900 mb-2 px-1">Choose your environment</h2>
+          <p className="text-gray-600 mb-6 px-1">
+            Pick one to start. You can install both later — the GitHub workflow is identical.
+          </p>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            {environments.map((env) => (
+              <Link
+                key={env.href}
+                href={env.href}
+                className="block bg-white rounded-xl shadow-lg border border-gray-200 overflow-hidden hover:shadow-xl transition-shadow"
+              >
+                <div
+                  className={`bg-gradient-to-br ${env.gradient} p-6 flex items-center gap-4 text-white`}
+                >
+                  <span className="text-4xl" aria-hidden="true">
+                    {env.emoji}
+                  </span>
+                  <div>
+                    <h3 className="text-xl font-bold">{env.name}</h3>
+                    <p className="text-white/90 text-sm">{env.tagline}</p>
+                  </div>
+                </div>
+                <div className="p-6">
+                  <p className="text-xs uppercase tracking-wide text-gray-500 font-semibold mb-1">
+                    Best for
+                  </p>
+                  <p className="text-sm text-gray-700 mb-4">{env.bestFor}</p>
+                  <ul className="space-y-2 text-sm text-gray-700">
+                    {env.bullets.map((bullet) => (
+                      <li key={bullet} className="flex items-start">
+                        <span className="text-emerald-600 mr-2 mt-0.5">&#10003;</span>
+                        <span>{bullet}</span>
+                      </li>
+                    ))}
+                  </ul>
+                  <span className="mt-5 inline-flex items-center text-sm font-semibold text-blue-700">
+                    Open the {env.name} guide
+                    <svg
+                      className="w-4 h-4 ml-1"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                      aria-hidden="true"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M9 5l7 7-7 7"
+                      />
+                    </svg>
+                  </span>
+                </div>
+              </Link>
+            ))}
+          </div>
+        </section>
+
+        {/* Shared prerequisites */}
+        <section className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
+          <div className="flex items-center mb-6">
+            <span className="text-4xl mr-4" aria-hidden="true">
+              ✅
+            </span>
+            <div>
+              <h2 className="text-2xl font-bold text-gray-900">Shared prerequisites</h2>
+              <p className="text-gray-600">
+                The same accounts and tools are needed whichever editor you choose
+              </p>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <div>
+              <h3 className="font-bold text-gray-900 mb-3">Accounts (free)</h3>
+              <ul className="space-y-2 text-sm text-gray-700">
+                <li className="flex items-start">
+                  <span className="text-blue-600 mr-2 font-bold">1.</span>
+                  <span>
+                    A <strong>GitHub account</strong>. Ask a maintainer to add you to the{' '}
+                    <a
+                      href="https://github.com/FreeForCharity"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-blue-600 underline hover:text-blue-800"
+                    >
+                      FreeForCharity
+                    </a>{' '}
+                    organization.
+                  </span>
+                </li>
+                <li className="flex items-start">
+                  <span className="text-blue-600 mr-2 font-bold">2.</span>
+                  <span>
+                    A <strong>Google/Gmail account</strong> (for Antigravity&apos;s free AI agent),
+                    or your GitHub account (for VS Code&apos;s Copilot free tier).
+                  </span>
+                </li>
+              </ul>
+            </div>
+            <div>
+              <h3 className="font-bold text-gray-900 mb-3">Core tools (free)</h3>
+              <ul className="space-y-2 text-sm text-gray-700">
+                <li className="flex items-start">
+                  <span className="text-blue-600 mr-2 font-bold">1.</span>
+                  <span>
+                    <strong>Git</strong> &mdash; version control
+                  </span>
+                </li>
+                <li className="flex items-start">
+                  <span className="text-blue-600 mr-2 font-bold">2.</span>
+                  <span>
+                    <strong>Node.js 20 LTS or newer</strong> &mdash; JavaScript runtime
+                  </span>
+                </li>
+                <li className="flex items-start">
+                  <span className="text-blue-600 mr-2 font-bold">3.</span>
+                  <span>
+                    <strong>pnpm</strong> &mdash; package manager (
+                    <code className="bg-gray-200 px-1 rounded">npm install -g pnpm</code>)
+                  </span>
+                </li>
+                <li className="flex items-start">
+                  <span className="text-blue-600 mr-2 font-bold">4.</span>
+                  <span>
+                    Your chosen <strong>editor</strong> &mdash; Antigravity or VS Code
+                  </span>
+                </li>
+              </ul>
+            </div>
+          </div>
+
+          <div className="mt-6 bg-blue-50 border-l-4 border-blue-600 p-4 rounded">
+            <p className="text-blue-900 text-sm">
+              <strong>Let the agent install things.</strong> You do not have to memorize install
+              commands. Once your editor and its AI agent are running, you can say: &ldquo;Check
+              whether Git, Node 20+, and pnpm are installed, and if not, tell me exactly how to
+              install them for my operating system.&rdquo; The agent will guide you step by step.
+            </p>
+          </div>
+        </section>
+
+        {/* MCP servers */}
+        <section className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
+          <div className="flex items-center mb-6">
+            <span className="text-4xl mr-4" aria-hidden="true">
+              🔌
+            </span>
+            <div>
+              <h2 className="text-2xl font-bold text-gray-900">
+                MCP servers used across our template repositories
+              </h2>
+              <p className="text-gray-600">
+                These connectors give your AI agent the abilities our workflow depends on
+              </p>
+            </div>
+          </div>
+
+          <p className="text-gray-700 mb-4">
+            Each environment guide shows the exact configuration. At a minimum, enable{' '}
+            <strong>GitHub</strong> and <strong>Playwright</strong>. The others are useful depending
+            on what you are working on.
+          </p>
+
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm border-collapse">
+              <thead>
+                <tr className="bg-gray-100">
+                  <th className="text-left p-3 font-semibold text-gray-900 border border-gray-200">
+                    MCP Server
+                  </th>
+                  <th className="text-left p-3 font-semibold text-gray-900 border border-gray-200">
+                    What it lets the agent do
+                  </th>
+                  <th className="text-left p-3 font-semibold text-gray-900 border border-gray-200">
+                    Priority
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td className="p-3 border border-gray-200 font-medium">GitHub</td>
+                  <td className="p-3 border border-gray-200">
+                    Read and create issues, open pull requests, review CI status, and merge
+                  </td>
+                  <td className="p-3 border border-gray-200 text-red-700 font-semibold">
+                    Required
+                  </td>
+                </tr>
+                <tr className="bg-gray-50">
+                  <td className="p-3 border border-gray-200 font-medium">Playwright</td>
+                  <td className="p-3 border border-gray-200">
+                    Drive a real browser to run and debug our end-to-end (E2E) tests
+                  </td>
+                  <td className="p-3 border border-gray-200 text-red-700 font-semibold">
+                    Required
+                  </td>
+                </tr>
+                <tr>
+                  <td className="p-3 border border-gray-200 font-medium">Cloudflare</td>
+                  <td className="p-3 border border-gray-200">
+                    Inspect DNS records and Pages deployments for charity domains
+                  </td>
+                  <td className="p-3 border border-gray-200 text-amber-700 font-semibold">
+                    Optional
+                  </td>
+                </tr>
+                <tr className="bg-gray-50">
+                  <td className="p-3 border border-gray-200 font-medium">Microsoft Learn Docs</td>
+                  <td className="p-3 border border-gray-200">
+                    Pull official Microsoft 365 / Azure documentation while working on admin tasks
+                  </td>
+                  <td className="p-3 border border-gray-200 text-amber-700 font-semibold">
+                    Optional
+                  </td>
+                </tr>
+                <tr>
+                  <td className="p-3 border border-gray-200 font-medium">Sentry</td>
+                  <td className="p-3 border border-gray-200">
+                    Look up production errors and performance issues for deployed sites
+                  </td>
+                  <td className="p-3 border border-gray-200 text-amber-700 font-semibold">
+                    Optional
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <div className="mt-6 bg-amber-50 border-l-4 border-amber-500 p-4 rounded">
+            <p className="text-amber-900 text-sm">
+              <strong>Security:</strong> MCP servers that talk to GitHub, Cloudflare, or Sentry need
+              an access token.{' '}
+              <strong>Never paste a token into a file, a commit, or a chat message.</strong> Store
+              it where the editor tells you (a local credential prompt or an environment variable),
+              use the narrowest scope possible, and rotate it regularly. See our{' '}
+              <a
+                href="https://github.com/FreeForCharity/FFC-IN-ffcadmin.org/blob/main/.claude/rules/01-security.md"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-amber-900 underline"
+              >
+                security rules
+              </a>
+              .
+            </p>
+          </div>
+        </section>
+
+        {/* The contribution loop */}
+        <section className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
+          <div className="flex items-center mb-6">
+            <span className="text-4xl mr-4" aria-hidden="true">
+              🔁
+            </span>
+            <div>
+              <h2 className="text-2xl font-bold text-gray-900">
+                What you will be able to do: the contribution loop
+              </h2>
+              <p className="text-gray-600">
+                The same four steps power every change, on every FFC repository
+              </p>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            {loopSteps.map((step) => (
+              <div key={step.number} className="border-l-4 border-blue-600 pl-4">
+                <h3 className="font-bold text-gray-900 mb-1">
+                  <span className="text-blue-600 mr-1">{step.number}.</span>
+                  {step.title}
+                </h3>
+                <p className="text-sm text-gray-700">{step.description}</p>
+              </div>
+            ))}
+          </div>
+
+          <div className="mt-6 bg-green-50 border-l-4 border-green-600 p-4 rounded">
+            <p className="text-green-900 text-sm">
+              <strong>Never push directly to main.</strong> Every change goes through a branch and a
+              pull request, and CI checks (format, lint, tests, build, Playwright) must pass before
+              merge. Your AI agent follows this rule automatically when it is set up correctly.
+            </p>
+          </div>
+        </section>
+
+        {/* Comparison */}
+        <section className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
+          <div className="flex items-center mb-6">
+            <span className="text-4xl mr-4" aria-hidden="true">
+              ⚖️
+            </span>
+            <div>
+              <h2 className="text-2xl font-bold text-gray-900">
+                Antigravity vs VS Code at a glance
+              </h2>
+              <p className="text-gray-600">Both reach the same finish line — pick what fits you</p>
+            </div>
+          </div>
+
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm border-collapse">
+              <thead>
+                <tr className="bg-gray-100">
+                  <th className="text-left p-3 font-semibold text-gray-900 border border-gray-200">
+                    Topic
+                  </th>
+                  <th className="text-left p-3 font-semibold text-gray-900 border border-gray-200">
+                    Google Antigravity
+                  </th>
+                  <th className="text-left p-3 font-semibold text-gray-900 border border-gray-200">
+                    Microsoft VS Code
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td className="p-3 border border-gray-200 font-medium">Built-in AI agent</td>
+                  <td className="p-3 border border-gray-200">Gemini agents in the Agent Manager</td>
+                  <td className="p-3 border border-gray-200">GitHub Copilot (agent mode)</td>
+                </tr>
+                <tr className="bg-gray-50">
+                  <td className="p-3 border border-gray-200 font-medium">Sign in with</td>
+                  <td className="p-3 border border-gray-200">Personal Google/Gmail account</td>
+                  <td className="p-3 border border-gray-200">GitHub account</td>
+                </tr>
+                <tr>
+                  <td className="p-3 border border-gray-200 font-medium">MCP config</td>
+                  <td className="p-3 border border-gray-200">
+                    MCP Store + <code className="bg-gray-200 px-1 rounded">mcpServers</code> config
+                  </td>
+                  <td className="p-3 border border-gray-200">
+                    <code className="bg-gray-200 px-1 rounded">.vscode/mcp.json</code> with{' '}
+                    <code className="bg-gray-200 px-1 rounded">servers</code> key
+                  </td>
+                </tr>
+                <tr className="bg-gray-50">
+                  <td className="p-3 border border-gray-200 font-medium">Maturity</td>
+                  <td className="p-3 border border-gray-200">Newer, free public preview</td>
+                  <td className="p-3 border border-gray-200">
+                    Long established, largest community
+                  </td>
+                </tr>
+                <tr>
+                  <td className="p-3 border border-gray-200 font-medium">Foundation</td>
+                  <td className="p-3 border border-gray-200">Fork of VS Code (familiar layout)</td>
+                  <td className="p-3 border border-gray-200">The original VS Code</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        {/* Related links */}
+        <section className="bg-gradient-to-br from-gray-50 to-emerald-50 rounded-xl shadow-lg p-6 md:p-8 border border-gray-200">
+          <h2 className="text-xl font-bold text-gray-900 mb-4">Where to go next</h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <ul className="space-y-2 text-sm text-gray-700">
+              <li>
+                <Link
+                  href="/developer-environment-setup/google-antigravity"
+                  className="text-blue-600 underline hover:text-blue-800"
+                >
+                  Google Antigravity setup guide
+                </Link>
+              </li>
+              <li>
+                <Link
+                  href="/developer-environment-setup/vscode"
+                  className="text-blue-600 underline hover:text-blue-800"
+                >
+                  Microsoft VS Code setup guide
+                </Link>
+              </li>
+              <li>
+                <Link href="/tech-stack" className="text-blue-600 underline hover:text-blue-800">
+                  FFC Tech Stack
+                </Link>
+                <span className="text-gray-500"> &mdash; what powers every FFC site</span>
+              </li>
+            </ul>
+            <ul className="space-y-2 text-sm text-gray-700">
+              <li>
+                <Link href="/guides" className="text-blue-600 underline hover:text-blue-800">
+                  Technical Guides
+                </Link>
+                <span className="text-gray-500"> &mdash; including WordPress to Next.js</span>
+              </li>
+              <li>
+                <Link href="/testing" className="text-blue-600 underline hover:text-blue-800">
+                  Testing strategy
+                </Link>
+                <span className="text-gray-500"> &mdash; how Playwright fits in</span>
+              </li>
+              <li>
+                <Link
+                  href="/contributor-ladder"
+                  className="text-blue-600 underline hover:text-blue-800"
+                >
+                  Contributor Ladder
+                </Link>
+                <span className="text-gray-500"> &mdash; grow from Contributor to Mentor</span>
+              </li>
+            </ul>
+          </div>
+        </section>
+      </main>
+    </div>
+  )
+}

--- a/src/app/developer-environment-setup/vscode/page.tsx
+++ b/src/app/developer-environment-setup/vscode/page.tsx
@@ -1,0 +1,628 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import Breadcrumbs from '@/components/Breadcrumbs'
+
+export const metadata: Metadata = {
+  title: 'VS Code Setup',
+  description:
+    'Set up Microsoft VS Code for Free For Charity website development. Install it, sign in with GitHub Copilot, connect GitHub, and configure the Playwright and GitHub MCP servers via .vscode/mcp.json so the AI agent can open issues, make PRs, and merge changes.',
+  keywords:
+    'VS Code, GitHub Copilot, agent mode, MCP servers, mcp.json, Playwright MCP, GitHub MCP, AI coding agent, Free For Charity, developer environment',
+}
+
+interface GuideSection {
+  id: string
+  number: string
+  title: string
+  icon: string
+}
+
+const sections: GuideSection[] = [
+  { id: 'overview', number: '1', title: 'What You Are Building', icon: '🧩' },
+  { id: 'install', number: '2', title: 'Install VS Code', icon: '⬇️' },
+  { id: 'core-tools', number: '3', title: 'Install Git, Node, and pnpm', icon: '🔧' },
+  { id: 'copilot', number: '4', title: 'Enable GitHub Copilot (Agent Mode)', icon: '🤖' },
+  { id: 'github', number: '5', title: 'Connect to GitHub', icon: '🐙' },
+  { id: 'extensions', number: '6', title: 'Recommended Extensions', icon: '🧱' },
+  { id: 'mcp', number: '7', title: 'Configure MCP Servers', icon: '🔌' },
+  { id: 'clone', number: '8', title: 'Clone a Template Repo', icon: '📦' },
+  { id: 'first-change', number: '9', title: 'Your First Issue to Merge', icon: '🔁' },
+  { id: 'security', number: '10', title: 'Security and Good Habits', icon: '🛡️' },
+  { id: 'troubleshooting', number: '11', title: 'Troubleshooting', icon: '🩺' },
+]
+
+export default function VSCodeSetupGuide() {
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Breadcrumbs
+        items={[
+          { label: 'Home', href: '/' },
+          { label: 'Developer Environment Setup', href: '/developer-environment-setup' },
+          { label: 'VS Code' },
+        ]}
+      />
+
+      {/* Header */}
+      <div className="bg-gradient-to-r from-blue-700 to-indigo-700 text-white py-16 px-4 sm:px-6 lg:px-8">
+        <div className="max-w-5xl mx-auto">
+          <div className="flex items-center mb-4">
+            <span className="text-5xl mr-4" aria-hidden="true">
+              🧩
+            </span>
+            <div>
+              <h1 className="text-3xl md:text-4xl font-bold">Microsoft VS Code Setup</h1>
+              <p className="text-blue-200 text-sm mt-1">
+                The industry-standard editor, configured for FFC development
+              </p>
+            </div>
+          </div>
+          <p className="text-blue-100 text-lg max-w-3xl">
+            VS Code is free, open source, and the most widely documented editor in the world. With
+            the GitHub Copilot free tier in <strong>agent mode</strong> plus a couple of MCP
+            servers, it can open issues, write code, run our Playwright tests, and prepare pull
+            requests for you.
+          </p>
+          <div className="mt-6 flex flex-wrap gap-3">
+            <span className="bg-blue-600/50 px-3 py-1 rounded-full text-sm font-medium">
+              Free &amp; open source
+            </span>
+            <span className="bg-blue-600/50 px-3 py-1 rounded-full text-sm font-medium">
+              Copilot free tier
+            </span>
+            <span className="bg-blue-600/50 px-3 py-1 rounded-full text-sm font-medium">
+              ~30 minutes
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <main className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        {/* TOC */}
+        <div className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-10">
+          <h2 className="text-2xl font-bold text-gray-900 mb-6">On this page</h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+            {sections.map((section) => (
+              <a
+                key={section.id}
+                href={`#${section.id}`}
+                className="flex items-center p-2 rounded-lg hover:bg-blue-50 transition-colors group"
+              >
+                <span className="text-xl mr-3" aria-hidden="true">
+                  {section.icon}
+                </span>
+                <span className="text-sm font-medium text-gray-700 group-hover:text-blue-700">
+                  <span className="text-blue-600 font-bold mr-1">{section.number}.</span>
+                  {section.title}
+                </span>
+              </a>
+            ))}
+          </div>
+        </div>
+
+        {/* 1. Overview */}
+        <section id="overview" className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
+          <div className="flex items-center mb-6">
+            <span className="text-4xl mr-4" aria-hidden="true">
+              🧩
+            </span>
+            <h2 className="text-2xl font-bold text-gray-900">1. What You Are Building</h2>
+          </div>
+          <p className="text-gray-700 mb-4">
+            You are turning a plain VS Code install into an AI-assisted FFC development environment.
+            The pieces: VS Code itself, the toolchain (Git, Node, pnpm), GitHub Copilot in agent
+            mode as your AI agent, a GitHub connection, and MCP servers for Playwright and GitHub.
+          </p>
+          <div className="bg-blue-50 border-l-4 border-blue-600 p-4 rounded">
+            <p className="text-blue-900 text-sm">
+              <strong>Agent mode is the key.</strong> Copilot&apos;s Ask and Edit modes cannot use
+              MCP tools. You must select <em>Agent</em> in the Copilot Chat mode dropdown for the
+              Playwright and GitHub servers to be usable.
+            </p>
+          </div>
+        </section>
+
+        {/* 2. Install */}
+        <section id="install" className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
+          <div className="flex items-center mb-6">
+            <span className="text-4xl mr-4" aria-hidden="true">
+              ⬇️
+            </span>
+            <h2 className="text-2xl font-bold text-gray-900">2. Install VS Code</h2>
+          </div>
+          <ol className="space-y-3 text-sm text-gray-700 list-decimal ml-5">
+            <li>
+              Download VS Code from{' '}
+              <a
+                href="https://code.visualstudio.com"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-700 underline hover:text-blue-900"
+              >
+                code.visualstudio.com
+              </a>{' '}
+              for your operating system.
+            </li>
+            <li>Run the installer and accept the defaults.</li>
+            <li>
+              On Windows, allow the &ldquo;Add to PATH&rdquo; and &ldquo;Open with Code&rdquo;
+              options so you can launch from the terminal with{' '}
+              <code className="bg-gray-200 px-1 rounded">code .</code>.
+            </li>
+            <li>Launch VS Code.</li>
+          </ol>
+        </section>
+
+        {/* 3. Core tools */}
+        <section id="core-tools" className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
+          <div className="flex items-center mb-6">
+            <span className="text-4xl mr-4" aria-hidden="true">
+              🔧
+            </span>
+            <h2 className="text-2xl font-bold text-gray-900">3. Install Git, Node, and pnpm</h2>
+          </div>
+          <p className="text-gray-700 mb-4">
+            FFC sites are Next.js projects. Open the integrated terminal (
+            <code className="bg-gray-200 px-1 rounded">Ctrl/Cmd + `</code>) and verify:
+          </p>
+          <div className="bg-gray-900 text-gray-100 p-4 rounded-lg text-sm font-mono overflow-x-auto mb-4">
+            <p className="text-blue-300"># Verify the toolchain</p>
+            <p>git --version</p>
+            <p>node --version &nbsp;&nbsp;# should be v20 or newer</p>
+            <p>pnpm --version</p>
+          </div>
+          <p className="text-gray-700 text-sm mb-2">
+            Missing something? Ask Copilot Chat (agent mode):
+          </p>
+          <div className="bg-blue-50 border border-blue-200 rounded-lg p-4 text-sm text-blue-900 italic">
+            &ldquo;Check whether Git, Node 20+, and pnpm are installed on my [Windows/macOS/Linux]
+            machine and give me exact install commands for anything missing.&rdquo;
+          </div>
+          <p className="text-gray-600 text-xs mt-3">
+            If you already have Node, install pnpm with{' '}
+            <code className="bg-gray-200 px-1 rounded">npm install -g pnpm</code>.
+          </p>
+        </section>
+
+        {/* 4. Copilot */}
+        <section id="copilot" className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
+          <div className="flex items-center mb-6">
+            <span className="text-4xl mr-4" aria-hidden="true">
+              🤖
+            </span>
+            <h2 className="text-2xl font-bold text-gray-900">
+              4. Enable GitHub Copilot (Agent Mode)
+            </h2>
+          </div>
+          <ol className="space-y-3 text-sm text-gray-700 list-decimal ml-5">
+            <li>
+              In the Extensions view (
+              <code className="bg-gray-200 px-1 rounded">Ctrl/Cmd+Shift+X</code>
+              ), install <strong>GitHub Copilot</strong> and <strong>GitHub Copilot Chat</strong>.
+            </li>
+            <li>
+              Click the Copilot icon and sign in with your GitHub account. The{' '}
+              <strong>Copilot free tier</strong> is enough to get started.
+            </li>
+            <li>
+              Open Copilot Chat, click the <strong>mode dropdown</strong>, and choose{' '}
+              <strong>Agent</strong>. This is required for MCP tools to be visible.
+            </li>
+          </ol>
+          <div className="mt-4 bg-blue-50 border-l-4 border-blue-600 p-4 rounded">
+            <p className="text-blue-900 text-sm">
+              The <strong>Configure Tools</strong> button in the chat input lets you see and toggle
+              which tools (including MCP servers) the agent may use.
+            </p>
+          </div>
+        </section>
+
+        {/* 5. GitHub */}
+        <section id="github" className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
+          <div className="flex items-center mb-6">
+            <span className="text-4xl mr-4" aria-hidden="true">
+              🐙
+            </span>
+            <h2 className="text-2xl font-bold text-gray-900">5. Connect to GitHub</h2>
+          </div>
+          <div className="space-y-5">
+            <div className="border-l-4 border-blue-600 pl-4">
+              <h3 className="font-bold text-gray-900 mb-2">5.1 — Confirm org membership</h3>
+              <p className="text-sm text-gray-700">
+                Make sure a maintainer has added you to the{' '}
+                <a
+                  href="https://github.com/FreeForCharity"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-blue-700 underline hover:text-blue-900"
+                >
+                  FreeForCharity
+                </a>{' '}
+                organization, and accept the invitation.
+              </p>
+            </div>
+            <div className="border-l-4 border-blue-600 pl-4">
+              <h3 className="font-bold text-gray-900 mb-2">5.2 — Sign in to GitHub in VS Code</h3>
+              <p className="text-sm text-gray-700 mb-2">
+                Use the <strong>Accounts</strong> menu (bottom-left) to sign in to GitHub, and
+                install the <strong>GitHub Pull Requests</strong> extension so you can manage issues
+                and PRs from the sidebar. Set your Git identity once:
+              </p>
+              <div className="bg-gray-900 text-gray-100 p-3 rounded-lg text-sm font-mono">
+                git config --global user.name &quot;Your Name&quot;
+                <br />
+                git config --global user.email &quot;you@example.com&quot;
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* 6. Extensions */}
+        <section id="extensions" className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
+          <div className="flex items-center mb-6">
+            <span className="text-4xl mr-4" aria-hidden="true">
+              🧱
+            </span>
+            <h2 className="text-2xl font-bold text-gray-900">6. Recommended Extensions</h2>
+          </div>
+          <p className="text-gray-700 mb-4">
+            These match the FFC tech stack and keep you consistent with CI.
+          </p>
+          <ul className="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-2 text-sm text-gray-700">
+            <li className="flex items-start">
+              <span className="text-blue-600 mr-2">&bull;</span>
+              <span>
+                <strong>ESLint</strong> &mdash; matches our lint step
+              </span>
+            </li>
+            <li className="flex items-start">
+              <span className="text-blue-600 mr-2">&bull;</span>
+              <span>
+                <strong>Prettier</strong> &mdash; matches our formatting step
+              </span>
+            </li>
+            <li className="flex items-start">
+              <span className="text-blue-600 mr-2">&bull;</span>
+              <span>
+                <strong>Tailwind CSS IntelliSense</strong> &mdash; class autocompletion
+              </span>
+            </li>
+            <li className="flex items-start">
+              <span className="text-blue-600 mr-2">&bull;</span>
+              <span>
+                <strong>Playwright Test for VS Code</strong> &mdash; run/debug E2E tests
+              </span>
+            </li>
+            <li className="flex items-start">
+              <span className="text-blue-600 mr-2">&bull;</span>
+              <span>
+                <strong>GitHub Pull Requests</strong> &mdash; issues and PRs in the sidebar
+              </span>
+            </li>
+            <li className="flex items-start">
+              <span className="text-blue-600 mr-2">&bull;</span>
+              <span>
+                <strong>GitHub Copilot</strong> + <strong>Copilot Chat</strong> &mdash; the AI agent
+              </span>
+            </li>
+          </ul>
+          <div className="mt-4 bg-blue-50 border-l-4 border-blue-600 p-4 rounded">
+            <p className="text-blue-900 text-sm">
+              Many FFC repos ship a{' '}
+              <code className="bg-gray-200 px-1 rounded">.vscode/extensions.json</code> with these
+              recommendations. When you open the repo, VS Code offers to install them in one click.
+            </p>
+          </div>
+        </section>
+
+        {/* 7. MCP */}
+        <section id="mcp" className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
+          <div className="flex items-center mb-6">
+            <span className="text-4xl mr-4" aria-hidden="true">
+              🔌
+            </span>
+            <h2 className="text-2xl font-bold text-gray-900">7. Configure MCP Servers</h2>
+          </div>
+          <p className="text-gray-700 mb-4">
+            VS Code reads MCP server configuration from{' '}
+            <code className="bg-gray-200 px-1 rounded">.vscode/mcp.json</code> in your workspace
+            (shareable in the repo) or from your user profile. For FFC work, enable{' '}
+            <strong>Playwright</strong> and <strong>GitHub</strong>.
+          </p>
+
+          <div className="bg-red-50 border border-red-200 rounded-lg p-4 mb-5">
+            <p className="text-red-800 text-sm">
+              <strong>Critical:</strong> VS Code uses the root key{' '}
+              <code className="bg-red-100 px-1 rounded">servers</code> &mdash; not{' '}
+              <code className="bg-red-100 px-1 rounded">mcpServers</code>. Copy-pasting a Cursor or
+              Antigravity config without changing this key is the number-one setup mistake.
+            </p>
+          </div>
+
+          <div className="space-y-6">
+            <div className="border-l-4 border-blue-600 pl-4">
+              <h3 className="font-bold text-gray-900 mb-2">Option A — Command palette</h3>
+              <p className="text-sm text-gray-700">
+                Open the Command Palette (
+                <code className="bg-gray-200 px-1 rounded">Ctrl/Cmd+Shift+P</code>) and run{' '}
+                <strong>MCP: Add Server</strong>. Choose <em>Workspace</em> to create{' '}
+                <code className="bg-gray-200 px-1 rounded">.vscode/mcp.json</code>, then follow the
+                guided flow. Or install Playwright directly: in the Extensions view search{' '}
+                <code className="bg-gray-200 px-1 rounded">@mcp playwright</code> and click Install.
+              </p>
+            </div>
+
+            <div className="border-l-4 border-blue-600 pl-4">
+              <h3 className="font-bold text-gray-900 mb-2">
+                Option B — Edit <code>.vscode/mcp.json</code>
+              </h3>
+              <p className="text-sm text-gray-700 mb-2">
+                Run <strong>MCP: Open Workspace Folder Configuration</strong> and paste:
+              </p>
+              <div className="bg-gray-900 text-gray-100 p-4 rounded-lg text-xs font-mono overflow-x-auto">
+                <pre>{`{
+  "servers": {
+    "playwright": {
+      "command": "npx",
+      "args": ["@playwright/mcp@latest"]
+    },
+    "github": {
+      "type": "http",
+      "url": "https://api.githubcopilot.com/mcp"
+    }
+  }
+}`}</pre>
+              </div>
+              <p className="text-sm text-gray-700 mt-2">
+                The GitHub server is the hosted Copilot MCP endpoint; VS Code handles its
+                authentication through your Copilot/GitHub sign-in. Save the file, then enable the
+                servers when VS Code prompts.
+              </p>
+            </div>
+          </div>
+
+          <div className="mt-5 bg-blue-50 border-l-4 border-blue-600 p-4 rounded">
+            <p className="text-blue-900 text-sm">
+              <strong>Verify:</strong> switch Copilot Chat to <em>Agent</em> mode, click{' '}
+              <strong>Configure Tools</strong>, and confirm the Playwright and GitHub tools are
+              listed and enabled. First Playwright run downloads a browser — that is expected.
+            </p>
+          </div>
+        </section>
+
+        {/* 8. Clone */}
+        <section id="clone" className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
+          <div className="flex items-center mb-6">
+            <span className="text-4xl mr-4" aria-hidden="true">
+              📦
+            </span>
+            <h2 className="text-2xl font-bold text-gray-900">8. Clone a Template Repo</h2>
+          </div>
+          <p className="text-gray-700 mb-4">
+            Practice on the{' '}
+            <a
+              href="https://github.com/FreeForCharity/FFC_Single_Page_Template"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-700 underline hover:text-blue-900"
+            >
+              FFC_Single_Page_Template
+            </a>
+            , the starting point for new charity sites.
+          </p>
+          <div className="bg-gray-900 text-gray-100 p-4 rounded-lg text-sm font-mono overflow-x-auto">
+            <p className="text-blue-300"># Clone, install, and verify</p>
+            <p>git clone https://github.com/FreeForCharity/FFC_Single_Page_Template.git</p>
+            <p>cd FFC_Single_Page_Template</p>
+            <p>code .</p>
+            <p>pnpm install</p>
+            <p>pnpm run build</p>
+            <p>pnpm run test:e2e &nbsp;&nbsp;# exercises Playwright</p>
+          </div>
+          <div className="mt-4 bg-blue-50 border-l-4 border-blue-600 p-4 rounded">
+            <p className="text-blue-900 text-sm">
+              Or ask Copilot agent mode to do all of it. Do not cancel the build or E2E run — they
+              can take a minute.
+            </p>
+          </div>
+        </section>
+
+        {/* 9. First change */}
+        <section id="first-change" className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
+          <div className="flex items-center mb-6">
+            <span className="text-4xl mr-4" aria-hidden="true">
+              🔁
+            </span>
+            <h2 className="text-2xl font-bold text-gray-900">9. Your First Issue to Merge</h2>
+          </div>
+          <p className="text-gray-700 mb-4">
+            With Copilot agent mode plus the GitHub and Playwright MCP servers, run the full FFC
+            contribution loop on a small change.
+          </p>
+          <div className="space-y-4">
+            <div className="border-l-4 border-blue-600 pl-4">
+              <h3 className="font-bold text-gray-900 mb-1">Step 1 — Pick or open an issue</h3>
+              <p className="text-sm text-gray-700">
+                Ask the agent to list open issues, or open a new one describing your change.
+              </p>
+            </div>
+            <div className="border-l-4 border-blue-600 pl-4">
+              <h3 className="font-bold text-gray-900 mb-1">Step 2 — Branch and edit</h3>
+              <p className="text-sm text-gray-700">
+                Have the agent create a branch (never{' '}
+                <code className="bg-gray-200 px-1 rounded">main</code>) and make the change. Review
+                the diff in Source Control.
+              </p>
+            </div>
+            <div className="border-l-4 border-blue-600 pl-4">
+              <h3 className="font-bold text-gray-900 mb-1">Step 3 — Run the checks</h3>
+              <p className="text-sm text-gray-700">
+                <code className="bg-gray-200 px-1 rounded">pnpm run format</code>,{' '}
+                <code className="bg-gray-200 px-1 rounded">pnpm run lint</code>,{' '}
+                <code className="bg-gray-200 px-1 rounded">pnpm test</code>,{' '}
+                <code className="bg-gray-200 px-1 rounded">pnpm run build</code>, and{' '}
+                <code className="bg-gray-200 px-1 rounded">pnpm run test:e2e</code>.
+              </p>
+            </div>
+            <div className="border-l-4 border-blue-600 pl-4">
+              <h3 className="font-bold text-gray-900 mb-1">Step 4 — Open a PR and merge</h3>
+              <p className="text-sm text-gray-700">
+                Via the GitHub MCP server, the agent commits with a{' '}
+                <a
+                  href="https://www.conventionalcommits.org/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-blue-700 underline hover:text-blue-900"
+                >
+                  Conventional Commit
+                </a>{' '}
+                message, pushes, and opens a PR linked with{' '}
+                <code className="bg-gray-200 px-1 rounded">Fixes #NNN</code>. After CI passes and a
+                maintainer approves, it merges.
+              </p>
+            </div>
+          </div>
+          <div className="mt-4 bg-green-50 border-l-4 border-green-600 p-4 rounded">
+            <p className="text-green-900 text-sm">
+              Every future change on any FFC charity or website repo follows these same four steps.
+            </p>
+          </div>
+        </section>
+
+        {/* 10. Security */}
+        <section id="security" className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
+          <div className="flex items-center mb-6">
+            <span className="text-4xl mr-4" aria-hidden="true">
+              🛡️
+            </span>
+            <h2 className="text-2xl font-bold text-gray-900">10. Security and Good Habits</h2>
+          </div>
+          <ul className="space-y-2 text-sm text-gray-700">
+            <li className="flex items-start">
+              <span className="text-red-500 mr-2 mt-0.5">&#10005;</span>
+              <span>
+                Never paste tokens or keys into chat, code, commits, or{' '}
+                <code className="bg-gray-200 px-1 rounded">.vscode/mcp.json</code> (it is committed
+                to the repo).
+              </span>
+            </li>
+            <li className="flex items-start">
+              <span className="text-blue-600 mr-2 mt-0.5">&#10003;</span>
+              <span>
+                Use VS Code&apos;s secure input prompts (
+                <code className="bg-gray-200 px-1 rounded">inputs</code>) or a git-ignored{' '}
+                <code className="bg-gray-200 px-1 rounded">.env</code> for any secrets.
+              </span>
+            </li>
+            <li className="flex items-start">
+              <span className="text-blue-600 mr-2 mt-0.5">&#10003;</span>
+              <span>Review every diff and command before approving the agent.</span>
+            </li>
+            <li className="flex items-start">
+              <span className="text-blue-600 mr-2 mt-0.5">&#10003;</span>
+              <span>Work on a branch and open a PR — never push directly to main.</span>
+            </li>
+          </ul>
+          <div className="mt-4 bg-amber-50 border-l-4 border-amber-500 p-4 rounded">
+            <p className="text-amber-900 text-sm">
+              See the FFC{' '}
+              <a
+                href="https://github.com/FreeForCharity/FFC-IN-ffcadmin.org/blob/main/.claude/rules/01-security.md"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-amber-900 underline"
+              >
+                security rules
+              </a>{' '}
+              for the full policy.
+            </p>
+          </div>
+        </section>
+
+        {/* 11. Troubleshooting */}
+        <section id="troubleshooting" className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
+          <div className="flex items-center mb-6">
+            <span className="text-4xl mr-4" aria-hidden="true">
+              🩺
+            </span>
+            <h2 className="text-2xl font-bold text-gray-900">11. Troubleshooting</h2>
+          </div>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm border-collapse">
+              <thead>
+                <tr className="bg-gray-100">
+                  <th className="text-left p-3 font-semibold text-gray-900 border border-gray-200">
+                    Symptom
+                  </th>
+                  <th className="text-left p-3 font-semibold text-gray-900 border border-gray-200">
+                    Fix
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td className="p-3 border border-gray-200">MCP tools are invisible in chat</td>
+                  <td className="p-3 border border-gray-200">
+                    Switch Copilot Chat to <strong>Agent</strong> mode — Ask/Edit cannot use MCP
+                    tools.
+                  </td>
+                </tr>
+                <tr className="bg-gray-50">
+                  <td className="p-3 border border-gray-200">Server fails to start</td>
+                  <td className="p-3 border border-gray-200">
+                    Confirm the root key is{' '}
+                    <code className="bg-gray-200 px-1 rounded">servers</code> (not{' '}
+                    <code className="bg-gray-200 px-1 rounded">mcpServers</code>) and reload the
+                    window.
+                  </td>
+                </tr>
+                <tr>
+                  <td className="p-3 border border-gray-200">Playwright cannot launch a browser</td>
+                  <td className="p-3 border border-gray-200">
+                    Run{' '}
+                    <code className="bg-gray-200 px-1 rounded">pnpm exec playwright install</code>{' '}
+                    once.
+                  </td>
+                </tr>
+                <tr className="bg-gray-50">
+                  <td className="p-3 border border-gray-200">Push rejected</td>
+                  <td className="p-3 border border-gray-200">
+                    Confirm FreeForCharity org membership and that you are on a branch, not{' '}
+                    <code className="bg-gray-200 px-1 rounded">main</code>.
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        {/* Footer nav */}
+        <div className="bg-gradient-to-br from-gray-50 to-blue-50 rounded-xl shadow-lg p-6 md:p-8 border border-gray-200">
+          <h2 className="text-xl font-bold text-gray-900 mb-4">Related</h2>
+          <ul className="space-y-2 text-sm text-gray-700">
+            <li>
+              <Link
+                href="/developer-environment-setup"
+                className="text-blue-700 underline hover:text-blue-900"
+              >
+                &larr; Back to Developer Environment Setup
+              </Link>
+            </li>
+            <li>
+              <Link
+                href="/developer-environment-setup/google-antigravity"
+                className="text-blue-700 underline hover:text-blue-900"
+              >
+                Prefer an agent-first IDE? Read the Google Antigravity setup guide
+              </Link>
+            </li>
+            <li>
+              <Link href="/testing" className="text-blue-700 underline hover:text-blue-900">
+                How Playwright fits into our testing strategy
+              </Link>
+            </li>
+          </ul>
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/src/app/developer-environment-setup/vscode/page.tsx
+++ b/src/app/developer-environment-setup/vscode/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
 import Breadcrumbs from '@/components/Breadcrumbs'
+import PromptBox from '@/components/PromptBox'
 
 export const metadata: Metadata = {
   title: 'VS Code Setup',
@@ -161,25 +162,35 @@ export default function VSCodeSetupGuide() {
             <h2 className="text-2xl font-bold text-gray-900">3. Install Git, Node, and pnpm</h2>
           </div>
           <p className="text-gray-700 mb-4">
-            FFC sites are Next.js projects. Open the integrated terminal (
-            <code className="bg-gray-200 px-1 rounded">Ctrl/Cmd + `</code>) and verify:
+            FFC sites are Next.js projects, so you need Git, Node.js 20+ and pnpm.{' '}
+            <strong>The recommended way to install them is to let Copilot do it for you.</strong>{' '}
+            Open Copilot Chat in <em>Agent</em> mode and paste the prompt below — it will detect
+            your operating system, run the installs in the integrated terminal, and verify the
+            versions.
           </p>
-          <div className="bg-gray-900 text-gray-100 p-4 rounded-lg text-sm font-mono overflow-x-auto mb-4">
-            <p className="text-blue-300"># Verify the toolchain</p>
+          <PromptBox accent="blue">
+            &ldquo;Set up my machine for Free For Charity Next.js development. Check whether Git,
+            Node.js 20 LTS or newer, and pnpm are installed. For anything missing, install it using
+            the right method for my operating system, then run <code>git --version</code>,{' '}
+            <code>node --version</code>, and <code>pnpm --version</code> and show me the output to
+            confirm everything works.&rdquo;
+          </PromptBox>
+          <p className="text-gray-700 mt-4 mb-2 text-sm">
+            Prefer to check by hand first? Open the integrated terminal (
+            <code className="bg-gray-200 px-1 rounded">Ctrl/Cmd + `</code>) and run:
+          </p>
+          <div className="bg-gray-900 text-gray-100 p-4 rounded-lg text-sm font-mono overflow-x-auto">
+            <p className="text-blue-300">
+              # Verify versions (the agent can install anything missing)
+            </p>
             <p>git --version</p>
             <p>node --version &nbsp;&nbsp;# should be v20 or newer</p>
             <p>pnpm --version</p>
           </div>
-          <p className="text-gray-700 text-sm mb-2">
-            Missing something? Ask Copilot Chat (agent mode):
-          </p>
-          <div className="bg-blue-50 border border-blue-200 rounded-lg p-4 text-sm text-blue-900 italic">
-            &ldquo;Check whether Git, Node 20+, and pnpm are installed on my [Windows/macOS/Linux]
-            machine and give me exact install commands for anything missing.&rdquo;
-          </div>
           <p className="text-gray-600 text-xs mt-3">
-            If you already have Node, install pnpm with{' '}
-            <code className="bg-gray-200 px-1 rounded">npm install -g pnpm</code>.
+            If you already have Node but not pnpm, the quickest manual install is{' '}
+            <code className="bg-gray-200 px-1 rounded">npm install -g pnpm</code> — or just let
+            Copilot handle it with the prompt above.
           </p>
         </section>
 
@@ -254,6 +265,11 @@ export default function VSCodeSetupGuide() {
               </div>
             </div>
           </div>
+          <PromptBox accent="blue">
+            &ldquo;Help me connect VS Code to GitHub. Set my global Git <code>user.name</code> and{' '}
+            <code>user.email</code>, confirm I am signed in to GitHub, install the GitHub Pull
+            Requests extension, and verify I have access to the FreeForCharity organization.&rdquo;
+          </PromptBox>
         </section>
 
         {/* 6. Extensions */}
@@ -380,7 +396,18 @@ export default function VSCodeSetupGuide() {
             </div>
           </div>
 
-          <div className="mt-5 bg-blue-50 border-l-4 border-blue-600 p-4 rounded">
+          <p className="text-gray-700 mt-5 mb-1 text-sm">
+            <strong>Recommended:</strong> let Copilot create the config for you. Paste this into
+            Copilot Chat (Agent mode):
+          </p>
+          <PromptBox accent="blue">
+            &ldquo;Create a <code>.vscode/mcp.json</code> in this workspace that registers two MCP
+            servers under the <code>servers</code> key: a <code>playwright</code> server that runs{' '}
+            <code>npx @playwright/mcp@latest</code>, and a <code>github</code> server of type{' '}
+            <code>http</code> at <code>https://api.githubcopilot.com/mcp</code>. Then start the
+            servers and confirm the Playwright and GitHub tools appear in Configure Tools.&rdquo;
+          </PromptBox>
+          <div className="mt-4 bg-blue-50 border-l-4 border-blue-600 p-4 rounded">
             <p className="text-blue-900 text-sm">
               <strong>Verify:</strong> switch Copilot Chat to <em>Agent</em> mode, click{' '}
               <strong>Configure Tools</strong>, and confirm the Playwright and GitHub tools are
@@ -409,6 +436,20 @@ export default function VSCodeSetupGuide() {
             </a>
             , the starting point for new charity sites.
           </p>
+          <p className="text-gray-700 mb-1 text-sm">
+            <strong>Recommended:</strong> have Copilot clone and verify the repo. Paste this into
+            Copilot Chat (Agent mode):
+          </p>
+          <PromptBox accent="blue">
+            &ldquo;Clone the repository{' '}
+            <code>https://github.com/FreeForCharity/FFC_Single_Page_Template.git</code>, open it in
+            this window, install dependencies with <code>pnpm install</code>, then run{' '}
+            <code>pnpm run build</code> and <code>pnpm run test:e2e</code>. Do not cancel
+            long-running commands. Tell me if anything fails and how to fix it.&rdquo;
+          </PromptBox>
+          <p className="text-gray-700 mt-4 mb-2 text-sm">
+            Prefer to do it by hand? The equivalent commands are:
+          </p>
           <div className="bg-gray-900 text-gray-100 p-4 rounded-lg text-sm font-mono overflow-x-auto">
             <p className="text-blue-300"># Clone, install, and verify</p>
             <p>git clone https://github.com/FreeForCharity/FFC_Single_Page_Template.git</p>
@@ -420,8 +461,7 @@ export default function VSCodeSetupGuide() {
           </div>
           <div className="mt-4 bg-blue-50 border-l-4 border-blue-600 p-4 rounded">
             <p className="text-blue-900 text-sm">
-              Or ask Copilot agent mode to do all of it. Do not cancel the build or E2E run — they
-              can take a minute.
+              Do not cancel the build or E2E run — they can take a minute.
             </p>
           </div>
         </section>
@@ -444,6 +484,11 @@ export default function VSCodeSetupGuide() {
               <p className="text-sm text-gray-700">
                 Ask the agent to list open issues, or open a new one describing your change.
               </p>
+              <PromptBox accent="blue">
+                &ldquo;Using the GitHub MCP server, list the open issues on this repository. If
+                there is no issue for the small change I want to make, open a new issue titled
+                &lsquo;&lt;short title&gt;&rsquo; describing it.&rdquo;
+              </PromptBox>
             </div>
             <div className="border-l-4 border-blue-600 pl-4">
               <h3 className="font-bold text-gray-900 mb-1">Step 2 — Branch and edit</h3>
@@ -452,6 +497,11 @@ export default function VSCodeSetupGuide() {
                 <code className="bg-gray-200 px-1 rounded">main</code>) and make the change. Review
                 the diff in Source Control.
               </p>
+              <PromptBox accent="blue">
+                &ldquo;Create a new branch for issue #&lt;number&gt; (do not commit to{' '}
+                <code>main</code>), then make the change it describes. When you are done, show me
+                the full diff so I can review it before we go further.&rdquo;
+              </PromptBox>
             </div>
             <div className="border-l-4 border-blue-600 pl-4">
               <h3 className="font-bold text-gray-900 mb-1">Step 3 — Run the checks</h3>
@@ -462,6 +512,12 @@ export default function VSCodeSetupGuide() {
                 <code className="bg-gray-200 px-1 rounded">pnpm run build</code>, and{' '}
                 <code className="bg-gray-200 px-1 rounded">pnpm run test:e2e</code>.
               </p>
+              <PromptBox accent="blue">
+                &ldquo;Run the full pre-commit checklist in order: <code>pnpm run format</code>,{' '}
+                <code>pnpm run lint</code>, <code>pnpm test</code>, <code>pnpm run build</code>, and{' '}
+                <code>pnpm run test:e2e</code>. Do not cancel anything. Fix any failures and re-run
+                until everything passes.&rdquo;
+              </PromptBox>
             </div>
             <div className="border-l-4 border-blue-600 pl-4">
               <h3 className="font-bold text-gray-900 mb-1">Step 4 — Open a PR and merge</h3>
@@ -479,6 +535,11 @@ export default function VSCodeSetupGuide() {
                 <code className="bg-gray-200 px-1 rounded">Fixes #NNN</code>. After CI passes and a
                 maintainer approves, it merges.
               </p>
+              <PromptBox accent="blue">
+                &ldquo;Commit the changes with a Conventional Commit message, push the branch, and
+                open a pull request that links the issue with &lsquo;Fixes #&lt;number&gt;&rsquo;.
+                Then watch the CI checks and fix anything that fails until they are green.&rdquo;
+              </PromptBox>
             </div>
           </div>
           <div className="mt-4 bg-green-50 border-l-4 border-green-600 p-4 rounded">

--- a/src/app/developer-environment-setup/vscode/page.tsx
+++ b/src/app/developer-environment-setup/vscode/page.tsx
@@ -188,9 +188,11 @@ export default function VSCodeSetupGuide() {
             <p>pnpm --version</p>
           </div>
           <p className="text-gray-600 text-xs mt-3">
-            If you already have Node but not pnpm, the quickest manual install is{' '}
-            <code className="bg-gray-200 px-1 rounded">npm install -g pnpm</code> — or just let
-            Copilot handle it with the prompt above.
+            If you already have Node but not pnpm, install the major version our repos pin in{' '}
+            <code className="bg-gray-200 px-1 rounded">package.json</code> with{' '}
+            <code className="bg-gray-200 px-1 rounded">npm install -g pnpm@9</code> (or run{' '}
+            <code className="bg-gray-200 px-1 rounded">corepack enable</code>) — or just let Copilot
+            handle it with the prompt above.
           </p>
         </section>
 
@@ -508,13 +510,15 @@ export default function VSCodeSetupGuide() {
               <p className="text-sm text-gray-700">
                 <code className="bg-gray-200 px-1 rounded">pnpm run format</code>,{' '}
                 <code className="bg-gray-200 px-1 rounded">pnpm run lint</code>,{' '}
-                <code className="bg-gray-200 px-1 rounded">pnpm test</code>,{' '}
-                <code className="bg-gray-200 px-1 rounded">pnpm run build</code>, and{' '}
-                <code className="bg-gray-200 px-1 rounded">pnpm run test:e2e</code>.
+                <code className="bg-gray-200 px-1 rounded">pnpm run build</code>,{' '}
+                <code className="bg-gray-200 px-1 rounded">pnpm test</code>, and{' '}
+                <code className="bg-gray-200 px-1 rounded">pnpm run test:e2e</code> — in that order,
+                which matches CI (build before tests, since some tests check the build output).
               </p>
               <PromptBox accent="blue">
-                &ldquo;Run the full pre-commit checklist in order: <code>pnpm run format</code>,{' '}
-                <code>pnpm run lint</code>, <code>pnpm test</code>, <code>pnpm run build</code>, and{' '}
+                &ldquo;Run the full pre-commit checklist in this order, which matches CI:{' '}
+                <code>pnpm run format</code>, <code>pnpm run lint</code>,{' '}
+                <code>pnpm run build</code>, <code>pnpm test</code>, and{' '}
                 <code>pnpm run test:e2e</code>. Do not cancel anything. Fix any failures and re-run
                 until everything passes.&rdquo;
               </PromptBox>

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -44,6 +44,24 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.7,
     },
     {
+      url: `${SITE_URL}/developer-environment-setup/`,
+      lastModified: now,
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+    {
+      url: `${SITE_URL}/developer-environment-setup/google-antigravity/`,
+      lastModified: now,
+      changeFrequency: 'monthly',
+      priority: 0.7,
+    },
+    {
+      url: `${SITE_URL}/developer-environment-setup/vscode/`,
+      lastModified: now,
+      changeFrequency: 'monthly',
+      priority: 0.7,
+    },
+    {
       url: `${SITE_URL}/tech-stack/`,
       lastModified: now,
       changeFrequency: 'monthly',

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -207,6 +207,14 @@ export default function Footer() {
             <ul className="space-y-2 text-sm">
               <li>
                 <Link
+                  href="/developer-environment-setup"
+                  className="text-gray-400 hover:text-white transition-colors"
+                >
+                  Dev Environment Setup
+                </Link>
+              </li>
+              <li>
+                <Link
                   href="/get-involved"
                   className="text-gray-400 hover:text-white transition-colors"
                 >

--- a/src/components/PromptBox.tsx
+++ b/src/components/PromptBox.tsx
@@ -1,0 +1,46 @@
+import type { ReactNode } from 'react'
+
+/**
+ * PromptBox renders a copy-and-paste prompt that a volunteer types directly
+ * into their in-IDE AI agent (Antigravity Agent Manager or VS Code Copilot
+ * agent mode). Used throughout the developer environment setup guides so each
+ * step has a ready-made instruction for the agent.
+ */
+const ACCENTS = {
+  emerald: {
+    container: 'border-emerald-300 bg-emerald-50',
+    label: 'text-emerald-700',
+    text: 'text-emerald-900',
+  },
+  blue: {
+    container: 'border-blue-300 bg-blue-50',
+    label: 'text-blue-700',
+    text: 'text-blue-900',
+  },
+} as const
+
+interface PromptBoxProps {
+  /** Accent color, usually matching the guide (emerald = Antigravity, blue = VS Code). */
+  accent?: keyof typeof ACCENTS
+  /** Optional override for the label above the prompt. */
+  label?: string
+  /** The prompt text the volunteer should paste into the AI agent. */
+  children: ReactNode
+}
+
+export default function PromptBox({
+  accent = 'emerald',
+  label = 'Copy this prompt into your AI agent',
+  children,
+}: PromptBoxProps) {
+  const c = ACCENTS[accent]
+  return (
+    <div className={`mt-4 rounded-lg border ${c.container} p-4`}>
+      <div className="mb-2 flex items-center gap-2">
+        <span aria-hidden="true">💬</span>
+        <span className={`text-xs font-semibold uppercase tracking-wide ${c.label}`}>{label}</span>
+      </div>
+      <p className={`font-mono text-sm leading-relaxed ${c.text}`}>{children}</p>
+    </div>
+  )
+}

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -42,6 +42,11 @@ export const resourcesDropdown: NavDropdown = {
   id: 'resources',
   items: [
     {
+      label: 'Dev Environment Setup',
+      href: '/developer-environment-setup',
+      description: 'Set up Antigravity or VS Code with AI agents and MCP servers.',
+    },
+    {
       label: 'Tech Stack',
       href: '/tech-stack',
       description: 'Technologies and tools used across FFC projects.',


### PR DESCRIPTION
## Summary

Adds a **Developer Environment Setup** section so any FFC volunteer can set up their own computer, connect it to GitHub, and use a free in-IDE AI agent + MCP servers to open issues, make PRs, and merge changes into FFC charity and website repositories.

### New pages
- **`/developer-environment-setup`** (hub) — the goal, shared prerequisites, an MCP-server reference table (GitHub + Playwright required; Cloudflare / Microsoft Learn / Sentry optional), the issue → branch → PR → merge contribution loop, and an Antigravity-vs-VS Code comparison.
- **`/developer-environment-setup/google-antigravity`** — install, Google sign-in, Editor/Agent Manager tour, toolchain, GitHub, MCP setup (`mcpServers` key, Playwright + GitHub), template clone, first issue→merge, security, troubleshooting.
- **`/developer-environment-setup/vscode`** — install, Copilot agent mode, GitHub, recommended extensions, `.vscode/mcp.json` (`servers` key, `@playwright/mcp@latest` + hosted GitHub MCP), template clone, first issue→merge, security, troubleshooting.

### AI-first + copy-paste prompts
- New reusable **`PromptBox`** component renders ready-made prompts a volunteer pastes directly into their AI agent.
- Toolchain (Git/Node/pnpm) and template-clone steps **lead with letting the AI agent do the installs**; manual commands remain as a fallback.
- Prompt boxes cover the GitHub connection, MCP setup, and all four issue→merge steps in both guides.

### Wiring
- Added to the **Resources** nav dropdown, the Footer **Learning Paths** column, `sitemap.ts`, and the navigation-coverage test.

## Verification
- `pnpm run format` ✓ · `pnpm run lint` ✓ (0 errors) · `pnpm test` ✓ (334 passed) · `pnpm run build` ✓ (all 3 routes prerendered) · `pnpm run test:e2e` ✓ (12 passed)

## Related issues
Refs #291 · closes #292 · closes #293

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X4omPQW2ErDyZsMtxypuMe)_