### PR TITLE
docs: reconcile pre-commit/CI check order (build before test)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,11 +43,11 @@ All changes follow this process:
 1. **Issue** -- Work starts from a GitHub Issue
 2. **Branch** -- Create a feature branch from `main`
 3. **Develop** -- Make changes, commit frequently
-4. **Pre-commit checklist** (run in this order):
+4. **Pre-commit checklist** (run in this order, matching CI):
    1. `pnpm run format` -- Auto-fix formatting
    2. `pnpm run lint` -- Catch code quality issues
-   3. `pnpm test` -- Run unit tests
-   4. `pnpm run build` -- Verify the static export succeeds
+   3. `pnpm run build` -- Verify the static export succeeds
+   4. `pnpm test` -- Run unit tests (some tests check the build output, so build first)
    5. `pnpm run test:e2e` -- Run end-to-end tests
 5. **PR** -- Open a Pull Request, link to the issue with `Fixes #NNN` or `Refs #NNN`
 6. **Merge** -- Merge via merge queue (no direct commits to `main`)
@@ -163,8 +163,8 @@ GitHub Actions enforces the following on every PR:
 
 1. **Prettier** -- `pnpm run format:check` (formatting must pass)
 2. **ESLint** -- `pnpm run lint` (no errors allowed)
-3. **Jest** -- `pnpm test` (all unit tests must pass)
-4. **Build** -- `pnpm run build` (static export must succeed)
+3. **Build** -- `pnpm run build` (static export must succeed)
+4. **Jest** -- `pnpm test` (all unit tests must pass; some assert against the build output)
 5. **Playwright** -- `pnpm run test:e2e` (E2E tests must pass)
 6. **CodeQL** -- Static analysis and security scanning (separate workflow)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ All changes follow this process:
 1. **Issue** -- Work starts from a GitHub Issue
 2. **Branch** -- Create a feature branch from `main`
 3. **Develop** -- Make changes, commit frequently
-4. **Pre-commit checklist** (run in this order, matching CI):
+4. **Pre-commit checklist** (run in this order -- build before tests, the same ordering CI uses; CI additionally runs `type-check` and uses `format:check`):
    1. `pnpm run format` -- Auto-fix formatting
    2. `pnpm run lint` -- Catch code quality issues
    3. `pnpm run build` -- Verify the static export succeeds
@@ -163,10 +163,11 @@ GitHub Actions enforces the following on every PR:
 
 1. **Prettier** -- `pnpm run format:check` (formatting must pass)
 2. **ESLint** -- `pnpm run lint` (no errors allowed)
-3. **Build** -- `pnpm run build` (static export must succeed)
-4. **Jest** -- `pnpm test` (all unit tests must pass; some assert against the build output)
-5. **Playwright** -- `pnpm run test:e2e` (E2E tests must pass)
-6. **CodeQL** -- Static analysis and security scanning (separate workflow)
+3. **TypeScript** -- `pnpm run type-check` (no type errors)
+4. **Build** -- `pnpm run build` (static export must succeed)
+5. **Jest** -- `pnpm test` (all unit tests must pass; some assert against the build output)
+6. **Playwright** -- `pnpm run test:e2e` (E2E tests must pass)
+7. **CodeQL** -- Static analysis and security scanning (separate workflow)
 
 PRs cannot merge until all checks pass.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,8 +39,8 @@ Run these in order before committing:
 ```bash
 pnpm run format    # Fix formatting
 pnpm run lint      # Check for lint errors
-pnpm test          # Run unit tests
 pnpm run build     # Verify static export
+pnpm test          # Run unit tests (build first; some tests check build output)
 pnpm run test:e2e  # Run E2E tests
 ```
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -79,7 +79,7 @@ public/           --> Static assets (Images/, Svgs/, fonts)
    import { assetPath } from '@/lib/assetPath'
    ;<img src={assetPath('/Images/volunteers.jpg')} alt="Volunteers" />
    ```
-4. Run the pre-commit checklist: `pnpm run format && pnpm run lint && pnpm test && pnpm run build`
+4. Run the pre-commit checklist: `pnpm run format && pnpm run lint && pnpm run build && pnpm test`
 
 ### Updating Site Content
 


### PR DESCRIPTION
## Summary

Reconciles a doc inconsistency surfaced during review of #294.

The actual CI pipeline (`.github/workflows/ci.yml`) runs **`format → lint → type-check → build → test → test:e2e`** — i.e. **build before the Jest suite** (some unit tests assert against the generated `out/` build output), and `.github/copilot-instructions.md` documents the same order.

However, three docs still listed `test` before `build`:
- **AGENTS.md** — pre-commit checklist + "CI Pipeline" section
- **CLAUDE.md** — pre-commit checklist
- **GEMINI.md** — pre-commit one-liner

This PR reorders those to put **build before test**, matching CI. `CONTRIBUTING.md`, `CODE_QUALITY.md`, and `README.md` already used the correct order and are unchanged.

## Why it matters
Following the old order makes `pnpm test` fail locally on a clean checkout (the build-output / SEO tests need `out/` to exist first), which diverges from CI and confuses contributors.

Docs-only change; no source or test files touched.

Refs #291

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X4omPQW2ErDyZsMtxypuMe)_