### PR TITLE
feat: restructure dev-env setup around AI agent choice (Claude Desktop + Codex guides)

### DIFF
--- a/src/app/developer-environment-setup/claude-desktop/page.tsx
+++ b/src/app/developer-environment-setup/claude-desktop/page.tsx
@@ -1,0 +1,558 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import Breadcrumbs from '@/components/Breadcrumbs'
+import PromptBox from '@/components/PromptBox'
+
+export const metadata: Metadata = {
+  title: 'Claude Desktop Setup',
+  description:
+    'The easiest way to start developing for Free For Charity: Claude Desktop (and Claude Mobile) at the Pro level. Connect GitHub via MCP and run the full issue → PR → merge loop with no local build tools required. Our recommended starting point for new developers.',
+  keywords:
+    'Claude Desktop, Claude Mobile, Claude Pro, MCP servers, GitHub MCP, connectors, beginner developer, Free For Charity, AI agent',
+}
+
+interface GuideSection {
+  id: string
+  number: string
+  title: string
+  icon: string
+}
+
+const sections: GuideSection[] = [
+  { id: 'overview', number: '1', title: 'Why Claude Desktop', icon: '🟠' },
+  { id: 'install', number: '2', title: 'Install Desktop + Mobile', icon: '⬇️' },
+  { id: 'sign-in', number: '3', title: 'Sign In (Pro Recommended)', icon: '🔑' },
+  { id: 'how-it-works', number: '4', title: 'How the Beginner Flow Works', icon: '💡' },
+  { id: 'github', number: '5', title: 'Confirm GitHub Access', icon: '🐙' },
+  { id: 'mcp', number: '6', title: 'Connect GitHub via MCP', icon: '🔌' },
+  { id: 'mobile', number: '7', title: 'Use Claude Mobile', icon: '📱' },
+  { id: 'first-change', number: '8', title: 'Your First Issue to Merge', icon: '🔁' },
+  { id: 'graduate', number: '9', title: 'When to Move to an IDE', icon: '🎓' },
+  { id: 'security', number: '10', title: 'Security and Good Habits', icon: '🛡️' },
+  { id: 'troubleshooting', number: '11', title: 'Troubleshooting', icon: '🩺' },
+]
+
+export default function ClaudeDesktopSetupGuide() {
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Breadcrumbs
+        items={[
+          { label: 'Home', href: '/' },
+          { label: 'Developer Environment Setup', href: '/developer-environment-setup' },
+          { label: 'Claude Desktop' },
+        ]}
+      />
+
+      {/* Header */}
+      <div className="bg-gradient-to-r from-amber-500 to-orange-600 text-white py-16 px-4 sm:px-6 lg:px-8">
+        <div className="max-w-5xl mx-auto">
+          <div className="flex items-center mb-4">
+            <span className="text-5xl mr-4" aria-hidden="true">
+              🟠
+            </span>
+            <div>
+              <h1 className="text-3xl md:text-4xl font-bold">Claude Desktop Setup</h1>
+              <p className="text-amber-100 text-sm mt-1">
+                The easiest way to start — our recommendation for new developers
+              </p>
+            </div>
+          </div>
+          <p className="text-amber-50 text-lg max-w-3xl">
+            Claude Desktop plus Claude Mobile is the gentlest on-ramp to Free For Charity
+            development. You sign in, connect GitHub, and let Claude open pull requests for you —
+            with no build tools to install. CI runs the tests automatically.
+          </p>
+          <div className="mt-6 flex flex-wrap gap-3">
+            <span className="bg-white/20 px-3 py-1 rounded-full text-sm font-medium">
+              Beginner-friendly
+            </span>
+            <span className="bg-white/20 px-3 py-1 rounded-full text-sm font-medium">
+              Claude Pro recommended
+            </span>
+            <span className="bg-white/20 px-3 py-1 rounded-full text-sm font-medium">
+              ~20 minutes
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <main className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        {/* TOC */}
+        <div className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-10">
+          <h2 className="text-2xl font-bold text-gray-900 mb-6">On this page</h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+            {sections.map((section) => (
+              <a
+                key={section.id}
+                href={`#${section.id}`}
+                className="flex items-center p-2 rounded-lg hover:bg-amber-50 transition-colors group"
+              >
+                <span className="text-xl mr-3" aria-hidden="true">
+                  {section.icon}
+                </span>
+                <span className="text-sm font-medium text-gray-700 group-hover:text-amber-700">
+                  <span className="text-amber-600 font-bold mr-1">{section.number}.</span>
+                  {section.title}
+                </span>
+              </a>
+            ))}
+          </div>
+        </div>
+
+        {/* 1. Overview */}
+        <section id="overview" className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
+          <div className="flex items-center mb-6">
+            <span className="text-4xl mr-4" aria-hidden="true">
+              🟠
+            </span>
+            <h2 className="text-2xl font-bold text-gray-900">1. Why Claude Desktop</h2>
+          </div>
+          <p className="text-gray-700 mb-4">
+            For someone new to development, the simplest setup is a desktop app that already knows
+            how to talk to GitHub. Claude Desktop does exactly that. You describe a change in plain
+            English; Claude reads the repository, makes the edit, and opens a pull request through
+            the GitHub <strong>MCP</strong> connector. Free For Charity&apos;s CI then runs the
+            build and tests automatically — so you do not need Node, Git, or a code editor on day
+            one.
+          </p>
+          <div className="bg-amber-50 border-l-4 border-amber-500 p-4 rounded">
+            <p className="text-amber-900 text-sm">
+              <strong>Already pay for ChatGPT, Gemini, or Copilot instead?</strong> Keep your AI —
+              see the{' '}
+              <Link
+                href="/developer-environment-setup"
+                className="text-amber-900 underline font-medium"
+              >
+                hub
+              </Link>{' '}
+              to set that one up. This guide assumes Claude is your AI of choice.
+            </p>
+          </div>
+        </section>
+
+        {/* 2. Install */}
+        <section id="install" className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
+          <div className="flex items-center mb-6">
+            <span className="text-4xl mr-4" aria-hidden="true">
+              ⬇️
+            </span>
+            <h2 className="text-2xl font-bold text-gray-900">2. Install Desktop + Mobile</h2>
+          </div>
+          <ol className="space-y-3 text-sm text-gray-700 list-decimal ml-5">
+            <li>
+              Download <strong>Claude Desktop</strong> for macOS or Windows from{' '}
+              <a
+                href="https://claude.ai/download"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-amber-700 underline hover:text-amber-900"
+              >
+                claude.ai/download
+              </a>{' '}
+              and run the installer.
+            </li>
+            <li>
+              Install <strong>Claude Mobile</strong> on your phone from the Apple App Store or
+              Google Play so you can review and drive work on the go.
+            </li>
+            <li>Launch Claude Desktop.</li>
+          </ol>
+        </section>
+
+        {/* 3. Sign in */}
+        <section id="sign-in" className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
+          <div className="flex items-center mb-6">
+            <span className="text-4xl mr-4" aria-hidden="true">
+              🔑
+            </span>
+            <h2 className="text-2xl font-bold text-gray-900">3. Sign In (Pro Recommended)</h2>
+          </div>
+          <p className="text-gray-700 mb-4">
+            Sign in with your Anthropic account. For real FFC work we recommend the personal{' '}
+            <strong>Claude Pro</strong> plan: it gives you enough usage to complete tasks without
+            constantly hitting limits, and it unlocks custom MCP <strong>connectors</strong> (the
+            free tier is limited to a single custom connector).
+          </p>
+          <div className="bg-amber-50 border-l-4 border-amber-500 p-4 rounded">
+            <p className="text-amber-900 text-sm">
+              You can start on the free tier to look around, but plan to upgrade to Pro before doing
+              ongoing work — the GitHub connector is central to this guide.
+            </p>
+          </div>
+        </section>
+
+        {/* 4. How it works */}
+        <section id="how-it-works" className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
+          <div className="flex items-center mb-6">
+            <span className="text-4xl mr-4" aria-hidden="true">
+              💡
+            </span>
+            <h2 className="text-2xl font-bold text-gray-900">4. How the Beginner Flow Works</h2>
+          </div>
+          <p className="text-gray-700 mb-4">
+            The key idea: <strong>everything happens through GitHub.</strong> With the GitHub MCP
+            connector, Claude can read issues, create a branch, commit changes, and open a pull
+            request — all on GitHub&apos;s servers. Free For Charity&apos;s CI pipeline then builds
+            the site and runs the tests for you. You never have to install a toolchain or run
+            commands locally.
+          </p>
+          <div className="bg-emerald-50 border border-emerald-200 rounded-lg p-4 text-sm text-emerald-900">
+            <strong>No local tooling required.</strong> Node.js, pnpm, and Playwright only matter
+            when you graduate to an IDE (see step 9). For now, Claude + GitHub + CI is the whole
+            toolchain.
+          </div>
+        </section>
+
+        {/* 5. GitHub access */}
+        <section id="github" className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
+          <div className="flex items-center mb-6">
+            <span className="text-4xl mr-4" aria-hidden="true">
+              🐙
+            </span>
+            <h2 className="text-2xl font-bold text-gray-900">5. Confirm GitHub Access</h2>
+          </div>
+          <p className="text-gray-700">
+            Make sure a maintainer has added you to the{' '}
+            <a
+              href="https://github.com/FreeForCharity"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-amber-700 underline hover:text-amber-900"
+            >
+              FreeForCharity
+            </a>{' '}
+            GitHub organization, and accept the email invitation. Without org membership the GitHub
+            connector cannot open pull requests on our repositories.
+          </p>
+        </section>
+
+        {/* 6. MCP */}
+        <section id="mcp" className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
+          <div className="flex items-center mb-6">
+            <span className="text-4xl mr-4" aria-hidden="true">
+              🔌
+            </span>
+            <h2 className="text-2xl font-bold text-gray-900">6. Connect GitHub via MCP</h2>
+          </div>
+          <p className="text-gray-700 mb-4">
+            Claude Desktop calls MCP servers <strong>connectors</strong>. You need the{' '}
+            <strong>GitHub</strong> connector. There are two ways to add it.
+          </p>
+
+          <div className="space-y-6">
+            <div className="border-l-4 border-amber-500 pl-4">
+              <h3 className="font-bold text-gray-900 mb-2">
+                Option A — Connectors directory (easiest)
+              </h3>
+              <p className="text-sm text-gray-700">
+                Click the <strong>+</strong> button at the bottom of the chat box and choose{' '}
+                <strong>Connectors</strong>. Browse the directory, add <strong>GitHub</strong>, and
+                follow the sign-in prompts. When a connector is active, a small{' '}
+                <strong>hammer / tools icon</strong> appears under the chat box showing how many
+                tools are available.
+              </p>
+            </div>
+
+            <div className="border-l-4 border-amber-500 pl-4">
+              <h3 className="font-bold text-gray-900 mb-2">
+                Option B — Edit the config file (manual)
+              </h3>
+              <p className="text-sm text-gray-700 mb-2">
+                Go to <strong>Settings &rarr; Developer &rarr; Edit Config</strong>. This opens{' '}
+                <code className="bg-gray-200 px-1 rounded">claude_desktop_config.json</code> (it is
+                created if missing). Claude Desktop uses the{' '}
+                <code className="bg-gray-200 px-1 rounded">mcpServers</code> key. The official
+                GitHub MCP server runs locally via Docker:
+              </p>
+              <div className="bg-gray-900 text-gray-100 p-4 rounded-lg text-xs font-mono overflow-x-auto">
+                <pre>{`{
+  "mcpServers": {
+    "github": {
+      "command": "docker",
+      "args": [
+        "run", "-i", "--rm",
+        "-e", "GITHUB_PERSONAL_ACCESS_TOKEN",
+        "ghcr.io/github/github-mcp-server"
+      ],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "<your token>"
+      }
+    }
+  }
+}`}</pre>
+              </div>
+              <p className="text-sm text-gray-700 mt-2">
+                Fully quit Claude Desktop (Cmd+Q / Quit from the tray) and reopen it so the
+                connector loads.
+              </p>
+            </div>
+          </div>
+
+          <PromptBox accent="amber">
+            &ldquo;I want to use you with the Free For Charity GitHub repositories. Walk me through
+            adding the GitHub connector in Claude Desktop, confirm the tools are available, and then
+            list the open issues on the FreeForCharity/FFC_Single_Page_Template repository.&rdquo;
+          </PromptBox>
+
+          <div className="mt-4 bg-amber-50 border-l-4 border-amber-500 p-4 rounded">
+            <p className="text-amber-900 text-sm">
+              <strong>Token safety:</strong> if you use Option B, create a fine-grained Personal
+              Access Token with the narrowest scope that works, paste it only into the config file
+              on your own machine, and never put it in a repository, an issue, or a chat message.
+              Prefer Option A, where Claude manages the sign-in for you.
+            </p>
+          </div>
+        </section>
+
+        {/* 7. Mobile */}
+        <section id="mobile" className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
+          <div className="flex items-center mb-6">
+            <span className="text-4xl mr-4" aria-hidden="true">
+              📱
+            </span>
+            <h2 className="text-2xl font-bold text-gray-900">7. Use Claude Mobile</h2>
+          </div>
+          <p className="text-gray-700 mb-4">
+            Claude Mobile can use the same <strong>remote connectors</strong> you set up on the web.
+            One catch: you add connectors on <strong>claude.ai in a browser</strong> (or Claude
+            Desktop), and they sync automatically to your phone — you cannot add a new server from
+            the mobile app itself.
+          </p>
+          <ol className="space-y-2 text-sm text-gray-700 list-decimal ml-5">
+            <li>
+              On <strong>claude.ai</strong>, open settings and add the GitHub connector (remote
+              MCP).
+            </li>
+            <li>Open Claude Mobile — the connector is already available.</li>
+            <li>
+              Now you can triage issues, ask for small fixes, and check on a pull request from your
+              phone.
+            </li>
+          </ol>
+          <div className="mt-4 bg-blue-50 border-l-4 border-blue-600 p-4 rounded">
+            <p className="text-blue-900 text-sm">
+              Remote connectors run from Anthropic&apos;s cloud, not your device — which is exactly
+              why they work the same on desktop, web, and mobile.
+            </p>
+          </div>
+        </section>
+
+        {/* 8. First change */}
+        <section id="first-change" className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
+          <div className="flex items-center mb-6">
+            <span className="text-4xl mr-4" aria-hidden="true">
+              🔁
+            </span>
+            <h2 className="text-2xl font-bold text-gray-900">8. Your First Issue to Merge</h2>
+          </div>
+          <p className="text-gray-700 mb-4">
+            With the GitHub connector active, you can run the entire Free For Charity contribution
+            loop from chat. Try a small, safe change like fixing a typo.
+          </p>
+
+          <div className="space-y-4">
+            <div className="border-l-4 border-amber-500 pl-4">
+              <h3 className="font-bold text-gray-900 mb-1">Step 1 — Pick or open an issue</h3>
+              <PromptBox accent="amber">
+                &ldquo;Using the GitHub tools, list the open issues on
+                FreeForCharity/FFC_Single_Page_Template. If there is no issue for the small change I
+                want, open one titled &lsquo;&lt;short title&gt;&rsquo; describing it.&rdquo;
+              </PromptBox>
+            </div>
+            <div className="border-l-4 border-amber-500 pl-4">
+              <h3 className="font-bold text-gray-900 mb-1">Step 2 — Make the change on a branch</h3>
+              <PromptBox accent="amber">
+                &ldquo;Create a new branch for issue #&lt;number&gt; (never commit to{' '}
+                <code>main</code>), make the change it describes, and show me exactly what you
+                changed before opening anything.&rdquo;
+              </PromptBox>
+            </div>
+            <div className="border-l-4 border-amber-500 pl-4">
+              <h3 className="font-bold text-gray-900 mb-1">Step 3 — Open a PR and let CI run</h3>
+              <PromptBox accent="amber">
+                &ldquo;Open a pull request from that branch with a Conventional Commit title, link
+                the issue with &lsquo;Fixes #&lt;number&gt;&rsquo;, then watch the CI checks
+                (format, lint, build, tests, Playwright) and tell me if any fail.&rdquo;
+              </PromptBox>
+            </div>
+            <div className="border-l-4 border-amber-500 pl-4">
+              <h3 className="font-bold text-gray-900 mb-1">Step 4 — Review and merge</h3>
+              <p className="text-sm text-gray-700">
+                Review the diff on GitHub. A maintainer approves, and once every check is green the
+                pull request merges. That is the whole loop — no local tools required.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* 9. Graduate */}
+        <section id="graduate" className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
+          <div className="flex items-center mb-6">
+            <span className="text-4xl mr-4" aria-hidden="true">
+              🎓
+            </span>
+            <h2 className="text-2xl font-bold text-gray-900">9. When to Move to an IDE</h2>
+          </div>
+          <p className="text-gray-700 mb-4">
+            Most charity website work never needs more than this. Consider graduating to a full IDE
+            only when a task genuinely calls for running builds and tests on your own machine,
+            debugging a browser test, or doing a large refactor across many files.
+          </p>
+          <ul className="space-y-2 text-sm text-gray-700">
+            <li className="flex items-start">
+              <span className="text-blue-600 mr-2">&bull;</span>
+              <span>
+                Want to keep using Claude?{' '}
+                <Link
+                  href="/developer-environment-setup/vscode"
+                  className="text-amber-700 underline hover:text-amber-900"
+                >
+                  VS Code
+                </Link>{' '}
+                or{' '}
+                <Link
+                  href="/developer-environment-setup/google-antigravity"
+                  className="text-amber-700 underline hover:text-amber-900"
+                >
+                  Antigravity
+                </Link>{' '}
+                both let you run Claude as a CLI agent and an in-editor plug-in.
+              </span>
+            </li>
+            <li className="flex items-start">
+              <span className="text-blue-600 mr-2">&bull;</span>
+              <span>There is no rush — the beginner path stays valid for the long term.</span>
+            </li>
+          </ul>
+        </section>
+
+        {/* 10. Security */}
+        <section id="security" className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
+          <div className="flex items-center mb-6">
+            <span className="text-4xl mr-4" aria-hidden="true">
+              🛡️
+            </span>
+            <h2 className="text-2xl font-bold text-gray-900">10. Security and Good Habits</h2>
+          </div>
+          <ul className="space-y-2 text-sm text-gray-700">
+            <li className="flex items-start">
+              <span className="text-red-500 mr-2 mt-0.5">&#10005;</span>
+              <span>Never paste tokens or keys into chat, issues, commits, or pull requests.</span>
+            </li>
+            <li className="flex items-start">
+              <span className="text-amber-600 mr-2 mt-0.5">&#10003;</span>
+              <span>Prefer the managed Connectors sign-in over a hand-entered token.</span>
+            </li>
+            <li className="flex items-start">
+              <span className="text-amber-600 mr-2 mt-0.5">&#10003;</span>
+              <span>
+                Review the diff before a pull request merges — you are the human in the loop.
+              </span>
+            </li>
+            <li className="flex items-start">
+              <span className="text-amber-600 mr-2 mt-0.5">&#10003;</span>
+              <span>Always work on a branch and open a PR — never commit straight to main.</span>
+            </li>
+          </ul>
+          <div className="mt-4 bg-amber-50 border-l-4 border-amber-500 p-4 rounded">
+            <p className="text-amber-900 text-sm">
+              See the FFC{' '}
+              <a
+                href="https://github.com/FreeForCharity/FFC-IN-ffcadmin.org/blob/main/.claude/rules/01-security.md"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-amber-900 underline"
+              >
+                security rules
+              </a>{' '}
+              for the full policy.
+            </p>
+          </div>
+        </section>
+
+        {/* 11. Troubleshooting */}
+        <section id="troubleshooting" className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
+          <div className="flex items-center mb-6">
+            <span className="text-4xl mr-4" aria-hidden="true">
+              🩺
+            </span>
+            <h2 className="text-2xl font-bold text-gray-900">11. Troubleshooting</h2>
+          </div>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm border-collapse">
+              <thead>
+                <tr className="bg-gray-100">
+                  <th className="text-left p-3 font-semibold text-gray-900 border border-gray-200">
+                    Symptom
+                  </th>
+                  <th className="text-left p-3 font-semibold text-gray-900 border border-gray-200">
+                    Fix
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td className="p-3 border border-gray-200">No tools / hammer icon missing</td>
+                  <td className="p-3 border border-gray-200">
+                    Fully quit Claude Desktop (Cmd+Q or Quit from the tray) and reopen — a restart
+                    is required after adding a connector.
+                  </td>
+                </tr>
+                <tr className="bg-gray-50">
+                  <td className="p-3 border border-gray-200">Connector won&apos;t add on mobile</td>
+                  <td className="p-3 border border-gray-200">
+                    Add it on claude.ai in a browser instead; it syncs to mobile automatically.
+                  </td>
+                </tr>
+                <tr>
+                  <td className="p-3 border border-gray-200">Can&apos;t open a PR on our repo</td>
+                  <td className="p-3 border border-gray-200">
+                    Confirm you accepted the FreeForCharity org invitation and that the GitHub
+                    connector is signed in.
+                  </td>
+                </tr>
+                <tr className="bg-gray-50">
+                  <td className="p-3 border border-gray-200">Only one custom connector allowed</td>
+                  <td className="p-3 border border-gray-200">
+                    That is the free-tier limit — upgrade to Claude Pro for additional connectors.
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        {/* Footer nav */}
+        <div className="bg-gradient-to-br from-gray-50 to-amber-50 rounded-xl shadow-lg p-6 md:p-8 border border-gray-200">
+          <h2 className="text-xl font-bold text-gray-900 mb-4">Related</h2>
+          <ul className="space-y-2 text-sm text-gray-700">
+            <li>
+              <Link
+                href="/developer-environment-setup"
+                className="text-amber-700 underline hover:text-amber-900"
+              >
+                &larr; Back to Developer Environment Setup
+              </Link>
+            </li>
+            <li>
+              <Link
+                href="/developer-environment-setup/codex"
+                className="text-amber-700 underline hover:text-amber-900"
+              >
+                Prefer ChatGPT? Set up OpenAI Codex instead
+              </Link>
+            </li>
+            <li>
+              <Link
+                href="/developer-environment-setup/vscode"
+                className="text-amber-700 underline hover:text-amber-900"
+              >
+                Ready for more? Move up to VS Code (advanced)
+              </Link>
+            </li>
+          </ul>
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/src/app/developer-environment-setup/claude-desktop/page.tsx
+++ b/src/app/developer-environment-setup/claude-desktop/page.tsx
@@ -235,71 +235,35 @@ export default function ClaudeDesktopSetupGuide() {
             <h2 className="text-2xl font-bold text-gray-900">6. Connect GitHub via MCP</h2>
           </div>
           <p className="text-gray-700 mb-4">
-            Claude Desktop calls MCP servers <strong>connectors</strong>. You need the{' '}
-            <strong>GitHub</strong> connector. There are two ways to add it.
+            Claude Desktop calls MCP servers <strong>connectors</strong>, and the GitHub connector
+            is already available — you do not install anything by hand. The simplest path is to let
+            Claude set it up: paste the prompt below and follow whatever sign-in it walks you
+            through. (If you prefer to click through it yourself, the <strong>+</strong> button at
+            the bottom of the chat box has a <strong>Connectors</strong> option, and{' '}
+            <strong>Settings &rarr; Connectors</strong> lists what is enabled.)
           </p>
 
-          <div className="space-y-6">
-            <div className="border-l-4 border-amber-500 pl-4">
-              <h3 className="font-bold text-gray-900 mb-2">
-                Option A — Connectors directory (easiest)
-              </h3>
-              <p className="text-sm text-gray-700">
-                Click the <strong>+</strong> button at the bottom of the chat box and choose{' '}
-                <strong>Connectors</strong>. Browse the directory, add <strong>GitHub</strong>, and
-                follow the sign-in prompts. When a connector is active, a small{' '}
-                <strong>hammer / tools icon</strong> appears under the chat box showing how many
-                tools are available.
-              </p>
-            </div>
-
-            <div className="border-l-4 border-amber-500 pl-4">
-              <h3 className="font-bold text-gray-900 mb-2">
-                Option B — Edit the config file (manual)
-              </h3>
-              <p className="text-sm text-gray-700 mb-2">
-                Go to <strong>Settings &rarr; Developer &rarr; Edit Config</strong>. This opens{' '}
-                <code className="bg-gray-200 px-1 rounded">claude_desktop_config.json</code> (it is
-                created if missing). Claude Desktop uses the{' '}
-                <code className="bg-gray-200 px-1 rounded">mcpServers</code> key. The official
-                GitHub MCP server runs locally via Docker:
-              </p>
-              <div className="bg-gray-900 text-gray-100 p-4 rounded-lg text-xs font-mono overflow-x-auto">
-                <pre>{`{
-  "mcpServers": {
-    "github": {
-      "command": "docker",
-      "args": [
-        "run", "-i", "--rm",
-        "-e", "GITHUB_PERSONAL_ACCESS_TOKEN",
-        "ghcr.io/github/github-mcp-server"
-      ],
-      "env": {
-        "GITHUB_PERSONAL_ACCESS_TOKEN": "<your token>"
-      }
-    }
-  }
-}`}</pre>
-              </div>
-              <p className="text-sm text-gray-700 mt-2">
-                Fully quit Claude Desktop (Cmd+Q / Quit from the tray) and reopen it so the
-                connector loads.
-              </p>
-            </div>
-          </div>
-
           <PromptBox accent="amber">
-            &ldquo;I want to use you with the Free For Charity GitHub repositories. Walk me through
-            adding the GitHub connector in Claude Desktop, confirm the tools are available, and then
-            list the open issues on the FreeForCharity/FFC_Single_Page_Template repository.&rdquo;
+            &ldquo;I want to work on Free For Charity&apos;s website repositories on GitHub (the
+            organization is FreeForCharity). Set yourself up end to end: enable the GitHub connector
+            so you can read issues and open pull requests for me, and walk me through any sign-in.
+            When you are ready, confirm you can see the{' '}
+            <strong>FreeForCharity/FFC_Single_Page_Template</strong> repository and list its open
+            issues.&rdquo;
           </PromptBox>
+
+          <div className="mt-4 bg-emerald-50 border border-emerald-200 rounded-lg p-4 text-sm text-emerald-900">
+            When a connector is active, a small <strong>hammer / tools icon</strong> appears under
+            the chat box showing how many tools are available. If it is missing, fully quit Claude
+            Desktop (Cmd+Q or Quit from the tray) and reopen.
+          </div>
 
           <div className="mt-4 bg-amber-50 border-l-4 border-amber-500 p-4 rounded">
             <p className="text-amber-900 text-sm">
-              <strong>Token safety:</strong> if you use Option B, create a fine-grained Personal
-              Access Token with the narrowest scope that works, paste it only into the config file
-              on your own machine, and never put it in a repository, an issue, or a chat message.
-              Prefer Option A, where Claude manages the sign-in for you.
+              <strong>Let Claude handle the details.</strong> Connector names, sign-in screens, and
+              setup steps change over time, so we deliberately do not print exact configuration here
+              — Claude will use whatever the current version needs. Your job is to approve the
+              sign-in and never paste a token into chat, an issue, or a repository.
             </p>
           </div>
         </section>
@@ -363,8 +327,11 @@ export default function ClaudeDesktopSetupGuide() {
               <h3 className="font-bold text-gray-900 mb-1">Step 2 — Make the change on a branch</h3>
               <PromptBox accent="amber">
                 &ldquo;Create a new branch for issue #&lt;number&gt; (never commit to{' '}
-                <code>main</code>), make the change it describes, and show me exactly what you
-                changed before opening anything.&rdquo;
+                <code>main</code>) and make the change it describes. Our template is{' '}
+                <strong>FreeForCharity/FFC_Single_Page_Template</strong>; for an example of how a
+                finished Free For Charity site is structured, look at{' '}
+                <strong>FreeForCharity/FFC-IN-ffcadmin.org</strong> and match its conventions. Show
+                me exactly what you changed before opening anything.&rdquo;
               </PromptBox>
             </div>
             <div className="border-l-4 border-amber-500 pl-4">

--- a/src/app/developer-environment-setup/codex/page.tsx
+++ b/src/app/developer-environment-setup/codex/page.tsx
@@ -1,0 +1,531 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import Breadcrumbs from '@/components/Breadcrumbs'
+import PromptBox from '@/components/PromptBox'
+
+export const metadata: Metadata = {
+  title: 'OpenAI Codex Setup',
+  description:
+    'Set up OpenAI Codex for Free For Charity development. Sign in with your ChatGPT Plus or Pro account, connect GitHub, add the GitHub and Playwright MCP servers, and run the issue → PR → merge loop. Best if you already pay for ChatGPT.',
+  keywords:
+    'OpenAI Codex, Codex app, Codex CLI, ChatGPT Plus, ChatGPT Pro, MCP servers, GitHub MCP, AGENTS.md, Free For Charity, AI agent',
+}
+
+interface GuideSection {
+  id: string
+  number: string
+  title: string
+  icon: string
+}
+
+const sections: GuideSection[] = [
+  { id: 'overview', number: '1', title: 'Why Codex', icon: '⚫' },
+  { id: 'install', number: '2', title: 'Install the Codex App', icon: '⬇️' },
+  { id: 'sign-in', number: '3', title: 'Sign In with ChatGPT', icon: '🔑' },
+  { id: 'github', number: '4', title: 'Connect GitHub', icon: '🐙' },
+  { id: 'mcp', number: '5', title: 'Add MCP Servers', icon: '🔌' },
+  { id: 'agents-md', number: '6', title: 'Codex Reads AGENTS.md', icon: '📄' },
+  { id: 'first-change', number: '7', title: 'Your First Issue to Merge', icon: '🔁' },
+  { id: 'graduate', number: '8', title: 'When to Move to an IDE', icon: '🎓' },
+  { id: 'security', number: '9', title: 'Security and Good Habits', icon: '🛡️' },
+  { id: 'troubleshooting', number: '10', title: 'Troubleshooting', icon: '🩺' },
+]
+
+export default function CodexSetupGuide() {
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Breadcrumbs
+        items={[
+          { label: 'Home', href: '/' },
+          { label: 'Developer Environment Setup', href: '/developer-environment-setup' },
+          { label: 'OpenAI Codex' },
+        ]}
+      />
+
+      {/* Header */}
+      <div className="bg-gradient-to-r from-slate-700 to-slate-900 text-white py-16 px-4 sm:px-6 lg:px-8">
+        <div className="max-w-5xl mx-auto">
+          <div className="flex items-center mb-4">
+            <span className="text-5xl mr-4" aria-hidden="true">
+              ⚫
+            </span>
+            <div>
+              <h1 className="text-3xl md:text-4xl font-bold">OpenAI Codex Setup</h1>
+              <p className="text-slate-300 text-sm mt-1">
+                Best if you already pay for ChatGPT Plus or Pro
+              </p>
+            </div>
+          </div>
+          <p className="text-slate-200 text-lg max-w-3xl">
+            Codex is OpenAI&apos;s coding agent. If ChatGPT is already your AI, use it for Free For
+            Charity too: sign in with your ChatGPT account, connect GitHub, and run the same issue
+            &rarr; pull request &rarr; merge loop as every FFC repository.
+          </p>
+          <div className="mt-6 flex flex-wrap gap-3">
+            <span className="bg-white/15 px-3 py-1 rounded-full text-sm font-medium">
+              Beginner-friendly
+            </span>
+            <span className="bg-white/15 px-3 py-1 rounded-full text-sm font-medium">
+              Sign in with ChatGPT
+            </span>
+            <span className="bg-white/15 px-3 py-1 rounded-full text-sm font-medium">
+              ~20 minutes
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <main className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        {/* TOC */}
+        <div className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-10">
+          <h2 className="text-2xl font-bold text-gray-900 mb-6">On this page</h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+            {sections.map((section) => (
+              <a
+                key={section.id}
+                href={`#${section.id}`}
+                className="flex items-center p-2 rounded-lg hover:bg-slate-100 transition-colors group"
+              >
+                <span className="text-xl mr-3" aria-hidden="true">
+                  {section.icon}
+                </span>
+                <span className="text-sm font-medium text-gray-700 group-hover:text-slate-900">
+                  <span className="text-slate-600 font-bold mr-1">{section.number}.</span>
+                  {section.title}
+                </span>
+              </a>
+            ))}
+          </div>
+        </div>
+
+        {/* 1. Overview */}
+        <section id="overview" className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
+          <div className="flex items-center mb-6">
+            <span className="text-4xl mr-4" aria-hidden="true">
+              ⚫
+            </span>
+            <h2 className="text-2xl font-bold text-gray-900">1. Why Codex</h2>
+          </div>
+          <p className="text-gray-700 mb-4">
+            Codex comes as a <strong>desktop app</strong>, a <strong>command-line (CLI)</strong>{' '}
+            tool, an IDE extension, and a cloud agent at{' '}
+            <a
+              href="https://chatgpt.com/codex"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-slate-700 underline hover:text-slate-900"
+            >
+              chatgpt.com/codex
+            </a>
+            . They share one account and one configuration. If you already pay for ChatGPT, this is
+            the most natural way to help Free For Charity.
+          </p>
+          <div className="bg-slate-100 border-l-4 border-slate-500 p-4 rounded">
+            <p className="text-slate-800 text-sm">
+              <strong>Prefer Claude, Gemini, or Copilot?</strong> Use the AI you already pay for —
+              the{' '}
+              <Link
+                href="/developer-environment-setup"
+                className="text-slate-900 underline font-medium"
+              >
+                hub
+              </Link>{' '}
+              points you to the right guide. This one assumes Codex is your AI of choice.
+            </p>
+          </div>
+        </section>
+
+        {/* 2. Install */}
+        <section id="install" className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
+          <div className="flex items-center mb-6">
+            <span className="text-4xl mr-4" aria-hidden="true">
+              ⬇️
+            </span>
+            <h2 className="text-2xl font-bold text-gray-900">2. Install the Codex App</h2>
+          </div>
+          <p className="text-gray-700 mb-4">
+            The <strong>Codex app</strong> is available on macOS and Windows and is the easiest
+            place to start.
+          </p>
+          <ol className="space-y-3 text-sm text-gray-700 list-decimal ml-5">
+            <li>
+              Download the Codex app from the{' '}
+              <a
+                href="https://developers.openai.com/codex/app"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-slate-700 underline hover:text-slate-900"
+              >
+                Codex app page
+              </a>{' '}
+              and install it.
+            </li>
+            <li>Launch the app.</li>
+            <li>
+              <span className="text-gray-600">
+                (Optional, advanced) Prefer the terminal? The Codex CLI installs with{' '}
+                <code className="bg-gray-200 px-1 rounded">npm install -g @openai/codex</code>, then
+                run <code className="bg-gray-200 px-1 rounded">codex</code>. The CLI and app share
+                the same configuration.
+              </span>
+            </li>
+          </ol>
+        </section>
+
+        {/* 3. Sign in */}
+        <section id="sign-in" className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
+          <div className="flex items-center mb-6">
+            <span className="text-4xl mr-4" aria-hidden="true">
+              🔑
+            </span>
+            <h2 className="text-2xl font-bold text-gray-900">3. Sign In with ChatGPT</h2>
+          </div>
+          <p className="text-gray-700 mb-4">
+            Open the app (or run <code className="bg-gray-200 px-1 rounded">codex</code>) and choose{' '}
+            <strong>Sign in with ChatGPT</strong>. Codex is included with{' '}
+            <strong>ChatGPT Plus, Pro, Business, Edu, and Enterprise</strong> plans — Plus or Pro is
+            plenty for FFC work. (An OpenAI API key also works but needs extra setup; signing in
+            with ChatGPT is simpler.)
+          </p>
+        </section>
+
+        {/* 4. GitHub */}
+        <section id="github" className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
+          <div className="flex items-center mb-6">
+            <span className="text-4xl mr-4" aria-hidden="true">
+              🐙
+            </span>
+            <h2 className="text-2xl font-bold text-gray-900">4. Connect GitHub</h2>
+          </div>
+          <div className="space-y-5">
+            <div className="border-l-4 border-slate-500 pl-4">
+              <h3 className="font-bold text-gray-900 mb-2">4.1 — Confirm org membership</h3>
+              <p className="text-sm text-gray-700">
+                Make sure a maintainer has added you to the{' '}
+                <a
+                  href="https://github.com/FreeForCharity"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-slate-700 underline hover:text-slate-900"
+                >
+                  FreeForCharity
+                </a>{' '}
+                organization and accept the invitation.
+              </p>
+            </div>
+            <div className="border-l-4 border-slate-500 pl-4">
+              <h3 className="font-bold text-gray-900 mb-2">4.2 — Connect your repository</h3>
+              <p className="text-sm text-gray-700">
+                For the cloud agent, open the environment settings at{' '}
+                <a
+                  href="https://chatgpt.com/codex"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-slate-700 underline hover:text-slate-900"
+                >
+                  chatgpt.com/codex
+                </a>{' '}
+                and follow the steps to connect a GitHub repository (for example{' '}
+                <code className="bg-gray-200 px-1 rounded">
+                  FreeForCharity/FFC_Single_Page_Template
+                </code>
+                ). The desktop app and CLI can also work on a local clone you open directly.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* 5. MCP */}
+        <section id="mcp" className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
+          <div className="flex items-center mb-6">
+            <span className="text-4xl mr-4" aria-hidden="true">
+              🔌
+            </span>
+            <h2 className="text-2xl font-bold text-gray-900">5. Add MCP Servers</h2>
+          </div>
+          <p className="text-gray-700 mb-4">
+            Codex supports MCP servers in both the app/CLI and the IDE extension. Add{' '}
+            <strong>GitHub</strong> (and, once you are doing browser tests,{' '}
+            <strong>Playwright</strong>
+            ). The quickest way is the{' '}
+            <code className="bg-gray-200 px-1 rounded">codex mcp add</code> command:
+          </p>
+          <div className="bg-gray-900 text-gray-100 p-4 rounded-lg text-sm font-mono overflow-x-auto">
+            <p className="text-slate-400"># Add the GitHub and Playwright MCP servers</p>
+            <p>codex mcp add github -- npx @github/github-mcp-server</p>
+            <p>codex mcp add playwright -- npx @playwright/mcp</p>
+          </div>
+          <p className="text-gray-700 mt-4 mb-2 text-sm">
+            Prefer a config file? Edit{' '}
+            <code className="bg-gray-200 px-1 rounded">~/.codex/config.toml</code>:
+          </p>
+          <div className="bg-gray-900 text-gray-100 p-4 rounded-lg text-xs font-mono overflow-x-auto">
+            <pre>{`[mcp_servers.github]
+command = "npx"
+args = ["@github/github-mcp-server"]
+
+[mcp_servers.playwright]
+command = "npx"
+args = ["@playwright/mcp"]`}</pre>
+          </div>
+
+          <PromptBox accent="slate">
+            &ldquo;Add the GitHub and Playwright MCP servers to my Codex configuration, then confirm
+            they are connected and list the open issues on
+            FreeForCharity/FFC_Single_Page_Template.&rdquo;
+          </PromptBox>
+
+          <div className="mt-4 bg-slate-100 border-l-4 border-slate-500 p-4 rounded">
+            <p className="text-slate-800 text-sm">
+              <strong>Token safety:</strong> the GitHub MCP server authenticates with a token.
+              Provide it through an environment variable or Codex&apos;s secure configuration —
+              never hard-code it in a file you might commit.
+            </p>
+          </div>
+        </section>
+
+        {/* 6. AGENTS.md */}
+        <section id="agents-md" className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
+          <div className="flex items-center mb-6">
+            <span className="text-4xl mr-4" aria-hidden="true">
+              📄
+            </span>
+            <h2 className="text-2xl font-bold text-gray-900">6. Codex Reads AGENTS.md</h2>
+          </div>
+          <p className="text-gray-700 mb-4">
+            Codex automatically reads an <code className="bg-gray-200 px-1 rounded">AGENTS.md</code>{' '}
+            file for project-specific instructions — and{' '}
+            <strong>every Free For Charity repository ships one.</strong> It documents our tech
+            stack, the pre-commit/CI order (format &rarr; lint &rarr; build &rarr; test), naming
+            conventions, and security rules. You get the house style for free; no extra prompting
+            needed.
+          </p>
+          <div className="bg-emerald-50 border border-emerald-200 rounded-lg p-4 text-sm text-emerald-900">
+            Once GitHub is connected and the repo is open, Codex already knows how we work. Just
+            describe the change.
+          </div>
+        </section>
+
+        {/* 7. First change */}
+        <section id="first-change" className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
+          <div className="flex items-center mb-6">
+            <span className="text-4xl mr-4" aria-hidden="true">
+              🔁
+            </span>
+            <h2 className="text-2xl font-bold text-gray-900">7. Your First Issue to Merge</h2>
+          </div>
+          <p className="text-gray-700 mb-4">
+            Run the full Free For Charity contribution loop on a small, safe change.
+          </p>
+          <div className="space-y-4">
+            <div className="border-l-4 border-slate-500 pl-4">
+              <h3 className="font-bold text-gray-900 mb-1">Step 1 — Pick or open an issue</h3>
+              <PromptBox accent="slate">
+                &ldquo;List the open issues on FreeForCharity/FFC_Single_Page_Template. If none
+                cover the small change I want, open one titled &lsquo;&lt;short
+                title&gt;&rsquo;.&rdquo;
+              </PromptBox>
+            </div>
+            <div className="border-l-4 border-slate-500 pl-4">
+              <h3 className="font-bold text-gray-900 mb-1">Step 2 — Make the change on a branch</h3>
+              <PromptBox accent="slate">
+                &ldquo;Create a branch for issue #&lt;number&gt; (never <code>main</code>), make the
+                change, and show me the diff to review before opening anything.&rdquo;
+              </PromptBox>
+            </div>
+            <div className="border-l-4 border-slate-500 pl-4">
+              <h3 className="font-bold text-gray-900 mb-1">Step 3 — Open a PR and watch CI</h3>
+              <PromptBox accent="slate">
+                &ldquo;Open a pull request with a Conventional Commit title, link the issue with
+                &lsquo;Fixes #&lt;number&gt;&rsquo;, then watch the CI checks (format, lint, build,
+                tests, Playwright) and fix anything that fails.&rdquo;
+              </PromptBox>
+            </div>
+            <div className="border-l-4 border-slate-500 pl-4">
+              <h3 className="font-bold text-gray-900 mb-1">Step 4 — Review and merge</h3>
+              <p className="text-sm text-gray-700">
+                Review the diff on GitHub. Once a maintainer approves and all checks are green, the
+                pull request merges.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* 8. Graduate */}
+        <section id="graduate" className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
+          <div className="flex items-center mb-6">
+            <span className="text-4xl mr-4" aria-hidden="true">
+              🎓
+            </span>
+            <h2 className="text-2xl font-bold text-gray-900">8. When to Move to an IDE</h2>
+          </div>
+          <p className="text-gray-700 mb-4">
+            The Codex app and CLI already cover the vast majority of charity website work. Move into
+            a full IDE only when you want a tighter local edit-run-debug loop or a large refactor.
+            Codex has a first-class extension for both editors:
+          </p>
+          <ul className="space-y-2 text-sm text-gray-700">
+            <li className="flex items-start">
+              <span className="text-blue-600 mr-2">&bull;</span>
+              <span>
+                <Link
+                  href="/developer-environment-setup/vscode"
+                  className="text-slate-700 underline hover:text-slate-900"
+                >
+                  VS Code
+                </Link>{' '}
+                — run Codex as an in-editor agent alongside builds, tests, and Playwright.
+              </span>
+            </li>
+            <li className="flex items-start">
+              <span className="text-blue-600 mr-2">&bull;</span>
+              <span>
+                <Link
+                  href="/developer-environment-setup/google-antigravity"
+                  className="text-slate-700 underline hover:text-slate-900"
+                >
+                  Google Antigravity
+                </Link>{' '}
+                — an agent-first IDE you can also drive with Codex.
+              </span>
+            </li>
+          </ul>
+        </section>
+
+        {/* 9. Security */}
+        <section id="security" className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
+          <div className="flex items-center mb-6">
+            <span className="text-4xl mr-4" aria-hidden="true">
+              🛡️
+            </span>
+            <h2 className="text-2xl font-bold text-gray-900">9. Security and Good Habits</h2>
+          </div>
+          <ul className="space-y-2 text-sm text-gray-700">
+            <li className="flex items-start">
+              <span className="text-red-500 mr-2 mt-0.5">&#10005;</span>
+              <span>
+                Never paste tokens or keys into chat, code, commits, or config you might commit.
+              </span>
+            </li>
+            <li className="flex items-start">
+              <span className="text-slate-600 mr-2 mt-0.5">&#10003;</span>
+              <span>
+                Keep Codex&apos;s tool-approval prompts on while you are learning, so you see each
+                action before it runs.
+              </span>
+            </li>
+            <li className="flex items-start">
+              <span className="text-slate-600 mr-2 mt-0.5">&#10003;</span>
+              <span>Review the diff before a pull request merges.</span>
+            </li>
+            <li className="flex items-start">
+              <span className="text-slate-600 mr-2 mt-0.5">&#10003;</span>
+              <span>Always work on a branch and open a PR — never commit straight to main.</span>
+            </li>
+          </ul>
+          <div className="mt-4 bg-slate-100 border-l-4 border-slate-500 p-4 rounded">
+            <p className="text-slate-800 text-sm">
+              See the FFC{' '}
+              <a
+                href="https://github.com/FreeForCharity/FFC-IN-ffcadmin.org/blob/main/.claude/rules/01-security.md"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-slate-900 underline"
+              >
+                security rules
+              </a>{' '}
+              for the full policy.
+            </p>
+          </div>
+        </section>
+
+        {/* 10. Troubleshooting */}
+        <section id="troubleshooting" className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
+          <div className="flex items-center mb-6">
+            <span className="text-4xl mr-4" aria-hidden="true">
+              🩺
+            </span>
+            <h2 className="text-2xl font-bold text-gray-900">10. Troubleshooting</h2>
+          </div>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm border-collapse">
+              <thead>
+                <tr className="bg-gray-100">
+                  <th className="text-left p-3 font-semibold text-gray-900 border border-gray-200">
+                    Symptom
+                  </th>
+                  <th className="text-left p-3 font-semibold text-gray-900 border border-gray-200">
+                    Fix
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td className="p-3 border border-gray-200">Sign-in not recognized</td>
+                  <td className="p-3 border border-gray-200">
+                    Confirm your ChatGPT plan includes Codex (Plus/Pro/Business/Edu/Enterprise) and
+                    sign in again.
+                  </td>
+                </tr>
+                <tr className="bg-gray-50">
+                  <td className="p-3 border border-gray-200">MCP server not connecting</td>
+                  <td className="p-3 border border-gray-200">
+                    Re-run <code className="bg-gray-200 px-1 rounded">codex mcp add</code> or check{' '}
+                    <code className="bg-gray-200 px-1 rounded">~/.codex/config.toml</code>; raise{' '}
+                    <code className="bg-gray-200 px-1 rounded">startup_timeout_sec</code> if it is
+                    slow to launch.
+                  </td>
+                </tr>
+                <tr>
+                  <td className="p-3 border border-gray-200">Can&apos;t open a PR on our repo</td>
+                  <td className="p-3 border border-gray-200">
+                    Confirm FreeForCharity org membership and that the repo is connected at
+                    chatgpt.com/codex.
+                  </td>
+                </tr>
+                <tr className="bg-gray-50">
+                  <td className="p-3 border border-gray-200">Codex ignores house style</td>
+                  <td className="p-3 border border-gray-200">
+                    Make sure you are working in the repo so Codex can read its{' '}
+                    <code className="bg-gray-200 px-1 rounded">AGENTS.md</code>.
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        {/* Footer nav */}
+        <div className="bg-gradient-to-br from-gray-50 to-slate-100 rounded-xl shadow-lg p-6 md:p-8 border border-gray-200">
+          <h2 className="text-xl font-bold text-gray-900 mb-4">Related</h2>
+          <ul className="space-y-2 text-sm text-gray-700">
+            <li>
+              <Link
+                href="/developer-environment-setup"
+                className="text-slate-700 underline hover:text-slate-900"
+              >
+                &larr; Back to Developer Environment Setup
+              </Link>
+            </li>
+            <li>
+              <Link
+                href="/developer-environment-setup/claude-desktop"
+                className="text-slate-700 underline hover:text-slate-900"
+              >
+                Prefer Claude? Set up Claude Desktop instead
+              </Link>
+            </li>
+            <li>
+              <Link
+                href="/developer-environment-setup/vscode"
+                className="text-slate-700 underline hover:text-slate-900"
+              >
+                Ready for more? Move up to VS Code (advanced)
+              </Link>
+            </li>
+          </ul>
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/src/app/developer-environment-setup/codex/page.tsx
+++ b/src/app/developer-environment-setup/codex/page.tsx
@@ -160,13 +160,12 @@ export default function CodexSetupGuide() {
               </a>{' '}
               and install it.
             </li>
-            <li>Launch the app.</li>
+            <li>Launch the app and sign in (next step).</li>
             <li>
               <span className="text-gray-600">
-                (Optional, advanced) Prefer the terminal? The Codex CLI installs with{' '}
-                <code className="bg-gray-200 px-1 rounded">npm install -g @openai/codex</code>, then
-                run <code className="bg-gray-200 px-1 rounded">codex</code>. The CLI and app share
-                the same configuration.
+                (Optional, advanced) There is also a Codex command-line tool if you prefer the
+                terminal. It shares the same account and configuration as the app — ask Codex to set
+                it up for you when you get there.
               </span>
             </li>
           </ol>
@@ -181,8 +180,7 @@ export default function CodexSetupGuide() {
             <h2 className="text-2xl font-bold text-gray-900">3. Sign In with ChatGPT</h2>
           </div>
           <p className="text-gray-700 mb-4">
-            Open the app (or run <code className="bg-gray-200 px-1 rounded">codex</code>) and choose{' '}
-            <strong>Sign in with ChatGPT</strong>. Codex is included with{' '}
+            Open the app and choose <strong>Sign in with ChatGPT</strong>. Codex is included with{' '}
             <strong>ChatGPT Plus, Pro, Business, Edu, and Enterprise</strong> plans — Plus or Pro is
             plenty for FFC work. (An OpenAI API key also works but needs extra setup; signing in
             with ChatGPT is simpler.)
@@ -244,42 +242,28 @@ export default function CodexSetupGuide() {
             <h2 className="text-2xl font-bold text-gray-900">5. Add MCP Servers</h2>
           </div>
           <p className="text-gray-700 mb-4">
-            Codex supports MCP servers in both the app/CLI and the IDE extension. Add{' '}
-            <strong>GitHub</strong> (and, once you are doing browser tests,{' '}
-            <strong>Playwright</strong>
-            ). The quickest way is the{' '}
-            <code className="bg-gray-200 px-1 rounded">codex mcp add</code> command:
+            Codex understands MCP servers in the app, the CLI, and the IDE extension. You need{' '}
+            <strong>GitHub</strong> (and, once you are running browser tests,{' '}
+            <strong>Playwright</strong>). Rather than memorize commands or config files — which
+            change between versions — just ask Codex to set them up:
           </p>
-          <div className="bg-gray-900 text-gray-100 p-4 rounded-lg text-sm font-mono overflow-x-auto">
-            <p className="text-slate-400"># Add the GitHub and Playwright MCP servers</p>
-            <p>codex mcp add github -- npx @github/github-mcp-server</p>
-            <p>codex mcp add playwright -- npx @playwright/mcp</p>
-          </div>
-          <p className="text-gray-700 mt-4 mb-2 text-sm">
-            Prefer a config file? Edit{' '}
-            <code className="bg-gray-200 px-1 rounded">~/.codex/config.toml</code>:
-          </p>
-          <div className="bg-gray-900 text-gray-100 p-4 rounded-lg text-xs font-mono overflow-x-auto">
-            <pre>{`[mcp_servers.github]
-command = "npx"
-args = ["@github/github-mcp-server"]
-
-[mcp_servers.playwright]
-command = "npx"
-args = ["@playwright/mcp"]`}</pre>
-          </div>
 
           <PromptBox accent="slate">
-            &ldquo;Add the GitHub and Playwright MCP servers to my Codex configuration, then confirm
-            they are connected and list the open issues on
-            FreeForCharity/FFC_Single_Page_Template.&rdquo;
+            &ldquo;I want to work on Free For Charity&apos;s website repositories on GitHub
+            (organization: FreeForCharity). Set yourself up: enable the GitHub MCP server so you can
+            read issues and open pull requests, and the Playwright MCP server if we will run the
+            site&apos;s end-to-end tests. Install or enable whatever you need, walk me through any
+            sign-in, then confirm you can see{' '}
+            <strong>FreeForCharity/FFC_Single_Page_Template</strong> and list its open
+            issues.&rdquo;
           </PromptBox>
 
           <div className="mt-4 bg-slate-100 border-l-4 border-slate-500 p-4 rounded">
             <p className="text-slate-800 text-sm">
-              <strong>Token safety:</strong> the GitHub MCP server authenticates with a token.
-              Provide it through an environment variable or Codex&apos;s secure configuration —
-              never hard-code it in a file you might commit.
+              <strong>Let Codex handle the particulars.</strong> Server names and setup steps drift
+              over time, so we keep this prompt-driven instead of pasting config that could be
+              stale. The GitHub server needs a token — provide it only through Codex&apos;s secure
+              prompt or an environment variable, and never paste it into a file, an issue, or chat.
             </p>
           </div>
         </section>
@@ -329,8 +313,11 @@ args = ["@playwright/mcp"]`}</pre>
             <div className="border-l-4 border-slate-500 pl-4">
               <h3 className="font-bold text-gray-900 mb-1">Step 2 — Make the change on a branch</h3>
               <PromptBox accent="slate">
-                &ldquo;Create a branch for issue #&lt;number&gt; (never <code>main</code>), make the
-                change, and show me the diff to review before opening anything.&rdquo;
+                &ldquo;Create a branch for issue #&lt;number&gt; (never <code>main</code>) and make
+                the change. Follow the repo&apos;s <code>AGENTS.md</code>; our template is{' '}
+                <strong>FreeForCharity/FFC_Single_Page_Template</strong>, and{' '}
+                <strong>FreeForCharity/FFC-IN-ffcadmin.org</strong> is a live example of a finished
+                site to match. Show me the diff to review before opening anything.&rdquo;
               </PromptBox>
             </div>
             <div className="border-l-4 border-slate-500 pl-4">
@@ -470,10 +457,8 @@ args = ["@playwright/mcp"]`}</pre>
                 <tr className="bg-gray-50">
                   <td className="p-3 border border-gray-200">MCP server not connecting</td>
                   <td className="p-3 border border-gray-200">
-                    Re-run <code className="bg-gray-200 px-1 rounded">codex mcp add</code> or check{' '}
-                    <code className="bg-gray-200 px-1 rounded">~/.codex/config.toml</code>; raise{' '}
-                    <code className="bg-gray-200 px-1 rounded">startup_timeout_sec</code> if it is
-                    slow to launch.
+                    Ask Codex to re-enable the server and confirm it started; if it is slow to
+                    launch, ask it to increase the server&apos;s startup timeout.
                   </td>
                 </tr>
                 <tr>

--- a/src/app/developer-environment-setup/google-antigravity/page.tsx
+++ b/src/app/developer-environment-setup/google-antigravity/page.tsx
@@ -279,36 +279,16 @@ export default function GoogleAntigravitySetupGuide() {
             <h2 className="text-2xl font-bold text-gray-900">5. Install Git, Node, and pnpm</h2>
           </div>
           <p className="text-gray-700 mb-4">
-            FFC sites are Next.js projects, so you need Git, Node.js 20+ and pnpm.{' '}
-            <strong>The recommended way to install them is to let the agent do it for you.</strong>{' '}
-            Open the Agent Manager and paste the prompt below — the agent will detect your operating
-            system, run the installs, and verify the versions.
+            FFC sites are Next.js projects, so you need Git, Node.js 20+ and pnpm 9 (our repos pin
+            pnpm 9). <strong>Do not look up install commands — let the agent do it for you.</strong>{' '}
+            Open the Agent Manager and ask:
           </p>
           <PromptBox accent="emerald">
             &ldquo;Set up my machine for Free For Charity Next.js development. Check whether Git,
-            Node.js 20 LTS or newer, and pnpm are installed. For anything missing, install it using
-            the right method for my operating system, then run <code>git --version</code>,{' '}
-            <code>node --version</code>, and <code>pnpm --version</code> and show me the output to
-            confirm everything works.&rdquo;
+            Node.js 20 LTS or newer, and pnpm 9 are installed, install anything missing using the
+            right method for my operating system, and confirm the versions when you are done. Our
+            repositories pin pnpm 9, so match that.&rdquo;
           </PromptBox>
-          <p className="text-gray-700 mt-4 mb-2 text-sm">
-            Prefer to check by hand first? Open the Editor terminal and run:
-          </p>
-          <div className="bg-gray-900 text-gray-100 p-4 rounded-lg text-sm font-mono overflow-x-auto">
-            <p className="text-emerald-400">
-              # Verify versions (the agent can install anything missing)
-            </p>
-            <p>git --version</p>
-            <p>node --version &nbsp;&nbsp;# should be v20 or newer</p>
-            <p>pnpm --version</p>
-          </div>
-          <p className="text-gray-600 text-xs mt-3">
-            If you already have Node but not pnpm, install the major version our repos pin in{' '}
-            <code className="bg-gray-200 px-1 rounded">package.json</code> with{' '}
-            <code className="bg-gray-200 px-1 rounded">npm install -g pnpm@9</code> (or run{' '}
-            <code className="bg-gray-200 px-1 rounded">corepack enable</code>) — or just let the
-            agent handle it with the prompt above.
-          </p>
         </section>
 
         {/* 6. GitHub */}
@@ -344,23 +324,18 @@ export default function GoogleAntigravitySetupGuide() {
               <h3 className="font-bold text-gray-900 mb-2">
                 6.2 — Sign in to GitHub in the editor
               </h3>
-              <p className="text-sm text-gray-700 mb-2">
+              <p className="text-sm text-gray-700">
                 Use the built-in GitHub sign-in (Accounts / Source Control panel) and authorize in
                 the browser. This stores credentials securely so Git can push without pasting
-                passwords. You can confirm in the terminal:
+                passwords. The agent can set up your Git identity and confirm everything for you —
+                just ask.
               </p>
-              <div className="bg-gray-900 text-gray-100 p-3 rounded-lg text-sm font-mono">
-                git config --global user.name &quot;Your Name&quot;
-                <br />
-                git config --global user.email &quot;you@example.com&quot;
-              </div>
             </div>
           </div>
           <PromptBox accent="emerald">
-            &ldquo;Help me connect this editor to GitHub. Set my global Git <code>user.name</code>{' '}
-            and <code>user.email</code>, confirm I am signed in to GitHub, and verify I have access
-            to the FreeForCharity organization. Walk me through any browser authorization that is
-            needed.&rdquo;
+            &ldquo;Help me connect this editor to GitHub. Set my Git name and email, confirm I am
+            signed in, and verify I have access to the FreeForCharity organization. Walk me through
+            any browser authorization that is needed.&rdquo;
           </PromptBox>
           <div className="mt-4 bg-amber-50 border-l-4 border-amber-500 p-4 rounded">
             <p className="text-amber-900 text-sm">
@@ -380,69 +355,26 @@ export default function GoogleAntigravitySetupGuide() {
           </div>
           <p className="text-gray-700 mb-4">
             MCP (Model Context Protocol) servers give the agent extra abilities. For FFC work you
-            need at least <strong>Playwright</strong> (browser testing) and <strong>GitHub</strong>{' '}
-            (issues and PRs). Antigravity offers two ways to add them.
-          </p>
-
-          <div className="space-y-6">
-            <div className="border-l-4 border-emerald-600 pl-4">
-              <h3 className="font-bold text-gray-900 mb-2">Option A — MCP Store (easiest)</h3>
-              <p className="text-sm text-gray-700">
-                Open the <strong>MCP Store</strong> from the Agent Manager / settings, search for
-                the server you want (for example <em>Playwright</em> or <em>GitHub</em>), and click{' '}
-                <strong>Install</strong>. Antigravity walks you through any sign-in the server
-                needs.
-              </p>
-            </div>
-
-            <div className="border-l-4 border-emerald-600 pl-4">
-              <h3 className="font-bold text-gray-900 mb-2">Option B — Edit the MCP config</h3>
-              <p className="text-sm text-gray-700 mb-2">
-                Open Antigravity&apos;s MCP configuration (Settings &rarr; search &ldquo;MCP&rdquo;
-                &rarr; <em>Edit configuration</em>). Antigravity uses the{' '}
-                <code className="bg-gray-200 px-1 rounded">mcpServers</code> key (the same style as
-                other VS Code-derived agent editors):
-              </p>
-              <div className="bg-gray-900 text-gray-100 p-4 rounded-lg text-xs font-mono overflow-x-auto">
-                <pre>{`{
-  "mcpServers": {
-    "playwright": {
-      "command": "npx",
-      "args": ["@playwright/mcp@latest"]
-    },
-    "github": {
-      "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-github"]
-    }
-  }
-}`}</pre>
-              </div>
-              <p className="text-sm text-gray-700 mt-2">
-                After saving, reload the agent. The new tools appear in the agent&apos;s tool list.
-              </p>
-            </div>
-          </div>
-
-          <p className="text-gray-700 mt-5 mb-1 text-sm">
-            <strong>Recommended:</strong> let the agent add the servers for you. Paste this into the
-            Agent Manager:
+            need at least <strong>GitHub</strong> (issues and PRs) and <strong>Playwright</strong>{' '}
+            (browser testing). Antigravity ships an <strong>MCP Store</strong> where these are
+            available as one-click installs — you do not assemble any configuration by hand. The
+            easiest path is to let the agent enable them:
           </p>
           <PromptBox accent="emerald">
-            &ldquo;Add the Playwright and GitHub MCP servers to my Antigravity configuration. Use{' '}
-            <code>npx @playwright/mcp@latest</code> for Playwright and{' '}
-            <code>npx -y @modelcontextprotocol/server-github</code> for GitHub under the{' '}
-            <code>mcpServers</code> key. Then reload so the new tools are available, and confirm
-            they are connected.&rdquo;
+            &ldquo;Enable the GitHub and Playwright MCP servers for me — install them from the MCP
+            Store or wherever they live in this version, walk me through any sign-in, then reload
+            and confirm the new tools are available. I&apos;ll use them to work on
+            FreeForCharity&apos;s repositories.&rdquo;
           </PromptBox>
           <p className="text-gray-600 text-xs mt-2">
             The first Playwright run downloads a browser — that is expected.
           </p>
           <div className="mt-3 bg-amber-50 border-l-4 border-amber-500 p-4 rounded">
             <p className="text-amber-900 text-sm">
-              The GitHub MCP server authenticates with a token. Provide it through the editor&apos;s
-              secure prompt or an environment variable —{' '}
-              <strong>never hard-code a token in the JSON file</strong>, which lives in your repo or
-              home folder.
+              <strong>Let the agent handle the particulars.</strong> Store entries and config
+              formats change between versions, so we keep this prompt-driven. The GitHub server
+              needs a token — provide it through the editor&apos;s secure prompt or an environment
+              variable, and never paste a token into a file, an issue, or chat.
             </p>
           </div>
         </section>
@@ -468,31 +400,21 @@ export default function GoogleAntigravitySetupGuide() {
             is the starting point for new charity sites and ships the full toolchain.
           </p>
           <p className="text-gray-700 mb-1 text-sm">
-            <strong>Recommended:</strong> have the agent clone and verify the repo. Paste this into
-            the Agent Manager:
+            Let the agent clone it, install dependencies, and run the checks — it knows the commands
+            for the current toolchain, so you do not have to:
           </p>
           <PromptBox accent="emerald">
-            &ldquo;Clone the repository{' '}
-            <code>https://github.com/FreeForCharity/FFC_Single_Page_Template.git</code>, open it,
-            install dependencies with <code>pnpm install</code>, then run{' '}
-            <code>pnpm run build</code> and <code>pnpm run test:e2e</code>. Do not cancel
-            long-running commands. Tell me if anything fails and how to fix it.&rdquo;
+            &ldquo;Clone <strong>FreeForCharity/FFC_Single_Page_Template</strong>, open it, install
+            dependencies, then run our full set of checks in the order our <code>AGENTS.md</code>{' '}
+            describes (formatting, linting, build, tests, and end-to-end tests). For an example of a
+            finished Free For Charity site, also pull up{' '}
+            <strong>FreeForCharity/FFC-IN-ffcadmin.org</strong>. Do not cancel long-running
+            commands; tell me if anything fails and how to fix it.&rdquo;
           </PromptBox>
-          <p className="text-gray-700 mt-4 mb-2 text-sm">
-            Prefer to do it by hand? The equivalent commands are:
-          </p>
-          <div className="bg-gray-900 text-gray-100 p-4 rounded-lg text-sm font-mono overflow-x-auto">
-            <p className="text-emerald-400"># Clone, install, and verify the toolchain</p>
-            <p>git clone https://github.com/FreeForCharity/FFC_Single_Page_Template.git</p>
-            <p>cd FFC_Single_Page_Template</p>
-            <p>pnpm install</p>
-            <p>pnpm run build</p>
-            <p>pnpm run test:e2e &nbsp;&nbsp;# exercises the Playwright setup</p>
-          </div>
           <div className="mt-4 bg-blue-50 border-l-4 border-blue-600 p-4 rounded">
             <p className="text-blue-900 text-sm">
               In the Editor you can also choose <strong>Open Folder</strong> to open the cloned
-              directory. Do not cancel the build or E2E tests — they can take a minute.
+              directory. The build and end-to-end tests can take a minute — let them finish.
             </p>
           </div>
         </section>
@@ -531,26 +453,27 @@ export default function GoogleAntigravitySetupGuide() {
               </p>
               <PromptBox accent="emerald">
                 &ldquo;Create a new branch for issue #&lt;number&gt; (do not commit to{' '}
-                <code>main</code>), then make the change it describes. When you are done, show me
-                the full diff so I can review it before we go further.&rdquo;
+                <code>main</code>) and make the change it describes. Follow the repo&apos;s{' '}
+                <code>AGENTS.md</code> conventions, and use{' '}
+                <strong>FreeForCharity/FFC-IN-ffcadmin.org</strong> as an example of how a finished
+                site is built. When you are done, show me the full diff so I can review it before we
+                go further.&rdquo;
               </PromptBox>
             </div>
             <div className="border-l-4 border-emerald-600 pl-4">
               <h3 className="font-bold text-gray-900 mb-1">Step 3 — Run the checks</h3>
               <p className="text-sm text-gray-700">
-                Have the agent run <code className="bg-gray-200 px-1 rounded">pnpm run format</code>
-                , <code className="bg-gray-200 px-1 rounded">pnpm run lint</code>,{' '}
-                <code className="bg-gray-200 px-1 rounded">pnpm run build</code>,{' '}
-                <code className="bg-gray-200 px-1 rounded">pnpm test</code>, and{' '}
-                <code className="bg-gray-200 px-1 rounded">pnpm run test:e2e</code> — in that order,
-                which matches CI (build before tests, since some tests check the build output).
+                Have the agent run our full set of checks — formatting, linting, build, unit tests,
+                and end-to-end tests — in the order our{' '}
+                <code className="bg-gray-200 px-1 rounded">AGENTS.md</code> specifies (build before
+                tests, to match CI). You do not need to remember the exact commands; the agent reads
+                them from the repo.
               </p>
               <PromptBox accent="emerald">
-                &ldquo;Run the full pre-commit checklist in this order, which matches CI:{' '}
-                <code>pnpm run format</code>, <code>pnpm run lint</code>,{' '}
-                <code>pnpm run build</code>, <code>pnpm test</code>, and{' '}
-                <code>pnpm run test:e2e</code>. Do not cancel anything. Fix any failures and re-run
-                until everything passes.&rdquo;
+                &ldquo;Run our full pre-commit checklist in the order documented in this repo&apos;s{' '}
+                <code>AGENTS.md</code> (formatting, linting, build, unit tests, then end-to-end
+                tests). Do not cancel anything. Fix any failures and re-run until everything
+                passes.&rdquo;
               </PromptBox>
             </div>
             <div className="border-l-4 border-emerald-600 pl-4">
@@ -666,17 +589,14 @@ export default function GoogleAntigravitySetupGuide() {
                 <tr className="bg-gray-50">
                   <td className="p-3 border border-gray-200">MCP tools not showing</td>
                   <td className="p-3 border border-gray-200">
-                    Reload the agent after editing the config; confirm{' '}
-                    <code className="bg-gray-200 px-1 rounded">mcpServers</code> (not{' '}
-                    <code className="bg-gray-200 px-1 rounded">servers</code>) is the root key.
+                    Reload the agent after enabling a server; if it still does not appear, ask the
+                    agent to re-enable it and confirm it started.
                   </td>
                 </tr>
                 <tr>
                   <td className="p-3 border border-gray-200">Playwright cannot launch a browser</td>
                   <td className="p-3 border border-gray-200">
-                    Run{' '}
-                    <code className="bg-gray-200 px-1 rounded">pnpm exec playwright install</code>{' '}
-                    once to download browsers.
+                    Ask the agent to install the Playwright browsers once.
                   </td>
                 </tr>
                 <tr className="bg-gray-50">

--- a/src/app/developer-environment-setup/google-antigravity/page.tsx
+++ b/src/app/developer-environment-setup/google-antigravity/page.tsx
@@ -77,6 +77,38 @@ export default function GoogleAntigravitySetupGuide() {
       </div>
 
       <main className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        {/* Advanced positioning */}
+        <div className="bg-indigo-50 border border-indigo-200 rounded-xl p-5 mb-8">
+          <p className="text-sm text-indigo-900">
+            <strong>This is an advanced environment.</strong> If you are new to development, start
+            with{' '}
+            <Link
+              href="/developer-environment-setup/claude-desktop"
+              className="text-indigo-800 underline font-medium"
+            >
+              Claude Desktop
+            </Link>{' '}
+            — most charity website work never needs more. Come here when you want local builds,
+            browser debugging, or larger refactors. Antigravity ships Gemini agents, but you can
+            also run{' '}
+            <Link
+              href="/developer-environment-setup/claude-desktop"
+              className="text-indigo-800 underline"
+            >
+              Claude
+            </Link>{' '}
+            or{' '}
+            <Link href="/developer-environment-setup/codex" className="text-indigo-800 underline">
+              Codex
+            </Link>{' '}
+            as the agent. See the{' '}
+            <Link href="/developer-environment-setup" className="text-indigo-800 underline">
+              setup hub
+            </Link>{' '}
+            to compare options.
+          </p>
+        </div>
+
         {/* TOC */}
         <div className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-10">
           <h2 className="text-2xl font-bold text-gray-900 mb-6">On this page</h2>

--- a/src/app/developer-environment-setup/page.tsx
+++ b/src/app/developer-environment-setup/page.tsx
@@ -5,86 +5,135 @@ import Breadcrumbs from '@/components/Breadcrumbs'
 export const metadata: Metadata = {
   title: 'Developer Environment Setup',
   description:
-    'Set up your individual developer environment for Free For Charity website development and digital infrastructure. Choose Google Antigravity or Microsoft VS Code, connect to GitHub, and enable MCP servers so AI agents can open issues, make PRs, and merge changes.',
+    'Start developing for Free For Charity with the AI agent of your choice — Claude, OpenAI Codex, Google Gemini, or GitHub Copilot. The easiest path is your AI’s native desktop app; advanced developers move into VS Code or Google Antigravity. New here? We recommend Claude Pro with Claude Desktop and Claude Mobile.',
   keywords:
-    'developer environment, Google Antigravity, VS Code, MCP servers, Playwright, GitHub, AI agents, Free For Charity, nonprofit web development',
+    'developer environment, AI agents, Claude, OpenAI Codex, Google Gemini, GitHub Copilot, Claude Desktop, Antigravity, VS Code, MCP servers, Free For Charity',
 }
 
-interface EnvironmentCard {
+interface Agent {
+  name: string
+  vendor: string
+  easiest: string
+  easiestHref?: string
+  advanced: string
+  advancedHref: string
+  ifYouPay: string
+}
+
+const agents: Agent[] = [
+  {
+    name: 'Claude',
+    vendor: 'Anthropic',
+    easiest: 'Claude Desktop + Claude Mobile',
+    easiestHref: '/developer-environment-setup/claude-desktop',
+    advanced: 'VS Code or Antigravity (Claude CLI / plug-in)',
+    advancedHref: '/developer-environment-setup/vscode',
+    ifYouPay: 'Have Claude Pro or Max? Use Claude.',
+  },
+  {
+    name: 'OpenAI Codex',
+    vendor: 'OpenAI',
+    easiest: 'Codex app (desktop)',
+    easiestHref: '/developer-environment-setup/codex',
+    advanced: 'VS Code or Antigravity (Codex CLI / extension)',
+    advancedHref: '/developer-environment-setup/vscode',
+    ifYouPay: 'Have ChatGPT Plus or Pro? Use Codex.',
+  },
+  {
+    name: 'Google Gemini',
+    vendor: 'Google',
+    easiest: 'Google Antigravity (agent-first IDE)',
+    easiestHref: '/developer-environment-setup/google-antigravity',
+    advanced: 'Google Antigravity',
+    advancedHref: '/developer-environment-setup/google-antigravity',
+    ifYouPay: 'Have a Google AI / Gemini plan? Use Gemini.',
+  },
+  {
+    name: 'GitHub Copilot',
+    vendor: 'GitHub / Microsoft',
+    easiest: 'VS Code (agent mode)',
+    easiestHref: '/developer-environment-setup/vscode',
+    advanced: 'VS Code',
+    advancedHref: '/developer-environment-setup/vscode',
+    ifYouPay: 'Have GitHub Copilot? Use Copilot in VS Code.',
+  },
+]
+
+interface GuideCard {
   href: string
   name: string
   tagline: string
-  bestFor: string
+  level: 'Beginner' | 'Advanced'
+  recommended?: boolean
   gradient: string
   emoji: string
   bullets: string[]
 }
 
-const environments: EnvironmentCard[] = [
+const guideCards: GuideCard[] = [
   {
-    href: '/developer-environment-setup/google-antigravity',
-    name: 'Google Antigravity',
-    tagline: "Google's agent-first IDE",
-    bestFor: 'Volunteers who want an AI agent to drive most of the work',
-    gradient: 'from-emerald-500 to-teal-600',
-    emoji: '🚀',
+    href: '/developer-environment-setup/claude-desktop',
+    name: 'Claude Desktop',
+    tagline: 'Claude on desktop + mobile',
+    level: 'Beginner',
+    recommended: true,
+    gradient: 'from-amber-500 to-orange-600',
+    emoji: '🟠',
     bullets: [
-      'Free public preview — sign in with a personal Google/Gmail account',
-      'Built on the VS Code foundation, with a dedicated Agent Manager',
-      'Built-in Gemini agents plan, write, test, and open PRs for you',
-      'MCP Store for one-click server installs (Playwright, GitHub, and more)',
+      'Our recommendation for new developers — Claude Pro level',
+      'Native desktop app plus Claude Mobile for work on the go',
+      'Connect GitHub via MCP; CI runs the tests for you',
+      'No local build tools required to get started',
+    ],
+  },
+  {
+    href: '/developer-environment-setup/codex',
+    name: 'OpenAI Codex',
+    tagline: 'Codex app, signed in with ChatGPT',
+    level: 'Beginner',
+    gradient: 'from-slate-600 to-slate-800',
+    emoji: '⚫',
+    bullets: [
+      'Best if you already pay for ChatGPT Plus or Pro',
+      'Codex desktop app (and CLI) with MCP + GitHub',
+      'Reads our AGENTS.md instructions automatically',
+      'Same issue → PR → merge loop as every FFC repo',
     ],
   },
   {
     href: '/developer-environment-setup/vscode',
     name: 'Microsoft VS Code',
-    tagline: 'The industry-standard editor',
-    bestFor: 'Volunteers who want a familiar, widely documented editor',
+    tagline: 'Agent mode + your AI of choice',
+    level: 'Advanced',
     gradient: 'from-blue-500 to-indigo-600',
     emoji: '🧩',
     bullets: [
-      'Free and open source on Windows, macOS, and Linux',
-      'GitHub Copilot free tier provides the built-in AI agent',
-      'MCP servers configured through .vscode/mcp.json (shared in the repo)',
-      'Huge extension ecosystem and the largest community knowledge base',
+      'The industry-standard editor, now with an agent-first mode',
+      'Run Copilot, Claude, or Codex as the agent',
+      'Local builds, tests, Playwright, and bigger refactors',
+      'Largest community and extension ecosystem',
+    ],
+  },
+  {
+    href: '/developer-environment-setup/google-antigravity',
+    name: 'Google Antigravity',
+    tagline: 'Google’s agent-first IDE',
+    level: 'Advanced',
+    gradient: 'from-emerald-500 to-teal-600',
+    emoji: '🚀',
+    bullets: [
+      'Gemini agents built in; add Claude or Codex too',
+      'Dedicated Agent Manager alongside a VS Code-style editor',
+      'Local builds, tests, Playwright, and bigger refactors',
+      'Free public preview, sign in with a Google account',
     ],
   },
 ]
 
-interface Step {
-  number: string
-  title: string
-  description: string
-}
-
-const loopSteps: Step[] = [
-  {
-    number: '1',
-    title: 'Pick up an Issue',
-    description:
-      'Every change starts from a GitHub Issue. Your AI agent can read the issue, ask clarifying questions, and plan the work.',
-  },
-  {
-    number: '2',
-    title: 'Branch & build',
-    description:
-      'The agent creates a branch, edits files, and runs the local checks (format, lint, build, test) for you.',
-  },
-  {
-    number: '3',
-    title: 'Open a Pull Request',
-    description:
-      'With the GitHub MCP server connected, the agent opens a PR, links it to the issue, and watches CI.',
-  },
-  {
-    number: '4',
-    title: 'Review & merge',
-    description:
-      'You review the diff, the agent fixes any CI failures, and once checks pass the change merges into the charity or website repository.',
-  },
-]
-
 export default function DeveloperEnvironmentSetupPage() {
+  const beginnerGuides = guideCards.filter((g) => g.level === 'Beginner')
+  const advancedGuides = guideCards.filter((g) => g.level === 'Advanced')
+
   return (
     <div className="min-h-screen bg-gray-50">
       <Breadcrumbs
@@ -92,7 +141,7 @@ export default function DeveloperEnvironmentSetupPage() {
       />
 
       {/* Hero */}
-      <div className="bg-gradient-to-r from-emerald-600 to-blue-700 text-white py-16 px-4 sm:px-6 lg:px-8">
+      <div className="bg-gradient-to-r from-emerald-600 via-blue-600 to-indigo-700 text-white py-16 px-4 sm:px-6 lg:px-8">
         <div className="max-w-5xl mx-auto">
           <div className="flex items-center mb-4">
             <span className="text-5xl mr-4" aria-hidden="true">
@@ -101,109 +150,270 @@ export default function DeveloperEnvironmentSetupPage() {
             <div>
               <h1 className="text-3xl md:text-4xl font-bold">Developer Environment Setup</h1>
               <p className="text-emerald-100 text-sm mt-1">
-                For Free For Charity website development &amp; digital infrastructure
+                Start with your AI of choice — then grow into a full IDE only if you need to
               </p>
             </div>
           </div>
           <p className="text-emerald-50 text-lg max-w-3xl">
-            This is the starting point for every Free For Charity volunteer developer. Set up your
-            own computer once, connect it to GitHub, and enable the AI agents and MCP servers our
-            template repositories rely on. From there you can open issues, make pull requests, and
-            merge changes into FFC charity and website repositories — with an AI agent doing most of
-            the heavy lifting.
+            Every Free For Charity volunteer developer works with an AI agent. The easiest way to
+            start is the <strong>native desktop app</strong> for your AI. As you take on more
+            advanced work, you can move into a full IDE like VS Code or Google Antigravity — but
+            most charity website work never needs that.
           </p>
           <div className="mt-6 flex flex-wrap gap-3">
             <span className="bg-white/15 px-3 py-1 rounded-full text-sm font-medium">
-              100% free tooling
+              Bring your own AI
             </span>
             <span className="bg-white/15 px-3 py-1 rounded-full text-sm font-medium">
-              AI-agent assisted
+              Beginner-friendly first
             </span>
             <span className="bg-white/15 px-3 py-1 rounded-full text-sm font-medium">
-              Last updated: May 2026
+              Last updated: June 2026
             </span>
           </div>
         </div>
       </div>
 
       <main className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-        {/* What is this */}
+        {/* Step 1: Start with your AI */}
         <section className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
-          <h2 className="text-2xl font-bold text-gray-900 mb-4">What you are setting up</h2>
+          <div className="flex items-center mb-4">
+            <span className="text-4xl mr-4" aria-hidden="true">
+              🤖
+            </span>
+            <div>
+              <h2 className="text-2xl font-bold text-gray-900">Step 1 — Start with your AI</h2>
+              <p className="text-gray-600">
+                Keep the AI you already use, or pick our recommendation
+              </p>
+            </div>
+          </div>
           <p className="text-gray-700 mb-4">
-            A Free For Charity development environment is a code editor on your own computer that is
-            connected to GitHub and supercharged with an AI agent. The agent can read our code, run
-            our tests, and talk to GitHub on your behalf through <strong>MCP servers</strong> (Model
-            Context Protocol) — small connectors that give the agent superpowers such as driving a
-            browser for Playwright tests or opening pull requests.
+            You do not need to learn a new AI to help Free For Charity. If you already pay for one
+            of the major AI agents, <strong>keep using it</strong> — this page shows how to point
+            your existing AI at our website template repositories. If you do not have one yet, we
+            have a simple recommendation below.
           </p>
-          <div className="bg-emerald-50 border-l-4 border-emerald-600 p-4 rounded">
-            <p className="text-emerald-900 text-sm">
-              <strong>The big idea:</strong> You do not need to be a senior engineer. Both editors
-              below ship with a free AI agent. Your job is to install the environment once, point it
-              at our repositories, and then <em>describe what you want in plain English</em>. The
-              agent writes the code, runs the checks, and prepares the pull request.
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <div className="bg-amber-50 border-l-4 border-amber-500 p-4 rounded">
+              <h3 className="font-bold text-amber-900 mb-1">Already pay for an AI? Use it.</h3>
+              <p className="text-sm text-amber-900">
+                Your paid AI should stay your primary AI. ChatGPT Plus/Pro &rarr; Codex. Claude
+                Pro/Max &rarr; Claude. A Google&nbsp;AI / Gemini plan &rarr; Gemini. GitHub Copilot
+                &rarr; VS Code. Set that one up for FFC and skip the rest.
+              </p>
+            </div>
+            <div className="bg-emerald-50 border-l-4 border-emerald-600 p-4 rounded">
+              <h3 className="font-bold text-emerald-900 mb-1">No AI yet? Start with Claude.</h3>
+              <p className="text-sm text-emerald-900">
+                Our recommendation for new developers is{' '}
+                <strong>Claude at the personal Pro level</strong>, using{' '}
+                <strong>Claude Desktop</strong> on your computer and <strong>Claude Mobile</strong>{' '}
+                on your phone. It is the gentlest on-ramp to the FFC workflow.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* The four primary AI agents */}
+        <section className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
+          <div className="flex items-center mb-6">
+            <span className="text-4xl mr-4" aria-hidden="true">
+              ⚖️
+            </span>
+            <div>
+              <h2 className="text-2xl font-bold text-gray-900">The four primary AI agents</h2>
+              <p className="text-gray-600">
+                All four can do the job — pick by what you already have or prefer
+              </p>
+            </div>
+          </div>
+          <p className="text-gray-700 mb-4">
+            Free For Charity supports four primary AI coding agents. In practice they{' '}
+            <strong>work almost the same</strong> for our purposes: you describe a change in plain
+            English, the agent edits the code, runs the checks, and opens a pull request. The main
+            difference is which app you sign in to and where it runs.
+          </p>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm border-collapse">
+              <thead>
+                <tr className="bg-gray-100">
+                  <th className="text-left p-3 font-semibold text-gray-900 border border-gray-200">
+                    AI agent
+                  </th>
+                  <th className="text-left p-3 font-semibold text-gray-900 border border-gray-200">
+                    Easiest start (native app)
+                  </th>
+                  <th className="text-left p-3 font-semibold text-gray-900 border border-gray-200">
+                    Advanced environment
+                  </th>
+                  <th className="text-left p-3 font-semibold text-gray-900 border border-gray-200">
+                    Already paying?
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {agents.map((a, i) => (
+                  <tr key={a.name} className={i % 2 === 1 ? 'bg-gray-50' : ''}>
+                    <td className="p-3 border border-gray-200">
+                      <span className="font-semibold text-gray-900">{a.name}</span>
+                      <span className="block text-xs text-gray-500">{a.vendor}</span>
+                    </td>
+                    <td className="p-3 border border-gray-200">
+                      {a.easiestHref ? (
+                        <Link
+                          href={a.easiestHref}
+                          className="text-blue-700 underline hover:text-blue-900"
+                        >
+                          {a.easiest}
+                        </Link>
+                      ) : (
+                        a.easiest
+                      )}
+                    </td>
+                    <td className="p-3 border border-gray-200">
+                      <Link
+                        href={a.advancedHref}
+                        className="text-blue-700 underline hover:text-blue-900"
+                      >
+                        {a.advanced}
+                      </Link>
+                    </td>
+                    <td className="p-3 border border-gray-200 text-gray-700">{a.ifYouPay}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <div className="mt-4 bg-blue-50 border-l-4 border-blue-600 p-4 rounded">
+            <p className="text-blue-900 text-sm">
+              <strong>No favoritism:</strong> we do not push one tool over another. Antigravity and
+              VS Code are equally capable advanced environments, and you can run Claude or Codex in
+              either one. Choose the path that fits the AI you already have.
             </p>
           </div>
         </section>
 
-        {/* Choose your environment */}
-        <section className="mb-8">
-          <h2 className="text-2xl font-bold text-gray-900 mb-2 px-1">Choose your environment</h2>
-          <p className="text-gray-600 mb-6 px-1">
-            Pick one to start. You can install both later — the GitHub workflow is identical.
-          </p>
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-            {environments.map((env) => (
-              <Link
-                key={env.href}
-                href={env.href}
-                className="block bg-white rounded-xl shadow-lg border border-gray-200 overflow-hidden hover:shadow-xl transition-shadow"
-              >
-                <div
-                  className={`bg-gradient-to-br ${env.gradient} p-6 flex items-center gap-4 text-white`}
-                >
-                  <span className="text-4xl" aria-hidden="true">
-                    {env.emoji}
+        {/* Easiest to advanced */}
+        <section className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
+          <div className="flex items-center mb-6">
+            <span className="text-4xl mr-4" aria-hidden="true">
+              🧭
+            </span>
+            <div>
+              <h2 className="text-2xl font-bold text-gray-900">
+                Step 2 — Pick an environment by difficulty
+              </h2>
+              <p className="text-gray-600">Start easy. Move up only when a task needs it.</p>
+            </div>
+          </div>
+
+          <div className="space-y-6">
+            {/* Beginner */}
+            <div>
+              <div className="flex items-center gap-2 mb-3">
+                <span className="text-xs font-bold uppercase tracking-wide bg-emerald-100 text-emerald-800 px-2 py-0.5 rounded-full">
+                  Start here · Beginner
+                </span>
+                <span className="text-sm text-gray-600">Your AI’s native desktop app</span>
+              </div>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                {beginnerGuides.map((g) => (
+                  <GuideCardLink key={g.href} guide={g} />
+                ))}
+              </div>
+            </div>
+
+            {/* Advanced */}
+            <div>
+              <div className="flex items-center gap-2 mb-3">
+                <span className="text-xs font-bold uppercase tracking-wide bg-indigo-100 text-indigo-800 px-2 py-0.5 rounded-full">
+                  Later · Advanced
+                </span>
+                <span className="text-sm text-gray-600">A full IDE, when you need more power</span>
+              </div>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                {advancedGuides.map((g) => (
+                  <GuideCardLink key={g.href} guide={g} />
+                ))}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* What advanced means */}
+        <section className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
+          <div className="flex items-center mb-6">
+            <span className="text-4xl mr-4" aria-hidden="true">
+              🎚️
+            </span>
+            <div>
+              <h2 className="text-2xl font-bold text-gray-900">
+                What “advanced” means — and why most people never need it
+              </h2>
+              <p className="text-gray-600">An honest look at when to graduate to an IDE</p>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
+            <div className="bg-emerald-50 border border-emerald-200 rounded-lg p-5">
+              <h3 className="font-bold text-emerald-800 mb-3">Beginner (native desktop app)</h3>
+              <ul className="space-y-2 text-sm text-emerald-900">
+                <li className="flex items-start">
+                  <span className="text-emerald-600 mr-2 mt-0.5">&#10003;</span>
+                  <span>
+                    Read issues, edit content, and open pull requests through the GitHub MCP server
                   </span>
-                  <div>
-                    <h3 className="text-xl font-bold">{env.name}</h3>
-                    <p className="text-white/90 text-sm">{env.tagline}</p>
-                  </div>
-                </div>
-                <div className="p-6">
-                  <p className="text-xs uppercase tracking-wide text-gray-500 font-semibold mb-1">
-                    Best for
-                  </p>
-                  <p className="text-sm text-gray-700 mb-4">{env.bestFor}</p>
-                  <ul className="space-y-2 text-sm text-gray-700">
-                    {env.bullets.map((bullet) => (
-                      <li key={bullet} className="flex items-start">
-                        <span className="text-emerald-600 mr-2 mt-0.5">&#10003;</span>
-                        <span>{bullet}</span>
-                      </li>
-                    ))}
-                  </ul>
-                  <span className="mt-5 inline-flex items-center text-sm font-semibold text-blue-700">
-                    Open the {env.name} guide
-                    <svg
-                      className="w-4 h-4 ml-1"
-                      fill="none"
-                      stroke="currentColor"
-                      viewBox="0 0 24 24"
-                      aria-hidden="true"
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2}
-                        d="M9 5l7 7-7 7"
-                      />
-                    </svg>
+                </li>
+                <li className="flex items-start">
+                  <span className="text-emerald-600 mr-2 mt-0.5">&#10003;</span>
+                  <span>CI runs the build and tests for you — nothing to install locally</span>
+                </li>
+                <li className="flex items-start">
+                  <span className="text-emerald-600 mr-2 mt-0.5">&#10003;</span>
+                  <span>Handles the large majority of charity website updates</span>
+                </li>
+                <li className="flex items-start">
+                  <span className="text-emerald-600 mr-2 mt-0.5">&#10003;</span>
+                  <span>Works from your phone with Claude Mobile</span>
+                </li>
+              </ul>
+            </div>
+            <div className="bg-indigo-50 border border-indigo-200 rounded-lg p-5">
+              <h3 className="font-bold text-indigo-800 mb-3">Advanced (full IDE)</h3>
+              <ul className="space-y-2 text-sm text-indigo-900">
+                <li className="flex items-start">
+                  <span className="text-indigo-600 mr-2 mt-0.5">+</span>
+                  <span>
+                    Run builds, unit tests, and Playwright on your own machine before pushing
                   </span>
-                </div>
-              </Link>
-            ))}
+                </li>
+                <li className="flex items-start">
+                  <span className="text-indigo-600 mr-2 mt-0.5">+</span>
+                  <span>Drive a real browser, debug failures, and iterate quickly</span>
+                </li>
+                <li className="flex items-start">
+                  <span className="text-indigo-600 mr-2 mt-0.5">+</span>
+                  <span>Larger refactors, new pages from scratch, and work across many repos</span>
+                </li>
+                <li className="flex items-start">
+                  <span className="text-indigo-600 mr-2 mt-0.5">+</span>
+                  <span>Run your AI as a CLI agent and as an in-editor plug-in</span>
+                </li>
+              </ul>
+            </div>
+          </div>
+
+          <div className="bg-amber-50 border-l-4 border-amber-500 p-4 rounded">
+            <p className="text-amber-900 text-sm">
+              <strong>Important caveat:</strong> most charities will never require an advanced
+              developer. The beginner path — your AI’s desktop app plus the GitHub MCP server, with
+              CI validating every change — handles the vast majority of website work. Only move to
+              an IDE when a specific task genuinely needs local builds, browser debugging, or a
+              large refactor. Becoming “advanced” is a nice-to-have for ambitious volunteers, not a
+              requirement for helping a charity.
+            </p>
           </div>
         </section>
 
@@ -216,19 +426,18 @@ export default function DeveloperEnvironmentSetupPage() {
             <div>
               <h2 className="text-2xl font-bold text-gray-900">Shared prerequisites</h2>
               <p className="text-gray-600">
-                The same accounts and tools are needed whichever editor you choose
+                What every path needs (advanced paths need a little more)
               </p>
             </div>
           </div>
-
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
             <div>
-              <h3 className="font-bold text-gray-900 mb-3">Accounts (free)</h3>
+              <h3 className="font-bold text-gray-900 mb-3">Everyone needs</h3>
               <ul className="space-y-2 text-sm text-gray-700">
                 <li className="flex items-start">
                   <span className="text-blue-600 mr-2 font-bold">1.</span>
                   <span>
-                    A <strong>GitHub account</strong>. Ask a maintainer to add you to the{' '}
+                    A <strong>GitHub account</strong>, added to the{' '}
                     <a
                       href="https://github.com/FreeForCharity"
                       target="_blank"
@@ -237,61 +446,36 @@ export default function DeveloperEnvironmentSetupPage() {
                     >
                       FreeForCharity
                     </a>{' '}
-                    organization.
+                    organization by a maintainer.
                   </span>
                 </li>
                 <li className="flex items-start">
                   <span className="text-blue-600 mr-2 font-bold">2.</span>
                   <span>
-                    A <strong>Google/Gmail account</strong> (for Antigravity&apos;s free AI agent),
-                    or your GitHub account (for VS Code&apos;s Copilot free tier).
+                    An <strong>AI account</strong> — Claude, ChatGPT/Codex, Google/Gemini, or GitHub
+                    Copilot (a paid tier is recommended for real work).
                   </span>
                 </li>
               </ul>
             </div>
             <div>
-              <h3 className="font-bold text-gray-900 mb-3">Core tools (free)</h3>
+              <h3 className="font-bold text-gray-900 mb-3">Advanced (IDE) paths also need</h3>
               <ul className="space-y-2 text-sm text-gray-700">
                 <li className="flex items-start">
-                  <span className="text-blue-600 mr-2 font-bold">1.</span>
+                  <span className="text-indigo-600 mr-2 font-bold">+</span>
                   <span>
-                    <strong>Git</strong> &mdash; version control
+                    <strong>Git</strong>, <strong>Node.js 20+</strong>, and <strong>pnpm 9</strong>{' '}
+                    (our repos pin pnpm 9 via{' '}
+                    <code className="bg-gray-200 px-1 rounded">package.json</code>). Your AI can
+                    install these for you.
                   </span>
                 </li>
                 <li className="flex items-start">
-                  <span className="text-blue-600 mr-2 font-bold">2.</span>
-                  <span>
-                    <strong>Node.js 20 LTS or newer</strong> &mdash; JavaScript runtime
-                  </span>
-                </li>
-                <li className="flex items-start">
-                  <span className="text-blue-600 mr-2 font-bold">3.</span>
-                  <span>
-                    <strong>pnpm</strong> &mdash; package manager. Our repos pin pnpm 9 via{' '}
-                    <code className="bg-gray-200 px-1 rounded">package.json</code>, so install the
-                    matching major with{' '}
-                    <code className="bg-gray-200 px-1 rounded">npm install -g pnpm@9</code> (or run{' '}
-                    <code className="bg-gray-200 px-1 rounded">corepack enable</code> to use the
-                    pinned version automatically)
-                  </span>
-                </li>
-                <li className="flex items-start">
-                  <span className="text-blue-600 mr-2 font-bold">4.</span>
-                  <span>
-                    Your chosen <strong>editor</strong> &mdash; Antigravity or VS Code
-                  </span>
+                  <span className="text-indigo-600 mr-2 font-bold">+</span>
+                  <span>The editor itself — VS Code or Antigravity.</span>
                 </li>
               </ul>
             </div>
-          </div>
-
-          <div className="mt-6 bg-blue-50 border-l-4 border-blue-600 p-4 rounded">
-            <p className="text-blue-900 text-sm">
-              <strong>Let the agent install things.</strong> You do not have to memorize install
-              commands. Once your editor and its AI agent are running, you can say: &ldquo;Check
-              whether Git, Node 20+, and pnpm are installed, and if not, tell me exactly how to
-              install them for my operating system.&rdquo; The agent will guide you step by step.
-            </p>
           </div>
         </section>
 
@@ -303,32 +487,30 @@ export default function DeveloperEnvironmentSetupPage() {
             </span>
             <div>
               <h2 className="text-2xl font-bold text-gray-900">
-                MCP servers used across our template repositories
+                MCP servers our template repositories use
               </h2>
               <p className="text-gray-600">
-                These connectors give your AI agent the abilities our workflow depends on
+                The same connectors give every AI agent the abilities our workflow needs
               </p>
             </div>
           </div>
-
           <p className="text-gray-700 mb-4">
-            Each environment guide shows the exact configuration. At a minimum, enable{' '}
-            <strong>GitHub</strong> and <strong>Playwright</strong>. The others are useful depending
-            on what you are working on.
+            MCP (Model Context Protocol) servers are small connectors that all four AI agents
+            understand. At a minimum, enable <strong>GitHub</strong>. Add{' '}
+            <strong>Playwright</strong> once you are working in an IDE and running browser tests.
           </p>
-
           <div className="overflow-x-auto">
             <table className="w-full text-sm border-collapse">
               <thead>
                 <tr className="bg-gray-100">
                   <th className="text-left p-3 font-semibold text-gray-900 border border-gray-200">
-                    MCP Server
+                    MCP server
                   </th>
                   <th className="text-left p-3 font-semibold text-gray-900 border border-gray-200">
                     What it lets the agent do
                   </th>
                   <th className="text-left p-3 font-semibold text-gray-900 border border-gray-200">
-                    Priority
+                    When
                   </th>
                 </tr>
               </thead>
@@ -339,40 +521,33 @@ export default function DeveloperEnvironmentSetupPage() {
                     Read and create issues, open pull requests, review CI status, and merge
                   </td>
                   <td className="p-3 border border-gray-200 text-red-700 font-semibold">
-                    Required
+                    Required (all paths)
                   </td>
                 </tr>
                 <tr className="bg-gray-50">
                   <td className="p-3 border border-gray-200 font-medium">Playwright</td>
                   <td className="p-3 border border-gray-200">
-                    Drive a real browser to run and debug our end-to-end (E2E) tests
+                    Drive a real browser to run and debug our end-to-end tests
                   </td>
-                  <td className="p-3 border border-gray-200 text-red-700 font-semibold">
-                    Required
+                  <td className="p-3 border border-gray-200 text-amber-700 font-semibold">
+                    Advanced / IDE
                   </td>
                 </tr>
                 <tr>
-                  <td className="p-3 border border-gray-200 font-medium">Cloudflare</td>
+                  <td className="p-3 border border-gray-200 font-medium">Filesystem</td>
                   <td className="p-3 border border-gray-200">
-                    Inspect DNS records and Pages deployments for charity domains
+                    Let a desktop-app agent read and edit a local clone of the repo
                   </td>
                   <td className="p-3 border border-gray-200 text-amber-700 font-semibold">
                     Optional
                   </td>
                 </tr>
                 <tr className="bg-gray-50">
-                  <td className="p-3 border border-gray-200 font-medium">Microsoft Learn Docs</td>
-                  <td className="p-3 border border-gray-200">
-                    Pull official Microsoft 365 / Azure documentation while working on admin tasks
+                  <td className="p-3 border border-gray-200 font-medium">
+                    Cloudflare / Microsoft Learn / Sentry
                   </td>
-                  <td className="p-3 border border-gray-200 text-amber-700 font-semibold">
-                    Optional
-                  </td>
-                </tr>
-                <tr>
-                  <td className="p-3 border border-gray-200 font-medium">Sentry</td>
                   <td className="p-3 border border-gray-200">
-                    Look up production errors and performance issues for deployed sites
+                    DNS &amp; Pages, Microsoft 365 docs, and production error tracking
                   </td>
                   <td className="p-3 border border-gray-200 text-amber-700 font-semibold">
                     Optional
@@ -381,14 +556,13 @@ export default function DeveloperEnvironmentSetupPage() {
               </tbody>
             </table>
           </div>
-
-          <div className="mt-6 bg-amber-50 border-l-4 border-amber-500 p-4 rounded">
+          <div className="mt-5 bg-amber-50 border-l-4 border-amber-500 p-4 rounded">
             <p className="text-amber-900 text-sm">
-              <strong>Security:</strong> MCP servers that talk to GitHub, Cloudflare, or Sentry need
+              <strong>Security:</strong> MCP servers that reach GitHub, Cloudflare, or Sentry need
               an access token.{' '}
-              <strong>Never paste a token into a file, a commit, or a chat message.</strong> Store
-              it where the editor tells you (a local credential prompt or an environment variable),
-              use the narrowest scope possible, and rotate it regularly. See our{' '}
+              <strong>Never paste a token into a file, a commit, or a chat message.</strong> Use the
+              app’s secure credential prompt or an environment variable, scope it narrowly, and
+              rotate it. See our{' '}
               <a
                 href="https://github.com/FreeForCharity/FFC-IN-ffcadmin.org/blob/main/.claude/rules/01-security.md"
                 target="_blank"
@@ -402,7 +576,7 @@ export default function DeveloperEnvironmentSetupPage() {
           </div>
         </section>
 
-        {/* The contribution loop */}
+        {/* Contribution loop */}
         <section className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
           <div className="flex items-center mb-6">
             <span className="text-4xl mr-4" aria-hidden="true">
@@ -410,136 +584,107 @@ export default function DeveloperEnvironmentSetupPage() {
             </span>
             <div>
               <h2 className="text-2xl font-bold text-gray-900">
-                What you will be able to do: the contribution loop
+                The contribution loop is the same
               </h2>
               <p className="text-gray-600">
-                The same four steps power every change, on every FFC repository
+                Whichever AI and environment you choose, every change follows four steps
               </p>
             </div>
           </div>
-
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-            {loopSteps.map((step) => (
-              <div key={step.number} className="border-l-4 border-blue-600 pl-4">
-                <h3 className="font-bold text-gray-900 mb-1">
-                  <span className="text-blue-600 mr-1">{step.number}.</span>
-                  {step.title}
-                </h3>
-                <p className="text-sm text-gray-700">{step.description}</p>
-              </div>
-            ))}
+            <div className="border-l-4 border-blue-600 pl-4">
+              <h3 className="font-bold text-gray-900 mb-1">
+                <span className="text-blue-600 mr-1">1.</span>Pick up an issue
+              </h3>
+              <p className="text-sm text-gray-700">
+                Every change starts from a GitHub issue. Your agent reads it and plans the work.
+              </p>
+            </div>
+            <div className="border-l-4 border-blue-600 pl-4">
+              <h3 className="font-bold text-gray-900 mb-1">
+                <span className="text-blue-600 mr-1">2.</span>Branch &amp; change
+              </h3>
+              <p className="text-sm text-gray-700">
+                The agent creates a branch and makes the change — on a beginner path, directly
+                through the GitHub MCP server.
+              </p>
+            </div>
+            <div className="border-l-4 border-blue-600 pl-4">
+              <h3 className="font-bold text-gray-900 mb-1">
+                <span className="text-blue-600 mr-1">3.</span>Open a pull request
+              </h3>
+              <p className="text-sm text-gray-700">
+                The agent opens a PR linked to the issue. CI runs format, lint, build, tests, and
+                Playwright.
+              </p>
+            </div>
+            <div className="border-l-4 border-blue-600 pl-4">
+              <h3 className="font-bold text-gray-900 mb-1">
+                <span className="text-blue-600 mr-1">4.</span>Review &amp; merge
+              </h3>
+              <p className="text-sm text-gray-700">
+                You review the diff, the agent fixes any CI failures, and the change merges once
+                checks pass.
+              </p>
+            </div>
           </div>
-
           <div className="mt-6 bg-green-50 border-l-4 border-green-600 p-4 rounded">
             <p className="text-green-900 text-sm">
               <strong>Never push directly to main.</strong> Every change goes through a branch and a
-              pull request, and CI checks (format, lint, build, tests, Playwright) must pass before
-              merge. Your AI agent follows this rule automatically when it is set up correctly.
+              pull request, and CI must pass before merge. A correctly set-up agent follows this
+              automatically.
             </p>
           </div>
         </section>
 
-        {/* Comparison */}
-        <section className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
-          <div className="flex items-center mb-6">
-            <span className="text-4xl mr-4" aria-hidden="true">
-              ⚖️
-            </span>
-            <div>
-              <h2 className="text-2xl font-bold text-gray-900">
-                Antigravity vs VS Code at a glance
-              </h2>
-              <p className="text-gray-600">Both reach the same finish line — pick what fits you</p>
-            </div>
-          </div>
-
-          <div className="overflow-x-auto">
-            <table className="w-full text-sm border-collapse">
-              <thead>
-                <tr className="bg-gray-100">
-                  <th className="text-left p-3 font-semibold text-gray-900 border border-gray-200">
-                    Topic
-                  </th>
-                  <th className="text-left p-3 font-semibold text-gray-900 border border-gray-200">
-                    Google Antigravity
-                  </th>
-                  <th className="text-left p-3 font-semibold text-gray-900 border border-gray-200">
-                    Microsoft VS Code
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td className="p-3 border border-gray-200 font-medium">Built-in AI agent</td>
-                  <td className="p-3 border border-gray-200">Gemini agents in the Agent Manager</td>
-                  <td className="p-3 border border-gray-200">GitHub Copilot (agent mode)</td>
-                </tr>
-                <tr className="bg-gray-50">
-                  <td className="p-3 border border-gray-200 font-medium">Sign in with</td>
-                  <td className="p-3 border border-gray-200">Personal Google/Gmail account</td>
-                  <td className="p-3 border border-gray-200">GitHub account</td>
-                </tr>
-                <tr>
-                  <td className="p-3 border border-gray-200 font-medium">MCP config</td>
-                  <td className="p-3 border border-gray-200">
-                    MCP Store + <code className="bg-gray-200 px-1 rounded">mcpServers</code> config
-                  </td>
-                  <td className="p-3 border border-gray-200">
-                    <code className="bg-gray-200 px-1 rounded">.vscode/mcp.json</code> with{' '}
-                    <code className="bg-gray-200 px-1 rounded">servers</code> key
-                  </td>
-                </tr>
-                <tr className="bg-gray-50">
-                  <td className="p-3 border border-gray-200 font-medium">Maturity</td>
-                  <td className="p-3 border border-gray-200">Newer, free public preview</td>
-                  <td className="p-3 border border-gray-200">
-                    Long established, largest community
-                  </td>
-                </tr>
-                <tr>
-                  <td className="p-3 border border-gray-200 font-medium">Foundation</td>
-                  <td className="p-3 border border-gray-200">Fork of VS Code (familiar layout)</td>
-                  <td className="p-3 border border-gray-200">The original VS Code</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-        </section>
-
-        {/* Related links */}
+        {/* Related */}
         <section className="bg-gradient-to-br from-gray-50 to-emerald-50 rounded-xl shadow-lg p-6 md:p-8 border border-gray-200">
-          <h2 className="text-xl font-bold text-gray-900 mb-4">Where to go next</h2>
+          <h2 className="text-xl font-bold text-gray-900 mb-4">Pick your guide</h2>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <ul className="space-y-2 text-sm text-gray-700">
               <li>
                 <Link
-                  href="/developer-environment-setup/google-antigravity"
+                  href="/developer-environment-setup/claude-desktop"
                   className="text-blue-600 underline hover:text-blue-800"
                 >
-                  Google Antigravity setup guide
+                  Claude Desktop
                 </Link>
+                <span className="text-gray-500"> &mdash; beginner, recommended</span>
+              </li>
+              <li>
+                <Link
+                  href="/developer-environment-setup/codex"
+                  className="text-blue-600 underline hover:text-blue-800"
+                >
+                  OpenAI Codex
+                </Link>
+                <span className="text-gray-500"> &mdash; beginner</span>
               </li>
               <li>
                 <Link
                   href="/developer-environment-setup/vscode"
                   className="text-blue-600 underline hover:text-blue-800"
                 >
-                  Microsoft VS Code setup guide
+                  Microsoft VS Code
                 </Link>
+                <span className="text-gray-500"> &mdash; advanced</span>
               </li>
+              <li>
+                <Link
+                  href="/developer-environment-setup/google-antigravity"
+                  className="text-blue-600 underline hover:text-blue-800"
+                >
+                  Google Antigravity
+                </Link>
+                <span className="text-gray-500"> &mdash; advanced</span>
+              </li>
+            </ul>
+            <ul className="space-y-2 text-sm text-gray-700">
               <li>
                 <Link href="/tech-stack" className="text-blue-600 underline hover:text-blue-800">
                   FFC Tech Stack
                 </Link>
                 <span className="text-gray-500"> &mdash; what powers every FFC site</span>
-              </li>
-            </ul>
-            <ul className="space-y-2 text-sm text-gray-700">
-              <li>
-                <Link href="/guides" className="text-blue-600 underline hover:text-blue-800">
-                  Technical Guides
-                </Link>
-                <span className="text-gray-500"> &mdash; including WordPress to Next.js</span>
               </li>
               <li>
                 <Link href="/testing" className="text-blue-600 underline hover:text-blue-800">
@@ -561,5 +706,53 @@ export default function DeveloperEnvironmentSetupPage() {
         </section>
       </main>
     </div>
+  )
+}
+
+function GuideCardLink({ guide }: { guide: GuideCard }) {
+  return (
+    <Link
+      href={guide.href}
+      className="block bg-white rounded-xl shadow-lg border border-gray-200 overflow-hidden hover:shadow-xl transition-shadow"
+    >
+      <div className={`bg-gradient-to-br ${guide.gradient} p-5 flex items-center gap-3 text-white`}>
+        <span className="text-3xl" aria-hidden="true">
+          {guide.emoji}
+        </span>
+        <div>
+          <div className="flex items-center gap-2">
+            <h3 className="text-lg font-bold">{guide.name}</h3>
+            {guide.recommended && (
+              <span className="text-[10px] font-bold uppercase tracking-wide bg-white/25 px-1.5 py-0.5 rounded">
+                Recommended
+              </span>
+            )}
+          </div>
+          <p className="text-white/90 text-sm">{guide.tagline}</p>
+        </div>
+      </div>
+      <div className="p-5">
+        <ul className="space-y-1.5 text-sm text-gray-700">
+          {guide.bullets.map((b) => (
+            <li key={b} className="flex items-start">
+              <span className="text-emerald-600 mr-2 mt-0.5">&#10003;</span>
+              <span>{b}</span>
+            </li>
+          ))}
+        </ul>
+        <span className="mt-4 inline-flex items-center text-sm font-semibold text-blue-700">
+          Open the {guide.name} guide
+          <svg
+            className="w-4 h-4 ml-1"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+          </svg>
+        </span>
+      </div>
+    </Link>
   )
 }

--- a/src/app/developer-environment-setup/page.tsx
+++ b/src/app/developer-environment-setup/page.tsx
@@ -15,9 +15,15 @@ interface Agent {
   vendor: string
   easiest: string
   easiestHref?: string
-  advanced: string
-  advancedHref: string
+  advanced: { label: string; href: string }[]
+  advancedNote?: string
   ifYouPay: string
+}
+
+const VSCODE = { label: 'VS Code', href: '/developer-environment-setup/vscode' }
+const ANTIGRAVITY = {
+  label: 'Antigravity',
+  href: '/developer-environment-setup/google-antigravity',
 }
 
 const agents: Agent[] = [
@@ -26,8 +32,8 @@ const agents: Agent[] = [
     vendor: 'Anthropic',
     easiest: 'Claude Desktop + Claude Mobile',
     easiestHref: '/developer-environment-setup/claude-desktop',
-    advanced: 'VS Code or Antigravity (Claude CLI / plug-in)',
-    advancedHref: '/developer-environment-setup/vscode',
+    advanced: [VSCODE, ANTIGRAVITY],
+    advancedNote: 'run Claude as a CLI or plug-in',
     ifYouPay: 'Have Claude Pro or Max? Use Claude.',
   },
   {
@@ -35,8 +41,8 @@ const agents: Agent[] = [
     vendor: 'OpenAI',
     easiest: 'Codex app (desktop)',
     easiestHref: '/developer-environment-setup/codex',
-    advanced: 'VS Code or Antigravity (Codex CLI / extension)',
-    advancedHref: '/developer-environment-setup/vscode',
+    advanced: [VSCODE, ANTIGRAVITY],
+    advancedNote: 'run Codex as a CLI or extension',
     ifYouPay: 'Have ChatGPT Plus or Pro? Use Codex.',
   },
   {
@@ -44,8 +50,7 @@ const agents: Agent[] = [
     vendor: 'Google',
     easiest: 'Google Antigravity (agent-first IDE)',
     easiestHref: '/developer-environment-setup/google-antigravity',
-    advanced: 'Google Antigravity',
-    advancedHref: '/developer-environment-setup/google-antigravity',
+    advanced: [ANTIGRAVITY],
     ifYouPay: 'Have a Google AI / Gemini plan? Use Gemini.',
   },
   {
@@ -53,8 +58,7 @@ const agents: Agent[] = [
     vendor: 'GitHub / Microsoft',
     easiest: 'VS Code (agent mode)',
     easiestHref: '/developer-environment-setup/vscode',
-    advanced: 'VS Code',
-    advancedHref: '/developer-environment-setup/vscode',
+    advanced: [VSCODE],
     ifYouPay: 'Have GitHub Copilot? Use Copilot in VS Code.',
   },
 ]
@@ -273,12 +277,18 @@ export default function DeveloperEnvironmentSetupPage() {
                       )}
                     </td>
                     <td className="p-3 border border-gray-200">
-                      <Link
-                        href={a.advancedHref}
-                        className="text-blue-700 underline hover:text-blue-900"
-                      >
-                        {a.advanced}
-                      </Link>
+                      {a.advanced.map((env, j) => (
+                        <span key={env.href}>
+                          {j > 0 && ' or '}
+                          <Link
+                            href={env.href}
+                            className="text-blue-700 underline hover:text-blue-900"
+                          >
+                            {env.label}
+                          </Link>
+                        </span>
+                      ))}
+                      {a.advancedNote && <span className="text-gray-500"> ({a.advancedNote})</span>}
                     </td>
                     <td className="p-3 border border-gray-200 text-gray-700">{a.ifYouPay}</td>
                   </tr>
@@ -453,7 +463,8 @@ export default function DeveloperEnvironmentSetupPage() {
                   <span className="text-blue-600 mr-2 font-bold">2.</span>
                   <span>
                     An <strong>AI account</strong> — Claude, ChatGPT/Codex, Google/Gemini, or GitHub
-                    Copilot (a paid tier is recommended for real work).
+                    Copilot. Every one has a free tier that is enough to start; upgrade to a paid
+                    tier only if and when you hit usage limits.
                   </span>
                 </li>
               </ul>

--- a/src/app/developer-environment-setup/page.tsx
+++ b/src/app/developer-environment-setup/page.tsx
@@ -497,7 +497,9 @@ export default function DeveloperEnvironmentSetupPage() {
           <p className="text-gray-700 mb-4">
             MCP (Model Context Protocol) servers are small connectors that all four AI agents
             understand. At a minimum, enable <strong>GitHub</strong>. Add{' '}
-            <strong>Playwright</strong> once you are working in an IDE and running browser tests.
+            <strong>Playwright</strong> once you are working in an IDE and running browser tests. In
+            most apps these come as ready-made plugins or connectors — you rarely install anything
+            by hand; just ask your agent to enable what it needs.
           </p>
           <div className="overflow-x-auto">
             <table className="w-full text-sm border-collapse">

--- a/src/app/developer-environment-setup/vscode/page.tsx
+++ b/src/app/developer-environment-setup/vscode/page.tsx
@@ -6,9 +6,9 @@ import PromptBox from '@/components/PromptBox'
 export const metadata: Metadata = {
   title: 'VS Code Setup',
   description:
-    'Set up Microsoft VS Code for Free For Charity website development. Install it, sign in with GitHub Copilot, connect GitHub, and configure the Playwright and GitHub MCP servers via .vscode/mcp.json so the AI agent can open issues, make PRs, and merge changes.',
+    'Set up Microsoft VS Code for Free For Charity website development. Install it, sign in with GitHub Copilot agent mode, connect GitHub, and enable the GitHub and Playwright MCP servers so the AI agent can open issues, make PRs, and merge changes.',
   keywords:
-    'VS Code, GitHub Copilot, agent mode, MCP servers, mcp.json, Playwright MCP, GitHub MCP, AI coding agent, Free For Charity, developer environment',
+    'VS Code, GitHub Copilot, agent mode, MCP servers, Playwright MCP, GitHub MCP, AI coding agent, Free For Charity, developer environment',
 }
 
 interface GuideSection {
@@ -194,38 +194,16 @@ export default function VSCodeSetupGuide() {
             <h2 className="text-2xl font-bold text-gray-900">3. Install Git, Node, and pnpm</h2>
           </div>
           <p className="text-gray-700 mb-4">
-            FFC sites are Next.js projects, so you need Git, Node.js 20+ and pnpm.{' '}
-            <strong>The recommended way to install them is to let Copilot do it for you.</strong>{' '}
-            Open Copilot Chat in <em>Agent</em> mode and paste the prompt below — it will detect
-            your operating system, run the installs in the integrated terminal, and verify the
-            versions.
+            FFC sites are Next.js projects, so you need Git, Node.js 20+ and pnpm 9 (our repos pin
+            pnpm 9). <strong>Do not look up install commands — let Copilot do it for you.</strong>{' '}
+            Open Copilot Chat in <em>Agent</em> mode and ask:
           </p>
           <PromptBox accent="blue">
             &ldquo;Set up my machine for Free For Charity Next.js development. Check whether Git,
-            Node.js 20 LTS or newer, and pnpm are installed. For anything missing, install it using
-            the right method for my operating system, then run <code>git --version</code>,{' '}
-            <code>node --version</code>, and <code>pnpm --version</code> and show me the output to
-            confirm everything works.&rdquo;
+            Node.js 20 LTS or newer, and pnpm 9 are installed, install anything missing using the
+            right method for my operating system, and confirm the versions when you are done. Our
+            repositories pin pnpm 9, so match that.&rdquo;
           </PromptBox>
-          <p className="text-gray-700 mt-4 mb-2 text-sm">
-            Prefer to check by hand first? Open the integrated terminal (
-            <code className="bg-gray-200 px-1 rounded">Ctrl/Cmd + `</code>) and run:
-          </p>
-          <div className="bg-gray-900 text-gray-100 p-4 rounded-lg text-sm font-mono overflow-x-auto">
-            <p className="text-blue-300">
-              # Verify versions (the agent can install anything missing)
-            </p>
-            <p>git --version</p>
-            <p>node --version &nbsp;&nbsp;# should be v20 or newer</p>
-            <p>pnpm --version</p>
-          </div>
-          <p className="text-gray-600 text-xs mt-3">
-            If you already have Node but not pnpm, install the major version our repos pin in{' '}
-            <code className="bg-gray-200 px-1 rounded">package.json</code> with{' '}
-            <code className="bg-gray-200 px-1 rounded">npm install -g pnpm@9</code> (or run{' '}
-            <code className="bg-gray-200 px-1 rounded">corepack enable</code>) — or just let Copilot
-            handle it with the prompt above.
-          </p>
         </section>
 
         {/* 4. Copilot */}
@@ -287,22 +265,18 @@ export default function VSCodeSetupGuide() {
             </div>
             <div className="border-l-4 border-blue-600 pl-4">
               <h3 className="font-bold text-gray-900 mb-2">5.2 — Sign in to GitHub in VS Code</h3>
-              <p className="text-sm text-gray-700 mb-2">
+              <p className="text-sm text-gray-700">
                 Use the <strong>Accounts</strong> menu (bottom-left) to sign in to GitHub, and
                 install the <strong>GitHub Pull Requests</strong> extension so you can manage issues
-                and PRs from the sidebar. Set your Git identity once:
+                and PRs from the sidebar. Copilot can set up your Git identity and confirm the
+                connection for you.
               </p>
-              <div className="bg-gray-900 text-gray-100 p-3 rounded-lg text-sm font-mono">
-                git config --global user.name &quot;Your Name&quot;
-                <br />
-                git config --global user.email &quot;you@example.com&quot;
-              </div>
             </div>
           </div>
           <PromptBox accent="blue">
-            &ldquo;Help me connect VS Code to GitHub. Set my global Git <code>user.name</code> and{' '}
-            <code>user.email</code>, confirm I am signed in to GitHub, install the GitHub Pull
-            Requests extension, and verify I have access to the FreeForCharity organization.&rdquo;
+            &ldquo;Help me connect VS Code to GitHub. Set my Git name and email, confirm I am signed
+            in, install the GitHub Pull Requests extension, and verify I have access to the
+            FreeForCharity organization.&rdquo;
           </PromptBox>
         </section>
 
@@ -373,79 +347,24 @@ export default function VSCodeSetupGuide() {
             <h2 className="text-2xl font-bold text-gray-900">7. Configure MCP Servers</h2>
           </div>
           <p className="text-gray-700 mb-4">
-            VS Code reads MCP server configuration from{' '}
-            <code className="bg-gray-200 px-1 rounded">.vscode/mcp.json</code> in your workspace
-            (shareable in the repo) or from your user profile. For FFC work, enable{' '}
-            <strong>Playwright</strong> and <strong>GitHub</strong>.
-          </p>
-
-          <div className="bg-red-50 border border-red-200 rounded-lg p-4 mb-5">
-            <p className="text-red-800 text-sm">
-              <strong>Critical:</strong> VS Code uses the root key{' '}
-              <code className="bg-red-100 px-1 rounded">servers</code> &mdash; not{' '}
-              <code className="bg-red-100 px-1 rounded">mcpServers</code>. Copy-pasting a Cursor or
-              Antigravity config without changing this key is the number-one setup mistake.
-            </p>
-          </div>
-
-          <div className="space-y-6">
-            <div className="border-l-4 border-blue-600 pl-4">
-              <h3 className="font-bold text-gray-900 mb-2">Option A — Command palette</h3>
-              <p className="text-sm text-gray-700">
-                Open the Command Palette (
-                <code className="bg-gray-200 px-1 rounded">Ctrl/Cmd+Shift+P</code>) and run{' '}
-                <strong>MCP: Add Server</strong>. Choose <em>Workspace</em> to create{' '}
-                <code className="bg-gray-200 px-1 rounded">.vscode/mcp.json</code>, then follow the
-                guided flow. Or install Playwright directly: in the Extensions view search{' '}
-                <code className="bg-gray-200 px-1 rounded">@mcp playwright</code> and click Install.
-              </p>
-            </div>
-
-            <div className="border-l-4 border-blue-600 pl-4">
-              <h3 className="font-bold text-gray-900 mb-2">
-                Option B — Edit <code>.vscode/mcp.json</code>
-              </h3>
-              <p className="text-sm text-gray-700 mb-2">
-                Run <strong>MCP: Open Workspace Folder Configuration</strong> and paste:
-              </p>
-              <div className="bg-gray-900 text-gray-100 p-4 rounded-lg text-xs font-mono overflow-x-auto">
-                <pre>{`{
-  "servers": {
-    "playwright": {
-      "command": "npx",
-      "args": ["@playwright/mcp@latest"]
-    },
-    "github": {
-      "type": "http",
-      "url": "https://api.githubcopilot.com/mcp"
-    }
-  }
-}`}</pre>
-              </div>
-              <p className="text-sm text-gray-700 mt-2">
-                The GitHub server is the hosted Copilot MCP endpoint; VS Code handles its
-                authentication through your Copilot/GitHub sign-in. Save the file, then enable the
-                servers when VS Code prompts.
-              </p>
-            </div>
-          </div>
-
-          <p className="text-gray-700 mt-5 mb-1 text-sm">
-            <strong>Recommended:</strong> let Copilot create the config for you. Paste this into
-            Copilot Chat (Agent mode):
+            VS Code reads MCP server configuration for a workspace, and the servers you need —{' '}
+            <strong>GitHub</strong> (issues and PRs) and <strong>Playwright</strong> (browser
+            testing) — are available without hand-writing any config. Rather than copy a snippet
+            that could be stale, let Copilot set them up in agent mode:
           </p>
           <PromptBox accent="blue">
-            &ldquo;Create a <code>.vscode/mcp.json</code> in this workspace that registers two MCP
-            servers under the <code>servers</code> key: a <code>playwright</code> server that runs{' '}
-            <code>npx @playwright/mcp@latest</code>, and a <code>github</code> server of type{' '}
-            <code>http</code> at <code>https://api.githubcopilot.com/mcp</code>. Then start the
-            servers and confirm the Playwright and GitHub tools appear in Configure Tools.&rdquo;
+            &ldquo;Configure the MCP servers I need for this workspace so you can work on Free For
+            Charity repositories: a GitHub server (issues and pull requests) and a Playwright server
+            (for our end-to-end tests). Add them however the current version of VS Code expects,
+            start them, and confirm both appear in <strong>Configure Tools</strong>. I&apos;ll
+            approve any sign-in.&rdquo;
           </PromptBox>
           <div className="mt-4 bg-blue-50 border-l-4 border-blue-600 p-4 rounded">
             <p className="text-blue-900 text-sm">
-              <strong>Verify:</strong> switch Copilot Chat to <em>Agent</em> mode, click{' '}
-              <strong>Configure Tools</strong>, and confirm the Playwright and GitHub tools are
-              listed and enabled. First Playwright run downloads a browser — that is expected.
+              <strong>Verify:</strong> make sure Copilot Chat is in <em>Agent</em> mode (Ask/Edit
+              cannot use MCP tools), open <strong>Configure Tools</strong>, and check the GitHub and
+              Playwright tools are listed and enabled. The first Playwright run downloads a browser
+              — that is expected.
             </p>
           </div>
         </section>
@@ -471,31 +390,20 @@ export default function VSCodeSetupGuide() {
             , the starting point for new charity sites.
           </p>
           <p className="text-gray-700 mb-1 text-sm">
-            <strong>Recommended:</strong> have Copilot clone and verify the repo. Paste this into
-            Copilot Chat (Agent mode):
+            Let Copilot clone it, install dependencies, and run the checks — it knows the commands
+            for the current toolchain:
           </p>
           <PromptBox accent="blue">
-            &ldquo;Clone the repository{' '}
-            <code>https://github.com/FreeForCharity/FFC_Single_Page_Template.git</code>, open it in
-            this window, install dependencies with <code>pnpm install</code>, then run{' '}
-            <code>pnpm run build</code> and <code>pnpm run test:e2e</code>. Do not cancel
-            long-running commands. Tell me if anything fails and how to fix it.&rdquo;
+            &ldquo;Clone <strong>FreeForCharity/FFC_Single_Page_Template</strong>, open it in this
+            window, install dependencies, then run our full set of checks in the order this
+            repo&apos;s <code>AGENTS.md</code> describes (formatting, linting, build, tests, and
+            end-to-end tests). For an example of a finished Free For Charity site, also pull up{' '}
+            <strong>FreeForCharity/FFC-IN-ffcadmin.org</strong>. Do not cancel long-running
+            commands; tell me if anything fails.&rdquo;
           </PromptBox>
-          <p className="text-gray-700 mt-4 mb-2 text-sm">
-            Prefer to do it by hand? The equivalent commands are:
-          </p>
-          <div className="bg-gray-900 text-gray-100 p-4 rounded-lg text-sm font-mono overflow-x-auto">
-            <p className="text-blue-300"># Clone, install, and verify</p>
-            <p>git clone https://github.com/FreeForCharity/FFC_Single_Page_Template.git</p>
-            <p>cd FFC_Single_Page_Template</p>
-            <p>code .</p>
-            <p>pnpm install</p>
-            <p>pnpm run build</p>
-            <p>pnpm run test:e2e &nbsp;&nbsp;# exercises Playwright</p>
-          </div>
           <div className="mt-4 bg-blue-50 border-l-4 border-blue-600 p-4 rounded">
             <p className="text-blue-900 text-sm">
-              Do not cancel the build or E2E run — they can take a minute.
+              The build and end-to-end run can take a minute — let them finish.
             </p>
           </div>
         </section>
@@ -533,26 +441,27 @@ export default function VSCodeSetupGuide() {
               </p>
               <PromptBox accent="blue">
                 &ldquo;Create a new branch for issue #&lt;number&gt; (do not commit to{' '}
-                <code>main</code>), then make the change it describes. When you are done, show me
-                the full diff so I can review it before we go further.&rdquo;
+                <code>main</code>) and make the change it describes. Follow the repo&apos;s{' '}
+                <code>AGENTS.md</code> conventions, and use{' '}
+                <strong>FreeForCharity/FFC-IN-ffcadmin.org</strong> as an example of how a finished
+                site is built. When you are done, show me the full diff so I can review it before we
+                go further.&rdquo;
               </PromptBox>
             </div>
             <div className="border-l-4 border-blue-600 pl-4">
               <h3 className="font-bold text-gray-900 mb-1">Step 3 — Run the checks</h3>
               <p className="text-sm text-gray-700">
-                <code className="bg-gray-200 px-1 rounded">pnpm run format</code>,{' '}
-                <code className="bg-gray-200 px-1 rounded">pnpm run lint</code>,{' '}
-                <code className="bg-gray-200 px-1 rounded">pnpm run build</code>,{' '}
-                <code className="bg-gray-200 px-1 rounded">pnpm test</code>, and{' '}
-                <code className="bg-gray-200 px-1 rounded">pnpm run test:e2e</code> — in that order,
-                which matches CI (build before tests, since some tests check the build output).
+                Have the agent run our full set of checks — formatting, linting, build, unit tests,
+                and end-to-end tests — in the order our{' '}
+                <code className="bg-gray-200 px-1 rounded">AGENTS.md</code> specifies (build before
+                tests, to match CI). The agent reads the exact commands from the repo, so you do not
+                have to.
               </p>
               <PromptBox accent="blue">
-                &ldquo;Run the full pre-commit checklist in this order, which matches CI:{' '}
-                <code>pnpm run format</code>, <code>pnpm run lint</code>,{' '}
-                <code>pnpm run build</code>, <code>pnpm test</code>, and{' '}
-                <code>pnpm run test:e2e</code>. Do not cancel anything. Fix any failures and re-run
-                until everything passes.&rdquo;
+                &ldquo;Run our full pre-commit checklist in the order documented in this repo&apos;s{' '}
+                <code>AGENTS.md</code> (formatting, linting, build, unit tests, then end-to-end
+                tests). Do not cancel anything. Fix any failures and re-run until everything
+                passes.&rdquo;
               </PromptBox>
             </div>
             <div className="border-l-4 border-blue-600 pl-4">
@@ -597,16 +506,14 @@ export default function VSCodeSetupGuide() {
             <li className="flex items-start">
               <span className="text-red-500 mr-2 mt-0.5">&#10005;</span>
               <span>
-                Never paste tokens or keys into chat, code, commits, or{' '}
-                <code className="bg-gray-200 px-1 rounded">.vscode/mcp.json</code> (it is committed
-                to the repo).
+                Never paste tokens or keys into chat, code, commits, or any workspace MCP config
+                file (those can be committed to the repo).
               </span>
             </li>
             <li className="flex items-start">
               <span className="text-blue-600 mr-2 mt-0.5">&#10003;</span>
               <span>
-                Use VS Code&apos;s secure input prompts (
-                <code className="bg-gray-200 px-1 rounded">inputs</code>) or a git-ignored{' '}
+                Use VS Code&apos;s secure input prompts or a git-ignored{' '}
                 <code className="bg-gray-200 px-1 rounded">.env</code> for any secrets.
               </span>
             </li>
@@ -666,18 +573,14 @@ export default function VSCodeSetupGuide() {
                 <tr className="bg-gray-50">
                   <td className="p-3 border border-gray-200">Server fails to start</td>
                   <td className="p-3 border border-gray-200">
-                    Confirm the root key is{' '}
-                    <code className="bg-gray-200 px-1 rounded">servers</code> (not{' '}
-                    <code className="bg-gray-200 px-1 rounded">mcpServers</code>) and reload the
-                    window.
+                    Ask Copilot to re-add the server the way the current version of VS Code expects,
+                    then reload the window.
                   </td>
                 </tr>
                 <tr>
                   <td className="p-3 border border-gray-200">Playwright cannot launch a browser</td>
                   <td className="p-3 border border-gray-200">
-                    Run{' '}
-                    <code className="bg-gray-200 px-1 rounded">pnpm exec playwright install</code>{' '}
-                    once.
+                    Ask the agent to install the Playwright browsers once.
                   </td>
                 </tr>
                 <tr className="bg-gray-50">

--- a/src/app/developer-environment-setup/vscode/page.tsx
+++ b/src/app/developer-environment-setup/vscode/page.tsx
@@ -78,6 +78,38 @@ export default function VSCodeSetupGuide() {
       </div>
 
       <main className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        {/* Advanced positioning */}
+        <div className="bg-indigo-50 border border-indigo-200 rounded-xl p-5 mb-8">
+          <p className="text-sm text-indigo-900">
+            <strong>This is an advanced environment.</strong> If you are new to development, start
+            with{' '}
+            <Link
+              href="/developer-environment-setup/claude-desktop"
+              className="text-indigo-800 underline font-medium"
+            >
+              Claude Desktop
+            </Link>{' '}
+            — most charity website work never needs more. Come here when you want local builds,
+            browser debugging, or larger refactors. VS Code&apos;s agent mode is Copilot-native, but
+            you can also run{' '}
+            <Link
+              href="/developer-environment-setup/claude-desktop"
+              className="text-indigo-800 underline"
+            >
+              Claude
+            </Link>{' '}
+            or{' '}
+            <Link href="/developer-environment-setup/codex" className="text-indigo-800 underline">
+              Codex
+            </Link>{' '}
+            as the agent. See the{' '}
+            <Link href="/developer-environment-setup" className="text-indigo-800 underline">
+              setup hub
+            </Link>{' '}
+            to compare options.
+          </p>
+        </div>
+
         {/* TOC */}
         <div className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-10">
           <h2 className="text-2xl font-bold text-gray-900 mb-6">On this page</h2>

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -50,6 +50,18 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.8,
     },
     {
+      url: `${SITE_URL}/developer-environment-setup/claude-desktop/`,
+      lastModified: now,
+      changeFrequency: 'monthly',
+      priority: 0.7,
+    },
+    {
+      url: `${SITE_URL}/developer-environment-setup/codex/`,
+      lastModified: now,
+      changeFrequency: 'monthly',
+      priority: 0.7,
+    },
+    {
       url: `${SITE_URL}/developer-environment-setup/google-antigravity/`,
       lastModified: now,
       changeFrequency: 'monthly',

--- a/src/components/PromptBox.tsx
+++ b/src/components/PromptBox.tsx
@@ -17,6 +17,16 @@ const ACCENTS = {
     label: 'text-blue-700',
     text: 'text-blue-900',
   },
+  amber: {
+    container: 'border-amber-300 bg-amber-50',
+    label: 'text-amber-700',
+    text: 'text-amber-900',
+  },
+  slate: {
+    container: 'border-slate-300 bg-slate-100',
+    label: 'text-slate-600',
+    text: 'text-slate-900',
+  },
 } as const
 
 interface PromptBoxProps {

--- a/src/components/PromptBox.tsx
+++ b/src/components/PromptBox.tsx
@@ -30,7 +30,10 @@ const ACCENTS = {
 } as const
 
 interface PromptBoxProps {
-  /** Accent color, usually matching the guide (emerald = Antigravity, blue = VS Code). */
+  /**
+   * Accent color, usually matching the guide:
+   * emerald = Antigravity, blue = VS Code, amber = Claude Desktop, slate = Codex.
+   */
   accent?: keyof typeof ACCENTS
   /** Optional override for the label above the prompt. */
   label?: string

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -44,7 +44,7 @@ export const resourcesDropdown: NavDropdown = {
     {
       label: 'Dev Environment Setup',
       href: '/developer-environment-setup',
-      description: 'Set up Antigravity or VS Code with AI agents and MCP servers.',
+      description: 'Start with your AI of choice — Claude, Codex, Gemini, or Copilot.',
     },
     {
       label: 'Tech Stack',


### PR DESCRIPTION
## Summary

Restructures the Developer Environment Setup section around the **AI agent you choose**, and makes the guides prompt-driven rather than snippet-driven.

### New model: start with your AI of choice
- **Hub rewrite** around the four primary AI agents — **Claude, OpenAI Codex, Google Gemini, GitHub Copilot** — with **bring-your-own-AI** guidance (keep the AI you already pay for) and a **beginner → advanced** progression. The easiest path is your AI's **native desktop app**; advanced developers move into an IDE. Includes an honest **"what 'advanced' means — and why most charities never need it"** section. Removes the old Antigravity-vs-VS Code framing for balance.
- **Default recommendation** for newcomers: **Claude Pro + Claude Desktop + Claude Mobile.**

### Two new beginner guides (full, standalone)
- **Claude Desktop** (`/developer-environment-setup/claude-desktop`) — our recommendation; GitHub via MCP connectors, Claude Mobile, no local tooling required.
- **OpenAI Codex** (`/developer-environment-setup/codex`) — ChatGPT sign-in, MCP, reads our `AGENTS.md`.

### Advanced guides rebalanced
- **VS Code** and **Antigravity** repositioned as equal "advanced" peers, each with a banner pointing newcomers to Claude Desktop and noting you can run Claude or Codex in either.

### Prompt-driven, not snippet-driven (review feedback)
- **Removed every code/config snippet** (JSON, CLI, bash, terminal blocks) — MCP servers are mostly plugins/connectors that don't need manual install, and snippets go stale.
- Replaced them with **generalized prompts** that let the agent handle the particulars of install/enable.
- **Prompts point at the real repos**: `FreeForCharity/FFC_Single_Page_Template` (template) and `FreeForCharity/FFC-IN-ffcadmin.org` (a finished example to match).
- Check-running prompts now say **"follow the order in `AGENTS.md`"** instead of hard-coded `pnpm` lists.

### Wiring
- New routes added to `sitemap.ts`; `PromptBox` gains amber (Claude) and slate (Codex) accents; Resources nav description refreshed.

## Verification
- `pnpm run format` ✓ · `pnpm run lint` ✓ (0 errors) · `pnpm run build` ✓ (5 routes) · `pnpm test` ✓ (334) · `pnpm run test:e2e` ✓ (12)

Refs #291

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X4omPQW2ErDyZsMtxypuMe)_