### PR TITLE
feat: surface Site Owner and Web Developer paths in the top-of-funnel

### DIFF
--- a/src/app/get-involved/page.tsx
+++ b/src/app/get-involved/page.tsx
@@ -5,7 +5,7 @@ import NonprofitCallout from '@/components/NonprofitCallout'
 export const metadata: Metadata = {
   title: 'Get Involved',
   description:
-    'Join Free For Charity as a volunteer. Choose your path: Global Administrator or Canva Designer. Start training and make an impact.',
+    'Join Free For Charity as a volunteer. Choose your track: Web Developer, Global Administrator, or Canva Designer — or just edit your own charity’s FFC website. Start building and make an impact.',
 }
 
 const roles = [

--- a/src/app/get-involved/page.tsx
+++ b/src/app/get-involved/page.tsx
@@ -10,6 +10,30 @@ export const metadata: Metadata = {
 
 const roles = [
   {
+    title: 'Web Developer',
+    subtitle: 'Build & Maintain Charity Websites',
+    description:
+      'Build and update charity websites with your AI agent. Describe changes in plain English, open pull requests, and let CI handle the checks — no heavy local setup required.',
+    skills: [
+      'Next.js & React static sites',
+      'GitHub issue → PR → merge workflow',
+      'AI-agent development (Claude / Codex)',
+      'Automated testing & accessibility',
+    ],
+    link: '/developer-environment-setup',
+    linkLabel: 'Set Up Your Environment',
+    icon: (
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"
+      />
+    ),
+    gradient: 'from-blue-500 to-indigo-600',
+    estimate: 'flexible',
+  },
+  {
     title: 'Global Administrator',
     subtitle: 'Manage Infrastructure & Security',
     description:
@@ -63,7 +87,7 @@ const steps = [
   {
     number: '1',
     title: 'Choose Your Track',
-    description: 'Pick a role that matches your skills and interests from the two tracks below.',
+    description: 'Pick a role that matches your skills and interests from the tracks below.',
   },
   {
     number: '2',
@@ -236,14 +260,14 @@ export default function GetInvolved() {
 
       {/* Role Cards */}
       <section id="choose-your-track" className="py-16 px-4 sm:px-6 lg:px-8 bg-white scroll-mt-20">
-        <div className="max-w-5xl mx-auto">
+        <div className="max-w-6xl mx-auto">
           <h2 className="text-3xl font-bold text-gray-900 text-center mb-4">Choose Your Track</h2>
           <p className="text-lg text-gray-600 text-center mb-12 max-w-2xl mx-auto">
-            We need volunteers across two disciplines. Pick the one that fits your skills — and use
-            our Conversion Guide when you're ready to build.
+            We need volunteers across several disciplines. Pick the one that fits your skills — and
+            use our Conversion Guide when you're ready to build.
           </p>
 
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-8 max-w-4xl mx-auto">
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-8 max-w-6xl mx-auto">
             {roles.map((role) => (
               <div
                 key={role.title}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -85,6 +85,121 @@ export default function Home() {
         </div>
       </section>
 
+      {/* Persona router */}
+      <section className="py-12 px-4 sm:px-6 lg:px-8 bg-white border-b border-gray-100">
+        <div className="max-w-7xl mx-auto">
+          <div className="text-center mb-8">
+            <h2 className="text-2xl md:text-3xl font-bold text-gray-900 mb-2">
+              What brings you here?
+            </h2>
+            <p className="text-gray-600 max-w-2xl mx-auto">
+              Pick the path that fits you — each one leads straight to the right starting point.
+            </p>
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+            {/* Charity site owner */}
+            <Link
+              href="/site-owner"
+              className="group block rounded-xl border-2 border-emerald-200 bg-emerald-50 p-6 hover:border-emerald-400 hover:shadow-lg transition-all"
+            >
+              <span className="text-3xl" aria-hidden="true">
+                🌱
+              </span>
+              <h3 className="text-lg font-bold text-emerald-900 mt-3 mb-1">
+                I run a charity and want to edit my site
+              </h3>
+              <p className="text-sm text-emerald-900/80 mb-3">
+                FFC built your website — keep it up to date in plain English, no coding.
+              </p>
+              <span className="inline-flex items-center text-sm font-semibold text-emerald-700 group-hover:text-emerald-900">
+                Edit my charity&apos;s website
+                <svg
+                  className="w-4 h-4 ml-1"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M9 5l7 7-7 7"
+                  />
+                </svg>
+              </span>
+            </Link>
+
+            {/* Web developer */}
+            <Link
+              href="/developer-environment-setup"
+              className="group block rounded-xl border-2 border-blue-200 bg-blue-50 p-6 hover:border-blue-400 hover:shadow-lg transition-all"
+            >
+              <span className="text-3xl" aria-hidden="true">
+                💻
+              </span>
+              <h3 className="text-lg font-bold text-blue-900 mt-3 mb-1">
+                I&apos;m a developer who wants to build sites
+              </h3>
+              <p className="text-sm text-blue-900/80 mb-3">
+                Use your AI agent to build and maintain charity websites — start with Claude
+                Desktop.
+              </p>
+              <span className="inline-flex items-center text-sm font-semibold text-blue-700 group-hover:text-blue-900">
+                Set up your environment
+                <svg
+                  className="w-4 h-4 ml-1"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M9 5l7 7-7 7"
+                  />
+                </svg>
+              </span>
+            </Link>
+
+            {/* Broader volunteer */}
+            <Link
+              href="/get-involved"
+              className="group block rounded-xl border-2 border-teal-200 bg-teal-50 p-6 hover:border-teal-400 hover:shadow-lg transition-all"
+            >
+              <span className="text-3xl" aria-hidden="true">
+                🚀
+              </span>
+              <h3 className="text-lg font-bold text-teal-900 mt-3 mb-1">
+                I want to help charities &amp; FFC broadly
+              </h3>
+              <p className="text-sm text-teal-900/80 mb-3">
+                Volunteer across many nonprofits — admin, design, or development tracks.
+              </p>
+              <span className="inline-flex items-center text-sm font-semibold text-teal-700 group-hover:text-teal-900">
+                See the volunteer tracks
+                <svg
+                  className="w-4 h-4 ml-1"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M9 5l7 7-7 7"
+                  />
+                </svg>
+              </span>
+            </Link>
+          </div>
+        </div>
+      </section>
+
       {/* Key Features Section */}
       <section className="py-16 px-4 sm:px-6 lg:px-8 bg-gray-50">
         <div className="max-w-7xl mx-auto">

--- a/src/app/volunteer/page.tsx
+++ b/src/app/volunteer/page.tsx
@@ -77,17 +77,17 @@ const faqs = [
   {
     question: 'Do I need prior experience?',
     answer:
-      'No. Both the Global Administrator and Canva Designer tracks include full training from scratch. We provide self-paced curricula with interactive checklists.',
+      'No. The Web Developer, Global Administrator, and Canva Designer tracks all include guidance from scratch — the developer path starts with an AI agent (Claude Desktop) and no heavy local setup. We provide self-paced curricula with interactive checklists.',
   },
   {
     question: 'How much time does it take?',
     answer:
-      'Global Administrators typically contribute 8-12 hours per week. Canva Designers contribute 5-10 hours per week. Both roles are flexible and remote.',
+      'It is flexible and remote. Web Developers can contribute as little or as much as they like, an issue at a time. Global Administrators typically contribute 8-12 hours per week and Canva Designers 5-10 hours per week.',
   },
   {
     question: 'What technologies will I learn?',
     answer:
-      'Global Admins learn Microsoft 365, GitHub, Cloudflare, DNS management, and CI/CD pipelines. Canva Designers learn Canva Pro, brand design, and digital marketing materials.',
+      'Web Developers learn Next.js/React static sites and the AI-agent (Claude/Codex) GitHub workflow. Global Admins learn Microsoft 365, GitHub, Cloudflare, DNS, and CI/CD pipelines. Canva Designers learn Canva Pro, brand design, and digital marketing materials.',
   },
   {
     question: 'Is this an internship or paid position?',
@@ -97,7 +97,7 @@ const faqs = [
   {
     question: 'How do I get started?',
     answer:
-      'Visit the Get Involved page, choose your track (Global Admin or Canva Designer), and start working through the self-paced training plan.',
+      'Visit the Get Involved page, choose your track (Web Developer, Global Admin, or Canva Designer), and start working through the self-paced path. If you just want to edit your own charity’s FFC site, head to the Site Owner walkthrough instead.',
   },
 ]
 
@@ -200,7 +200,91 @@ export default function VolunteerPage() {
               organizations — from domain registration to deployment.
             </p>
           </div>
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+            <div className="bg-blue-50 border border-blue-200 rounded-xl p-6">
+              <h3 className="text-xl font-bold text-gray-900 mb-2">Web Developer Track</h3>
+              <p className="text-gray-600 mb-4">
+                Build and maintain charity websites with your AI agent. Describe changes in plain
+                English, open pull requests, and let CI run the checks — no heavy local setup
+                required.
+              </p>
+              <ul className="text-sm text-gray-700 space-y-2">
+                <li className="flex items-center">
+                  <svg
+                    className="w-4 h-4 text-blue-500 mr-2"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                    aria-hidden="true"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M5 13l4 4L19 7"
+                    />
+                  </svg>
+                  Next.js &amp; React static sites
+                </li>
+                <li className="flex items-center">
+                  <svg
+                    className="w-4 h-4 text-blue-500 mr-2"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                    aria-hidden="true"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M5 13l4 4L19 7"
+                    />
+                  </svg>
+                  GitHub issue → PR → merge workflow
+                </li>
+                <li className="flex items-center">
+                  <svg
+                    className="w-4 h-4 text-blue-500 mr-2"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                    aria-hidden="true"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M5 13l4 4L19 7"
+                    />
+                  </svg>
+                  AI-agent development (Claude / Codex)
+                </li>
+                <li className="flex items-center">
+                  <svg
+                    className="w-4 h-4 text-blue-500 mr-2"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                    aria-hidden="true"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M5 13l4 4L19 7"
+                    />
+                  </svg>
+                  Automated testing &amp; accessibility
+                </li>
+              </ul>
+              <Link
+                href="/developer-environment-setup"
+                className="mt-4 inline-block text-blue-600 font-semibold hover:text-blue-800 text-sm"
+              >
+                Set up your environment &rarr;
+              </Link>
+            </div>
             <div className="bg-teal-50 border border-teal-200 rounded-xl p-6">
               <h3 className="text-xl font-bold text-gray-900 mb-2">Global Administrator Track</h3>
               <p className="text-gray-600 mb-4">
@@ -367,6 +451,27 @@ export default function VolunteerPage() {
                 View designer path &rarr;
               </Link>
             </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Site owner callout */}
+      <section className="px-4 sm:px-6 lg:px-8 -mt-4 pb-4">
+        <div className="max-w-5xl mx-auto">
+          <div className="bg-emerald-50 border-l-4 border-emerald-500 rounded p-5 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+            <p className="text-sm text-emerald-900">
+              <span className="text-lg mr-1" aria-hidden="true">
+                🌱
+              </span>
+              <strong>Just here to edit your own charity&apos;s FFC site?</strong> You don&apos;t
+              need a volunteer track — there&apos;s a short, no-code walkthrough made for you.
+            </p>
+            <Link
+              href="/site-owner"
+              className="inline-flex items-center whitespace-nowrap text-sm font-semibold text-emerald-700 hover:text-emerald-900"
+            >
+              Edit my charity&apos;s website &rarr;
+            </Link>
           </div>
         </div>
       </section>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -141,6 +141,9 @@ export default function Navigation() {
             >
               Get Involved
             </Link>
+            <Link href="/site-owner" className={`${linkClass('/site-owner')} whitespace-nowrap`}>
+              Edit My Site
+            </Link>
 
             {/* Training Dropdown */}
             <div
@@ -296,6 +299,13 @@ export default function Navigation() {
               onClick={() => setIsMenuOpen(false)}
             >
               Get Involved
+            </Link>
+            <Link
+              href="/site-owner"
+              className={mobileLinkClass('/site-owner')}
+              onClick={() => setIsMenuOpen(false)}
+            >
+              Edit My Site
             </Link>
 
             {/* Mobile Training Accordion */}

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -42,11 +42,6 @@ export const resourcesDropdown: NavDropdown = {
   id: 'resources',
   items: [
     {
-      label: 'Edit My Charity Website',
-      href: '/site-owner',
-      description: 'Site owners: edit your FFC-built site in plain English — no coding.',
-    },
-    {
       label: 'Dev Environment Setup',
       href: '/developer-environment-setup',
       description: 'Start with your AI of choice — Claude, Codex, Gemini, or Copilot.',


### PR DESCRIPTION
## Summary

First implementation slice of #310 — surfaces the **Site Owner** and **Web Developer** paths in the top-of-funnel, which previously reflected only the legacy Global Admin + Canva tracks.

- **Home** (`/`): new **"What brings you here?"** persona router under the hero — three cards routing to `/site-owner` (charity manager), `/developer-environment-setup` (web developer), and `/get-involved` (broader volunteer).
- **Get Involved**: added a **Web Developer** track card alongside Global Admin and Canva ("Choose Your Track" is now 3 columns).
- **Volunteer**: added the Web Developer track to "What FFC Volunteers Do", a **site-owner callout**, and refreshed the FAQ (now mentions web dev + the Site Owner path instead of only the two old tracks).
- **Navigation**: promoted **"Edit My Site"** to a top-level nav item (desktop + mobile) and removed the now-redundant Resources dropdown entry.

Visual-checked locally (home router, 3-track Get Involved, volunteer callout all render correctly desktop + the cards stack on mobile).

## Verification
`pnpm run format` ✓ · `pnpm run lint` ✓ (0 errors) · `pnpm run type-check` ✓ · `pnpm run build` ✓ (42 routes) · `pnpm test` ✓ (331) · `pnpm run test:e2e` ✓ (12, incl. nav structure + dropdowns)

Closes #311, closes #312, closes #313, closes #318
Refs #310

_Remaining #310 sub-issues (#314 Site-Owner "what to expect"/FAQ, #315 good-first-issue on-ramp, #316 template guide, #317 ladder cross-link) are left as separate follow-ups._

---
_Generated by [Claude Code](https://claude.ai/code/session_01X4omPQW2ErDyZsMtxypuMe)_