### PR TITLE
feat: add Site Owner pathway for non-technical charity site owners

### DIFF
--- a/src/app/developer-environment-setup/page.tsx
+++ b/src/app/developer-environment-setup/page.tsx
@@ -179,6 +179,46 @@ export default function DeveloperEnvironmentSetupPage() {
       </div>
 
       <main className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        {/* Site-owner fork — sits above the full agent matrix */}
+        <div className="bg-emerald-50 border-2 border-emerald-200 rounded-xl p-5 md:p-6 mb-8">
+          <div className="flex items-start gap-4">
+            <span className="text-3xl" aria-hidden="true">
+              🌱
+            </span>
+            <div>
+              <h2 className="text-lg font-bold text-emerald-900">
+                Just want to edit one charity&apos;s website FFC built for you?
+              </h2>
+              <p className="text-sm text-emerald-900/90 mt-1">
+                You don&apos;t need this whole page. If you run a single nonprofit and only want to
+                update your own site, there&apos;s a short, jargon-free walkthrough made for you —
+                no IDE, no local builds, no code. This page is for volunteers who want to develop
+                across many charities.
+              </p>
+              <Link
+                href="/site-owner"
+                className="mt-3 inline-flex items-center text-sm font-semibold text-emerald-700 hover:text-emerald-900"
+              >
+                Go to “Edit My Charity Website”
+                <svg
+                  className="w-4 h-4 ml-1"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M9 5l7 7-7 7"
+                  />
+                </svg>
+              </Link>
+            </div>
+          </div>
+        </div>
+
         {/* Step 1: Start with your AI */}
         <section className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
           <div className="flex items-center mb-4">

--- a/src/app/get-involved/page.tsx
+++ b/src/app/get-involved/page.tsx
@@ -129,6 +129,93 @@ export default function GetInvolved() {
         </div>
       </div>
 
+      {/* Which describes you? — pathway fork */}
+      <section className="py-12 px-4 sm:px-6 lg:px-8 bg-white border-b border-gray-100">
+        <div className="max-w-5xl mx-auto">
+          <h2 className="text-2xl sm:text-3xl font-bold text-gray-900 text-center mb-3">
+            Which describes you?
+          </h2>
+          <p className="text-gray-600 text-center mb-8 max-w-2xl mx-auto">
+            There are two ways to be here. Pick the one that fits — you can always explore the other
+            later.
+          </p>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            {/* Site owner */}
+            <Link
+              href="/site-owner"
+              className="group block rounded-xl border-2 border-emerald-200 bg-emerald-50 p-6 hover:border-emerald-400 hover:shadow-lg transition-all"
+            >
+              <div className="flex items-center mb-2">
+                <span className="text-3xl mr-3" aria-hidden="true">
+                  🌱
+                </span>
+                <h3 className="text-lg font-bold text-emerald-900">
+                  &ldquo;FFC built my charity&apos;s website and I want to edit it&rdquo;
+                </h3>
+              </div>
+              <p className="text-sm text-emerald-900/80 mb-3">
+                You run one nonprofit, you&apos;re not technical, and you just want to keep your own
+                site up to date. No coding, no jargon — describe changes in plain English and
+                approve them.
+              </p>
+              <span className="inline-flex items-center text-sm font-semibold text-emerald-700 group-hover:text-emerald-900">
+                Start the Site Owner walkthrough
+                <svg
+                  className="w-4 h-4 ml-1"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M9 5l7 7-7 7"
+                  />
+                </svg>
+              </span>
+            </Link>
+
+            {/* Holistic volunteer */}
+            <a
+              href="#choose-your-track"
+              className="group block rounded-xl border-2 border-blue-200 bg-blue-50 p-6 hover:border-blue-400 hover:shadow-lg transition-all"
+            >
+              <div className="flex items-center mb-2">
+                <span className="text-3xl mr-3" aria-hidden="true">
+                  🚀
+                </span>
+                <h3 className="text-lg font-bold text-blue-900">
+                  &ldquo;I want to help charities and FFC more broadly&rdquo;
+                </h3>
+              </div>
+              <p className="text-sm text-blue-900/80 mb-3">
+                You want to volunteer across many nonprofits — infrastructure, design, or web
+                development. Pick a track below and grow through the contributor ladder.
+              </p>
+              <span className="inline-flex items-center text-sm font-semibold text-blue-700 group-hover:text-blue-900">
+                See the volunteer tracks
+                <svg
+                  className="w-4 h-4 ml-1"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M19 14l-7 7m0 0l-7-7m7 7V3"
+                  />
+                </svg>
+              </span>
+            </a>
+          </div>
+        </div>
+      </section>
+
       {/* How It Works */}
       <section className="py-16 px-4 sm:px-6 lg:px-8">
         <div className="max-w-5xl mx-auto">
@@ -148,7 +235,7 @@ export default function GetInvolved() {
       </section>
 
       {/* Role Cards */}
-      <section className="py-16 px-4 sm:px-6 lg:px-8 bg-white">
+      <section id="choose-your-track" className="py-16 px-4 sm:px-6 lg:px-8 bg-white scroll-mt-20">
         <div className="max-w-5xl mx-auto">
           <h2 className="text-3xl font-bold text-gray-900 text-center mb-4">Choose Your Track</h2>
           <p className="text-lg text-gray-600 text-center mb-12 max-w-2xl mx-auto">

--- a/src/app/site-owner/common-edits/page.tsx
+++ b/src/app/site-owner/common-edits/page.tsx
@@ -1,0 +1,276 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import Breadcrumbs from '@/components/Breadcrumbs'
+import PromptBox from '@/components/PromptBox'
+
+export const metadata: Metadata = {
+  title: 'Common Edits Cookbook',
+  description:
+    'Ready-to-paste prompts for the most common edits to your FFC charity website: contact info, hours, the donate button, photos, text, team members, social links — plus recurring posts like a blog, newsletter, or board-meeting minutes. No code, just copy, fill in, and hand to your AI assistant.',
+  keywords:
+    'charity website edits, update nonprofit website, blog post, newsletter, board minutes, donate button, AI prompts, Free For Charity, site owner cookbook',
+  alternates: {
+    canonical: 'https://ffcadmin.org/site-owner/common-edits/',
+  },
+}
+
+interface QuickEdit {
+  title: string
+  blurb: string
+  prompt: string
+  caution?: string
+}
+
+const quickEdits: QuickEdit[] = [
+  {
+    title: 'Update contact info',
+    blurb: 'Phone number, email address, or mailing address.',
+    prompt:
+      'update our contact information to: phone <new phone>, email <new email>, address <new address>. Change it everywhere it appears.',
+  },
+  {
+    title: 'Change opening hours / service times',
+    blurb: 'New hours, holiday closures, or service schedules.',
+    prompt:
+      'update our hours / service times to <new hours>. If they appear in more than one place, update all of them and keep the format consistent.',
+  },
+  {
+    title: 'Update the donate link or button',
+    blurb: 'Point the donate button at a new link, or fix the label.',
+    prompt:
+      'update our donate button so it links to <new donation URL> and the button text reads <new label>. Double-check the link opens correctly.',
+  },
+  {
+    title: 'Replace the logo or a photo',
+    blurb: 'Swap in a new image you provide.',
+    prompt:
+      'replace <the logo / the photo in the “About” section / etc.> with the new image I’m providing. Keep it looking good on phones and computers, and add descriptive alt text for screen readers.',
+    caution: 'Have the new image file ready to share with your assistant.',
+  },
+  {
+    title: 'Edit a section of text',
+    blurb: 'Reword your mission, about, or services copy.',
+    prompt:
+      'update the <mission / about / services> text to read: “<your new wording>”. Keep the existing style and headings.',
+  },
+  {
+    title: 'Add or update a team member',
+    blurb: 'New board member or staff bio and photo.',
+    prompt:
+      'add a team member named <name>, role <role>, with this short bio: “<bio>”. Match how the other team members are shown. I’ll provide a photo.',
+  },
+  {
+    title: 'Update social media links',
+    blurb: 'New or changed Facebook, Instagram, etc.',
+    prompt:
+      'update our social media links: <Facebook URL>, <Instagram URL>, <other>. Remove any that no longer apply.',
+  },
+  {
+    title: 'Change colors or brand accents',
+    blurb: 'Tweak the accent colors to match your brand.',
+    prompt:
+      'adjust our brand accent color to <color or hex code>. Keep the text easy to read and make sure the contrast still meets accessibility guidelines.',
+    caution:
+      'Ask the assistant to confirm the new colors stay accessible (readable contrast) before publishing.',
+  },
+]
+
+export default function CommonEditsCookbookPage() {
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Breadcrumbs
+        items={[
+          { label: 'Home', href: '/' },
+          { label: 'Edit My Charity Website', href: '/site-owner' },
+          { label: 'Common Edits Cookbook' },
+        ]}
+      />
+
+      {/* Hero */}
+      <div className="bg-gradient-to-r from-emerald-500 via-teal-500 to-cyan-600 text-white py-16 px-4 sm:px-6 lg:px-8">
+        <div className="max-w-5xl mx-auto">
+          <div className="flex items-center mb-4">
+            <span className="text-5xl mr-4" aria-hidden="true">
+              📒
+            </span>
+            <div>
+              <h1 className="text-3xl md:text-4xl font-bold">Common Edits Cookbook</h1>
+              <p className="text-teal-50 text-sm mt-1">
+                Copy a prompt, fill in the blanks, hand it to your assistant
+              </p>
+            </div>
+          </div>
+          <p className="text-teal-50 text-lg max-w-3xl">
+            These are the changes charity site owners make most often. Each one is a friendly,
+            ready-to-paste prompt — no code. New here? Start with{' '}
+            <Link href="/site-owner" className="underline font-medium text-white">
+              Edit Your Charity&apos;s Website
+            </Link>{' '}
+            first, then keep this page handy.
+          </p>
+        </div>
+      </div>
+
+      <main className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        {/* How to use */}
+        <div className="bg-teal-50 border-l-4 border-teal-500 p-5 rounded mb-8 text-sm text-teal-900">
+          <strong>How to use a prompt:</strong> copy it, replace anything in{' '}
+          <strong>&lt;angle brackets&gt;</strong> with your details, and paste it to your assistant.
+          Every prompt assumes the assistant is already connected to your repository (set up on the{' '}
+          <Link href="/site-owner" className="underline font-medium">
+            main Site Owner page
+          </Link>
+          ). When in doubt, add: “follow the conventions in the repository&apos;s{' '}
+          <code>AGENTS.md</code>, and use FreeForCharity/FFC-IN-ffcadmin.org as an example.”
+        </div>
+
+        {/* Quick edits */}
+        <section className="mb-12">
+          <div className="flex items-center mb-6">
+            <span className="text-4xl mr-4" aria-hidden="true">
+              🛠️
+            </span>
+            <div>
+              <h2 className="text-2xl font-bold text-gray-900">Quick edits</h2>
+              <p className="text-gray-600">Updating content that&apos;s already on your site</p>
+            </div>
+          </div>
+          <div className="space-y-5">
+            {quickEdits.map((edit) => (
+              <div
+                key={edit.title}
+                className="bg-white rounded-xl shadow border border-gray-200 p-5 md:p-6"
+              >
+                <h3 className="text-lg font-bold text-gray-900">{edit.title}</h3>
+                <p className="text-sm text-gray-600 mt-0.5">{edit.blurb}</p>
+                <PromptBox accent="emerald" label="Paste this — fill in the blanks">
+                  &ldquo;In my charity&apos;s website repository{' '}
+                  <strong>&lt;your repository&gt;</strong>, please {edit.prompt} Show me what
+                  changed before publishing, and once I approve and the checks pass, publish
+                  it.&rdquo;
+                </PromptBox>
+                {edit.caution && (
+                  <div className="mt-3 bg-amber-50 border-l-4 border-amber-400 p-3 rounded text-xs text-amber-900">
+                    <strong>Tip:</strong> {edit.caution}
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* Recurring publishing tasks */}
+        <section className="mb-12">
+          <div className="flex items-center mb-6">
+            <span className="text-4xl mr-4" aria-hidden="true">
+              🗞️
+            </span>
+            <div>
+              <h2 className="text-2xl font-bold text-gray-900">Recurring posts</h2>
+              <p className="text-gray-600">
+                Blogs, newsletters, and minutes — published over and over
+              </p>
+            </div>
+          </div>
+
+          <div className="bg-blue-50 border-l-4 border-blue-600 p-5 rounded mb-6 text-sm text-blue-900">
+            <strong>Your site grows as your mission needs it.</strong> A new FFC site usually starts
+            as a single page and adds sections only when you need them. So each prompt below works
+            two ways: the <strong>first time</strong>, it asks the assistant to create the section
+            if you don&apos;t have one yet; <strong>after that</strong>, it just adds the latest
+            entry. The assistant figures out which applies.
+          </div>
+
+          {/* Blog */}
+          <div className="bg-white rounded-xl shadow border border-gray-200 p-5 md:p-6 mb-5">
+            <h3 className="text-lg font-bold text-gray-900">Add a blog / article / news post</h3>
+            <p className="text-sm text-gray-600 mt-0.5">Share an update, story, or announcement.</p>
+            <PromptBox accent="emerald" label="Paste this — fill in the blanks">
+              &ldquo;In my charity&apos;s website repository{' '}
+              <strong>&lt;your repository&gt;</strong>, I want to publish a news post titled{' '}
+              <strong>&lt;title&gt;</strong>, dated <strong>&lt;date&gt;</strong>, with this
+              content: &lsquo;<strong>&lt;your text&gt;</strong>
+              &rsquo;. If my site doesn&apos;t already have a news/blog section, create one that
+              matches the site&apos;s style and add a link to it from the main page; if it does,
+              just add this as the newest post. Follow the repository&apos;s <code>
+                AGENTS.md
+              </code>{' '}
+              and use FreeForCharity/FFC-IN-ffcadmin.org as an example. Show me the result before
+              publishing.&rdquo;
+            </PromptBox>
+          </div>
+
+          {/* Newsletter */}
+          <div className="bg-white rounded-xl shadow border border-gray-200 p-5 md:p-6 mb-5">
+            <h3 className="text-lg font-bold text-gray-900">Post the monthly newsletter</h3>
+            <p className="text-sm text-gray-600 mt-0.5">
+              Put each month&apos;s newsletter on your site.
+            </p>
+            <PromptBox accent="emerald" label="Paste this — fill in the blanks">
+              &ldquo;In my charity&apos;s website repository{' '}
+              <strong>&lt;your repository&gt;</strong>, publish our{' '}
+              <strong>&lt;month, year&gt;</strong> newsletter. Here is the content: &lsquo;
+              <strong>&lt;paste newsletter text&gt;</strong>&rsquo;. If there&apos;s no newsletter
+              section yet, create one that matches the site&apos;s style and link to it from the
+              main page; otherwise add this as the newest issue and keep past issues listed. Follow{' '}
+              <code>AGENTS.md</code>. Show me the result before publishing.&rdquo;
+            </PromptBox>
+          </div>
+
+          {/* Board minutes */}
+          <div className="bg-white rounded-xl shadow border border-amber-300 p-5 md:p-6">
+            <div className="flex items-center gap-2">
+              <h3 className="text-lg font-bold text-gray-900">Post the monthly board minutes</h3>
+              <span className="text-[10px] font-bold uppercase tracking-wide bg-amber-100 text-amber-800 px-2 py-0.5 rounded">
+                Member-based orgs
+              </span>
+            </div>
+            <p className="text-sm text-gray-600 mt-0.5">
+              For membership organizations that publish their board meeting minutes.
+            </p>
+
+            <div className="mt-3 bg-amber-50 border-l-4 border-amber-500 p-4 rounded text-sm text-amber-900">
+              <strong>Important — this is public.</strong> Your website can be seen by anyone on the
+              internet. A static site can&apos;t hide minutes behind a members-only login, so
+              anything you post here is visible to everyone. Only post minutes your board has{' '}
+              <strong>approved for public release</strong> — and if the full minutes shouldn&apos;t
+              be public, post a short approved summary instead.
+            </div>
+
+            <PromptBox accent="emerald" label="Paste this — fill in the blanks">
+              &ldquo;In my charity&apos;s website repository{' '}
+              <strong>&lt;your repository&gt;</strong>, publish our board meeting minutes for{' '}
+              <strong>&lt;meeting date&gt;</strong>. Here is the approved, public version: &lsquo;
+              <strong>&lt;paste approved minutes or summary&gt;</strong>
+              &rsquo;. If there&apos;s no minutes section yet, create one that matches the
+              site&apos;s style and link to it; otherwise add this as the newest entry and keep
+              prior minutes listed by date. Remember this will be publicly visible. Follow{' '}
+              <code>AGENTS.md</code>. Show me the result before publishing.&rdquo;
+            </PromptBox>
+          </div>
+        </section>
+
+        {/* Footer nav */}
+        <div className="bg-gradient-to-br from-gray-50 to-teal-50 rounded-xl shadow-lg p-6 md:p-8 border border-gray-200">
+          <h2 className="text-xl font-bold text-gray-900 mb-4">Related</h2>
+          <ul className="space-y-2 text-sm text-gray-700">
+            <li>
+              <Link href="/site-owner" className="text-teal-700 underline hover:text-teal-900">
+                &larr; Back to Edit Your Charity&apos;s Website
+              </Link>
+            </li>
+            <li>
+              <Link
+                href="/developer-environment-setup/claude-desktop"
+                className="text-teal-700 underline hover:text-teal-900"
+              >
+                Claude Desktop setup guide
+              </Link>
+              <span className="text-gray-500"> &mdash; how the assistant connects to GitHub</span>
+            </li>
+          </ul>
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/src/app/site-owner/page.tsx
+++ b/src/app/site-owner/page.tsx
@@ -1,0 +1,622 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import Breadcrumbs from '@/components/Breadcrumbs'
+import PromptBox from '@/components/PromptBox'
+
+export const metadata: Metadata = {
+  title: 'Edit My Charity Website',
+  description:
+    'FFC built a website for the charity you run, and you just want to edit it. This is the simplest path: no coding, no IDE, no jargon. Describe your change in plain English to an AI assistant, approve it, and your site updates automatically. Get to your first edit in about 20 minutes.',
+  keywords:
+    'edit charity website, nonprofit website owner, no-code website edit, Claude Desktop, AI website editing, Free For Charity, site owner, update my website',
+  alternates: {
+    canonical: 'https://ffcadmin.org/site-owner/',
+  },
+}
+
+interface PageSection {
+  id: string
+  number: string
+  title: string
+  icon: string
+}
+
+const sections: PageSection[] = [
+  { id: 'how-it-works', number: '1', title: 'How this works', icon: '💡' },
+  { id: 'before-you-start', number: '2', title: 'Before you start', icon: '✅' },
+  { id: 'first-edit', number: '3', title: 'Make your first edit', icon: '✏️' },
+  { id: 'publish', number: '4', title: 'See your change and publish it', icon: '🚀' },
+  { id: 'cookbook', number: '5', title: 'Common edits cookbook', icon: '📒' },
+  { id: 'glossary', number: '6', title: 'Plain-language glossary', icon: '📖' },
+  { id: 'help', number: '7', title: 'Good habits and getting help', icon: '🤝' },
+]
+
+const tldr = [
+  {
+    step: '1',
+    title: 'Accept your invite',
+    body: 'Open the email from GitHub and click Accept — this gives you the keys to your site.',
+  },
+  {
+    step: '2',
+    title: 'Install your AI assistant',
+    body: 'Download Claude Desktop, sign in, and connect it to GitHub once.',
+  },
+  {
+    step: '3',
+    title: 'Describe your change',
+    body: 'Type what you want in plain English, e.g. “update our phone number.”',
+  },
+  {
+    step: '4',
+    title: 'Approve — it’s live',
+    body: 'Read what the assistant changed, click approve, and your site updates in minutes.',
+  },
+]
+
+const glossary = [
+  {
+    term: 'Repository (“repo”)',
+    plain:
+      'The folder that holds your website’s files. FFC created one just for your charity — think of it as your site’s home.',
+  },
+  {
+    term: 'Branch',
+    plain:
+      'A safe scratch copy of your site where a change is drafted before it goes live. Your assistant makes one for you; you don’t have to think about it.',
+  },
+  {
+    term: 'Pull request (“PR”)',
+    plain:
+      'The “here’s what I changed — okay to publish?” page. It shows the change side-by-side so you can read it and approve.',
+  },
+  {
+    term: 'Merge',
+    plain: 'Clicking “yes, publish this.” Once merged, your change goes out to your live site.',
+  },
+  {
+    term: 'Checks',
+    plain:
+      'Quick automatic tests that confirm your site still builds correctly. A green check means it’s safe.',
+  },
+]
+
+export default function SiteOwnerPage() {
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Breadcrumbs items={[{ label: 'Home', href: '/' }, { label: 'Edit My Charity Website' }]} />
+
+      {/* Hero */}
+      <div className="bg-gradient-to-r from-emerald-500 via-teal-500 to-cyan-600 text-white py-16 px-4 sm:px-6 lg:px-8">
+        <div className="max-w-5xl mx-auto">
+          <div className="flex items-center mb-4">
+            <span className="text-5xl mr-4" aria-hidden="true">
+              🌱
+            </span>
+            <div>
+              <h1 className="text-3xl md:text-4xl font-bold">Edit Your Charity&apos;s Website</h1>
+              <p className="text-teal-50 text-sm mt-1">
+                FFC built your site — here&apos;s how to make changes yourself, no coding required
+              </p>
+            </div>
+          </div>
+          <p className="text-teal-50 text-lg max-w-3xl">
+            You founded a charity, FFC built you a website, and now you just want to keep it up to
+            date. You don&apos;t need to be technical and you don&apos;t need to learn to code. You
+            describe the change you want in plain English, an AI assistant makes it, you read it and
+            approve, and your site updates on its own.
+          </p>
+          <div className="mt-6 flex flex-wrap gap-3">
+            <span className="bg-white/20 px-3 py-1 rounded-full text-sm font-medium">
+              No coding
+            </span>
+            <span className="bg-white/20 px-3 py-1 rounded-full text-sm font-medium">
+              ~20 minutes to your first edit
+            </span>
+            <span className="bg-white/20 px-3 py-1 rounded-full text-sm font-medium">
+              Works from your phone
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <main className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        {/* Reassurance banner */}
+        <div className="bg-emerald-50 border-l-4 border-emerald-500 p-5 rounded mb-8">
+          <p className="text-emerald-900 text-sm">
+            <strong>You can ignore the technical stuff.</strong> If you only want to edit your one
+            charity site, you never need VS&nbsp;Code, Google Antigravity, Playwright, or anything
+            you install and run on your computer. Those are for full-time developers. Everything on
+            this page happens in a friendly chat window. The longer{' '}
+            <Link
+              href="/developer-environment-setup"
+              className="text-emerald-900 underline font-medium"
+            >
+              developer setup pages
+            </Link>{' '}
+            are optional — come back to them only if you ever want to go deeper.
+          </p>
+        </div>
+
+        {/* TL;DR */}
+        <section className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
+          <div className="flex items-center mb-6">
+            <span className="text-4xl mr-4" aria-hidden="true">
+              ⚡
+            </span>
+            <div>
+              <h2 className="text-2xl font-bold text-gray-900">The whole thing in four steps</h2>
+              <p className="text-gray-600">
+                This is the entire process — the rest of the page just walks you through it
+              </p>
+            </div>
+          </div>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+            {tldr.map((t) => (
+              <div key={t.step} className="border border-gray-200 rounded-lg p-4 bg-gray-50">
+                <div className="w-9 h-9 bg-teal-600 text-white rounded-full flex items-center justify-center font-bold mb-3">
+                  {t.step}
+                </div>
+                <h3 className="font-bold text-gray-900 mb-1 text-sm">{t.title}</h3>
+                <p className="text-sm text-gray-600">{t.body}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* TOC */}
+        <div className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-10">
+          <h2 className="text-2xl font-bold text-gray-900 mb-6">On this page</h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+            {sections.map((section) => (
+              <a
+                key={section.id}
+                href={`#${section.id}`}
+                className="flex items-center p-2 rounded-lg hover:bg-teal-50 transition-colors group"
+              >
+                <span className="text-xl mr-3" aria-hidden="true">
+                  {section.icon}
+                </span>
+                <span className="text-sm font-medium text-gray-700 group-hover:text-teal-700">
+                  <span className="text-teal-600 font-bold mr-1">{section.number}.</span>
+                  {section.title}
+                </span>
+              </a>
+            ))}
+          </div>
+        </div>
+
+        {/* 1. How it works */}
+        <section id="how-it-works" className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
+          <div className="flex items-center mb-6">
+            <span className="text-4xl mr-4" aria-hidden="true">
+              💡
+            </span>
+            <h2 className="text-2xl font-bold text-gray-900">1. How this works</h2>
+          </div>
+          <p className="text-gray-700 mb-4">
+            Your website lives in a <strong>repository</strong> — a folder of files that FFC set up
+            for your charity from our standard template. You don&apos;t edit those files by hand.
+            You tell an <strong>AI assistant</strong> what you want changed, in ordinary words, and
+            it makes the edit for you. Then it shows you exactly what it did and waits for your
+            approval before anything goes live.
+          </p>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <div className="bg-teal-50 border border-teal-200 rounded-lg p-4">
+              <h3 className="font-bold text-teal-800 mb-1 text-sm">You describe</h3>
+              <p className="text-sm text-teal-900">
+                “Change our phone number to 555-1234.” That&apos;s the whole skill you need.
+              </p>
+            </div>
+            <div className="bg-teal-50 border border-teal-200 rounded-lg p-4">
+              <h3 className="font-bold text-teal-800 mb-1 text-sm">The assistant does it</h3>
+              <p className="text-sm text-teal-900">
+                It finds the right spot, makes the change, and runs the safety checks for you.
+              </p>
+            </div>
+            <div className="bg-teal-50 border border-teal-200 rounded-lg p-4">
+              <h3 className="font-bold text-teal-800 mb-1 text-sm">You approve</h3>
+              <p className="text-sm text-teal-900">
+                Read what changed, click approve, and your site updates a few minutes later.
+              </p>
+            </div>
+          </div>
+          <div className="mt-4 bg-blue-50 border-l-4 border-blue-600 p-4 rounded">
+            <p className="text-blue-900 text-sm">
+              <strong>You are always in control.</strong> Nothing reaches your live website until
+              you&apos;ve seen the change and said yes.
+            </p>
+          </div>
+        </section>
+
+        {/* 2. Before you start */}
+        <section id="before-you-start" className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
+          <div className="flex items-center mb-6">
+            <span className="text-4xl mr-4" aria-hidden="true">
+              ✅
+            </span>
+            <div>
+              <h2 className="text-2xl font-bold text-gray-900">2. Before you start</h2>
+              <p className="text-gray-600">A one-time setup — about 15 minutes, done once</p>
+            </div>
+          </div>
+
+          <div className="bg-emerald-50 border border-emerald-200 rounded-lg p-4 mb-6 text-sm text-emerald-900">
+            <strong>What FFC already did for you:</strong> we created a repository (the folder that
+            holds your website) from our standard template and put your charity&apos;s site in it.
+            You&apos;ll edit your own copy — you never touch the template, and you only ever deal
+            with this one repository.
+          </div>
+
+          <ol className="space-y-5">
+            <li className="flex items-start">
+              <span className="flex-shrink-0 w-8 h-8 bg-teal-600 text-white rounded-full flex items-center justify-center font-bold mr-4">
+                1
+              </span>
+              <div>
+                <h3 className="font-bold text-gray-900">Make a free GitHub account</h3>
+                <p className="text-sm text-gray-700">
+                  GitHub is the service that stores your website&apos;s files. If you don&apos;t
+                  have an account yet, create a free one at{' '}
+                  <a
+                    href="https://github.com/signup"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-teal-700 underline hover:text-teal-900"
+                  >
+                    github.com/signup
+                  </a>
+                  . Use an email you check — your repository invitation comes here.
+                </p>
+              </div>
+            </li>
+            <li className="flex items-start">
+              <span className="flex-shrink-0 w-8 h-8 bg-teal-600 text-white rounded-full flex items-center justify-center font-bold mr-4">
+                2
+              </span>
+              <div>
+                <h3 className="font-bold text-gray-900">
+                  Accept the invitation to your repository
+                </h3>
+                <p className="text-sm text-gray-700">
+                  FFC adds you as a <strong>collaborator</strong> on your charity&apos;s repository
+                  — just your one repo, nothing else. You&apos;ll get an email titled something like
+                  “[your charity] invited you to collaborate” and a notification on GitHub. Open it
+                  and click <strong>Accept invitation</strong>. That&apos;s what gives you (and your
+                  assistant) permission to make changes.
+                </p>
+                <div className="mt-2 bg-amber-50 border-l-4 border-amber-400 p-3 rounded text-xs text-amber-900">
+                  Didn&apos;t get an invite, or the link expired? Email your FFC contact and ask
+                  them to re-send the collaborator invitation to your GitHub username.
+                </div>
+              </div>
+            </li>
+            <li className="flex items-start">
+              <span className="flex-shrink-0 w-8 h-8 bg-teal-600 text-white rounded-full flex items-center justify-center font-bold mr-4">
+                3
+              </span>
+              <div>
+                <h3 className="font-bold text-gray-900">Install your AI assistant</h3>
+                <p className="text-sm text-gray-700">
+                  We recommend <strong>Claude Desktop</strong> on your computer and{' '}
+                  <strong>Claude Mobile</strong> on your phone — it&apos;s the gentlest starting
+                  point. Download it from{' '}
+                  <a
+                    href="https://claude.ai/download"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-teal-700 underline hover:text-teal-900"
+                  >
+                    claude.ai/download
+                  </a>{' '}
+                  and sign in. Already pay for ChatGPT or another AI? You can use that instead — see
+                  the{' '}
+                  <Link
+                    href="/developer-environment-setup"
+                    className="text-teal-700 underline hover:text-teal-900"
+                  >
+                    full list of options
+                  </Link>
+                  .
+                </p>
+              </div>
+            </li>
+            <li className="flex items-start">
+              <span className="flex-shrink-0 w-8 h-8 bg-teal-600 text-white rounded-full flex items-center justify-center font-bold mr-4">
+                4
+              </span>
+              <div>
+                <h3 className="font-bold text-gray-900">Connect your assistant to GitHub (once)</h3>
+                <p className="text-sm text-gray-700">
+                  Your assistant needs a one-time connection to GitHub so it can see your
+                  repository. The{' '}
+                  <Link
+                    href="/developer-environment-setup/claude-desktop"
+                    className="text-teal-700 underline hover:text-teal-900"
+                  >
+                    Claude Desktop guide
+                  </Link>{' '}
+                  walks you through it — or just paste this and let the assistant set itself up:
+                </p>
+                <PromptBox accent="emerald" label="Paste this into your AI assistant">
+                  &ldquo;I want to edit my charity&apos;s website, which lives in a GitHub
+                  repository I was just added to. Set yourself up to work with GitHub: connect to it
+                  and walk me through any sign-in. When you&apos;re ready, confirm you can see my
+                  repository{' '}
+                  <strong>
+                    &lt;paste your repository address here, e.g. github.com/FreeForCharity/
+                    your-charity&gt;
+                  </strong>{' '}
+                  and tell me what website is inside it.&rdquo;
+                </PromptBox>
+              </div>
+            </li>
+          </ol>
+
+          <div className="mt-6 bg-green-50 border border-green-200 rounded-lg p-4 text-sm text-green-900">
+            <strong>You&apos;re set up when</strong> your assistant can tell you what&apos;s in your
+            repository. From here on, you just describe changes — the rest of this page shows how.
+          </div>
+        </section>
+
+        {/* 3. First edit */}
+        <section id="first-edit" className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
+          <div className="flex items-center mb-6">
+            <span className="text-4xl mr-4" aria-hidden="true">
+              ✏️
+            </span>
+            <div>
+              <h2 className="text-2xl font-bold text-gray-900">3. Make your first edit</h2>
+              <p className="text-gray-600">Let&apos;s change one small thing, start to finish</p>
+            </div>
+          </div>
+          <p className="text-gray-700 mb-4">
+            The best first edit is something small and safe — like fixing a typo or updating your
+            phone number. Paste the prompt below into your assistant, filling in the blanks. It will
+            make the change on a safe scratch copy and show you the result; behind the scenes it
+            handles all the technical steps so you don&apos;t have to.
+          </p>
+
+          <PromptBox accent="emerald" label="Paste this — fill in the blanks">
+            &ldquo;In my charity&apos;s website repository{' '}
+            <strong>&lt;your repository address&gt;</strong>, please{' '}
+            <strong>
+              &lt;describe the change, e.g. update the phone number on the home page to
+              (555)&nbsp;123-4567&gt;
+            </strong>
+            . Follow the conventions in the repository&apos;s <code>AGENTS.md</code> file, and use{' '}
+            <strong>FreeForCharity/FFC-IN-ffcadmin.org</strong> as an example of a finished FFC site
+            if you need one. Make the change on a new branch (don&apos;t publish to the live site
+            yet), then show me exactly what you changed in plain language before we go
+            further.&rdquo;
+          </PromptBox>
+
+          <div className="mt-6 space-y-4">
+            <div className="border-l-4 border-teal-500 pl-4">
+              <h3 className="font-bold text-gray-900 mb-1">Then: read what it changed</h3>
+              <p className="text-sm text-gray-700">
+                Your assistant will summarize the edit and can show you a before-and-after. If
+                something looks off, just say so in plain English (“actually, make it bold too”) and
+                it will adjust.
+              </p>
+            </div>
+            <div className="border-l-4 border-teal-500 pl-4">
+              <h3 className="font-bold text-gray-900 mb-1">Then: approve it</h3>
+              <p className="text-sm text-gray-700">
+                When you&apos;re happy, tell the assistant to open it for review and approve it. On
+                GitHub this appears as a <strong>pull request</strong> — but you can think of it
+                simply as a <em>“here&apos;s the change, okay to publish?”</em> page. You read it
+                and click approve.
+              </p>
+              <PromptBox accent="emerald" label="Paste this to publish">
+                &ldquo;That looks good. Open this change for review (a pull request) with a clear
+                title, then once the automatic checks pass, go ahead and publish it. Tell me when
+                it&apos;s live.&rdquo;
+              </PromptBox>
+            </div>
+          </div>
+
+          <div className="mt-6 bg-blue-50 border-l-4 border-blue-600 p-4 rounded">
+            <p className="text-blue-900 text-sm">
+              <strong>That&apos;s the whole loop.</strong> Describe → read → approve. You did not
+              open a code editor, type a command, or learn what a “branch” is — the assistant took
+              care of all of it.
+            </p>
+          </div>
+        </section>
+
+        {/* 4. Publish */}
+        <section id="publish" className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
+          <div className="flex items-center mb-6">
+            <span className="text-4xl mr-4" aria-hidden="true">
+              🚀
+            </span>
+            <div>
+              <h2 className="text-2xl font-bold text-gray-900">
+                4. See your change and publish it
+              </h2>
+              <p className="text-gray-600">“Did it work, and when will people see it?”</p>
+            </div>
+          </div>
+
+          <div className="space-y-5">
+            <div>
+              <h3 className="font-bold text-gray-900 mb-1">Automatic checks run first</h3>
+              <p className="text-sm text-gray-700">
+                When your change is ready to publish, a few automatic checks run for a minute or two
+                to make sure the site still builds correctly. You&apos;ll see them turn into a{' '}
+                <strong className="text-green-700">green check</strong> when all is well — that
+                means your change is safe to go live.
+              </p>
+            </div>
+            <div>
+              <h3 className="font-bold text-gray-900 mb-1">
+                Want to preview before it&apos;s live?
+              </h3>
+              <p className="text-sm text-gray-700">
+                Just ask your assistant to show you what the change will look like before you
+                approve — it can describe the result or walk you through it. (Your site publishes
+                straight from approval, so the surest “preview” is to have the assistant show you
+                the before-and-after first.)
+              </p>
+            </div>
+            <div>
+              <h3 className="font-bold text-gray-900 mb-1">After you approve</h3>
+              <p className="text-sm text-gray-700">
+                Once you approve and the checks are green, your change publishes automatically and
+                your live site updates in <strong>a few minutes</strong>. Refresh your website in
+                your browser to see it. (If it doesn&apos;t show right away, wait a couple of
+                minutes and refresh again — browsers sometimes hold an old copy.)
+              </p>
+            </div>
+            <div>
+              <h3 className="font-bold text-gray-900 mb-1">If a check fails</h3>
+              <p className="text-sm text-gray-700">
+                Don&apos;t worry — nothing went live. Your assistant can read the failure and fix
+                it. Just say:
+              </p>
+              <PromptBox accent="emerald" label="Paste this if a check is red">
+                &ldquo;One of the checks failed. Please read the error, fix the problem, and let me
+                know what it was in plain language.&rdquo;
+              </PromptBox>
+            </div>
+          </div>
+        </section>
+
+        {/* 5. Cookbook link */}
+        <section id="cookbook" className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
+          <div className="flex items-center mb-6">
+            <span className="text-4xl mr-4" aria-hidden="true">
+              📒
+            </span>
+            <div>
+              <h2 className="text-2xl font-bold text-gray-900">5. Common edits cookbook</h2>
+              <p className="text-gray-600">
+                Ready-to-paste prompts for the changes you&apos;ll make most
+              </p>
+            </div>
+          </div>
+          <p className="text-gray-700 mb-4">
+            Once you&apos;ve done your first edit, the cookbook is your quick reference for everyday
+            updates — contact info, hours, photos, the donate button, and recurring posts like a
+            blog, a newsletter, or board-meeting minutes. Each one is a friendly prompt you copy,
+            fill in, and hand to your assistant.
+          </p>
+          <Link
+            href="/site-owner/common-edits"
+            className="inline-flex items-center justify-center px-6 py-3 bg-gradient-to-r from-emerald-500 to-teal-600 text-white rounded-lg font-semibold hover:opacity-90 transition-opacity"
+          >
+            Open the Common Edits Cookbook
+            <svg
+              className="w-4 h-4 ml-2"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+            </svg>
+          </Link>
+        </section>
+
+        {/* 6. Glossary */}
+        <section id="glossary" className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
+          <div className="flex items-center mb-6">
+            <span className="text-4xl mr-4" aria-hidden="true">
+              📖
+            </span>
+            <div>
+              <h2 className="text-2xl font-bold text-gray-900">6. Plain-language glossary</h2>
+              <p className="text-gray-600">
+                The few GitHub words you might see — in one friendly sentence each
+              </p>
+            </div>
+          </div>
+          <dl className="space-y-4">
+            {glossary.map((g) => (
+              <div key={g.term} className="border-l-4 border-teal-200 pl-4">
+                <dt className="font-bold text-gray-900">{g.term}</dt>
+                <dd className="text-sm text-gray-700">{g.plain}</dd>
+              </div>
+            ))}
+          </dl>
+          <div className="mt-5 bg-teal-50 border border-teal-200 rounded-lg p-4 text-sm text-teal-900">
+            Good news: your assistant handles every one of these for you. You really only need the
+            first one — <strong>repository</strong> — to get started.
+          </div>
+        </section>
+
+        {/* 7. Help */}
+        <section id="help" className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
+          <div className="flex items-center mb-6">
+            <span className="text-4xl mr-4" aria-hidden="true">
+              🤝
+            </span>
+            <h2 className="text-2xl font-bold text-gray-900">7. Good habits and getting help</h2>
+          </div>
+          <ul className="space-y-2 text-sm text-gray-700">
+            <li className="flex items-start">
+              <span className="text-teal-600 mr-2 mt-0.5">&#10003;</span>
+              <span>
+                <strong>Always read the change before approving.</strong> You&apos;re the human in
+                the loop — a quick read is all it takes.
+              </span>
+            </li>
+            <li className="flex items-start">
+              <span className="text-teal-600 mr-2 mt-0.5">&#10003;</span>
+              <span>
+                <strong>Make one change at a time</strong> when you&apos;re learning. It keeps each
+                approval simple.
+              </span>
+            </li>
+            <li className="flex items-start">
+              <span className="text-red-500 mr-2 mt-0.5">&#10005;</span>
+              <span>
+                <strong>Never paste passwords or secret keys</strong> into the chat, your site, or
+                GitHub. Your assistant never needs them in a message.
+              </span>
+            </li>
+            <li className="flex items-start">
+              <span className="text-teal-600 mr-2 mt-0.5">&#10003;</span>
+              <span>
+                <strong>Stuck?</strong> Ask your assistant to explain in simpler terms, or email
+                your FFC contact — we&apos;re happy to help.
+              </span>
+            </li>
+          </ul>
+        </section>
+
+        {/* Footer nav */}
+        <div className="bg-gradient-to-br from-gray-50 to-teal-50 rounded-xl shadow-lg p-6 md:p-8 border border-gray-200">
+          <h2 className="text-xl font-bold text-gray-900 mb-4">Where to next</h2>
+          <ul className="space-y-2 text-sm text-gray-700">
+            <li>
+              <Link
+                href="/site-owner/common-edits"
+                className="text-teal-700 underline hover:text-teal-900"
+              >
+                Common Edits Cookbook
+              </Link>
+              <span className="text-gray-500"> &mdash; prompts for everyday updates</span>
+            </li>
+            <li>
+              <Link
+                href="/developer-environment-setup/claude-desktop"
+                className="text-teal-700 underline hover:text-teal-900"
+              >
+                Claude Desktop setup guide
+              </Link>
+              <span className="text-gray-500"> &mdash; the connection details, step by step</span>
+            </li>
+            <li>
+              <Link href="/get-involved" className="text-teal-700 underline hover:text-teal-900">
+                Want to help FFC more broadly?
+              </Link>
+              <span className="text-gray-500"> &mdash; the volunteer tracks</span>
+            </li>
+          </ul>
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -44,6 +44,18 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.7,
     },
     {
+      url: `${SITE_URL}/site-owner/`,
+      lastModified: now,
+      changeFrequency: 'monthly',
+      priority: 0.9,
+    },
+    {
+      url: `${SITE_URL}/site-owner/common-edits/`,
+      lastModified: now,
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+    {
       url: `${SITE_URL}/developer-environment-setup/`,
       lastModified: now,
       changeFrequency: 'monthly',

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -207,6 +207,14 @@ export default function Footer() {
             <ul className="space-y-2 text-sm">
               <li>
                 <Link
+                  href="/site-owner"
+                  className="text-gray-400 hover:text-white transition-colors"
+                >
+                  Edit My Charity Website
+                </Link>
+              </li>
+              <li>
+                <Link
                   href="/developer-environment-setup"
                   className="text-gray-400 hover:text-white transition-colors"
                 >

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -42,6 +42,11 @@ export const resourcesDropdown: NavDropdown = {
   id: 'resources',
   items: [
     {
+      label: 'Edit My Charity Website',
+      href: '/site-owner',
+      description: 'Site owners: edit your FFC-built site in plain English — no coding.',
+    },
+    {
       label: 'Dev Environment Setup',
       href: '/developer-environment-setup',
       description: 'Start with your AI of choice — Claude, Codex, Gemini, or Copilot.',


### PR DESCRIPTION
## Summary

Builds the **Site Owner pathway** — a dedicated, jargon-free track for FFC's primary trainee: a charity founder who is not technical, has never used AI tools, and just wants to edit their **one** FFC-built static site. This is kept distinct from the holistic FFC volunteer tracks. Implements the full epic #297.

Reflects the maintainer decisions recorded on #297:
- **Repo access** = direct repository collaborator (not org membership).
- **Change flow** = describe → read → approve, publishes on green checks (branch/PR hidden).
- **Front door** = both a `/get-involved` fork *and* a dedicated page.
- **Content** = site starts single-page and adds sections on demand; recurring-post prompts handle first-time vs. ongoing; board minutes gated to member-based orgs with a public-visibility warning.

## New pages

- **`/site-owner`** — linear walkthrough: how it works, *before you start* prerequisites (free GitHub account → accept the repo collaborator invite → install Claude Desktop + Mobile → connect GitHub once), *make your first edit* (agent-driven, "read it, click approve"), *see your change and publish it* (plain-language checks / preview / go-live timing / "ask your agent to fix it"), an inline glossary (repository, branch, pull request, merge, checks), and good habits. Leads with a reassurance banner that VS Code / Antigravity / Playwright / local builds can be ignored.
- **`/site-owner/common-edits`** — cookbook of ready-to-paste prompts: quick edits (contact, hours, donate, photo/logo, text, team, social, colors) plus the three recurring posts (blog/news, newsletter, board minutes). Recurring prompts work both first-time (create the section) and ongoing (add the latest entry). Board-minutes card is gated to member-based orgs and warns that a static site is public.

## Signposting & wiring

- `/get-involved` gains a **"Which describes you?"** fork above the existing tracks.
- Dev-env hub gains a top **site-owner fork banner** so beginners skip the full agent matrix (also serves the de-jargon pass).
- Added both routes to `sitemap.ts`, a **Resources** nav dropdown entry, and a Footer **Learning Paths** link.

No new build tooling; copy/structure/signposting only. All prompts point at *their* repo and use `FreeForCharity/FFC-IN-ffcadmin.org` as the finished example (consistent with #296).

## Verification

`pnpm run format` ✓ · `pnpm run lint` ✓ (0 errors) · `pnpm run build` ✓ (37 routes, incl. `/site-owner` + `/site-owner/common-edits`) · `pnpm test` ✓ (334) · `pnpm run test:e2e` ✓ (12)

Closes #298, #299, #300, #301, #302, #303
Refs #297

---
_Generated by [Claude Code](https://claude.ai/code/session_01X4omPQW2ErDyZsMtxypuMe)_