### PR TITLE
feat: add modular training model + Site Owner training track

### DIFF
--- a/__tests__/training-modules.test.ts
+++ b/__tests__/training-modules.test.ts
@@ -1,0 +1,48 @@
+import { TRAINING_MODULES, LEARNING_PATHS, getModule, getPath } from '../src/data/training-modules'
+
+describe('Training modules data model', () => {
+  it('has unique module ids', () => {
+    const ids = TRAINING_MODULES.map((m) => m.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it('every module defines at least one tier with directives', () => {
+    for (const m of TRAINING_MODULES) {
+      const tiers = Object.values(m.tiers)
+      expect(tiers.length).toBeGreaterThan(0)
+      for (const t of tiers) {
+        expect(t?.objective?.length ?? 0).toBeGreaterThan(0)
+        expect((t?.directives.length ?? 0) > 0).toBe(true)
+      }
+    }
+  })
+
+  it('every directive has a unique id across the catalog', () => {
+    const ids = TRAINING_MODULES.flatMap((m) =>
+      Object.values(m.tiers).flatMap((t) => t?.directives.map((d) => d.id) ?? [])
+    )
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it('every learning-path entry references a module that defines that tier', () => {
+    for (const path of LEARNING_PATHS) {
+      for (const entry of path.entries) {
+        const mod = getModule(entry.moduleId)
+        expect(mod).toBeDefined()
+        expect(mod?.tiers[entry.tier]).toBeDefined()
+      }
+    }
+  })
+
+  it('exposes the Site Owner path composed of operator (T1) modules', () => {
+    const owner = getPath('site-owner')
+    expect(owner).toBeDefined()
+    expect(owner!.entries.length).toBeGreaterThanOrEqual(8)
+    expect(owner!.entries.every((e) => e.tier === 'T1')).toBe(true)
+    // Must-not-miss fundamentals are present.
+    const ids = owner!.entries.map((e) => e.moduleId)
+    expect(ids).toContain('domains-dns')
+    expect(ids).toContain('email-m365')
+    expect(ids).toContain('security-trust')
+  })
+})

--- a/src/app/site-owner/page.tsx
+++ b/src/app/site-owner/page.tsx
@@ -623,6 +623,18 @@ export default function SiteOwnerPage() {
           <ul className="space-y-2 text-sm text-gray-700">
             <li>
               <Link
+                href="/site-owner/training"
+                className="text-teal-700 underline hover:text-teal-900"
+              >
+                Site Owner Training
+              </Link>
+              <span className="text-gray-500">
+                {' '}
+                &mdash; everything you&apos;re responsible for (domain, email, security &amp; more)
+              </span>
+            </li>
+            <li>
+              <Link
                 href="/site-owner/common-edits"
                 className="text-teal-700 underline hover:text-teal-900"
               >

--- a/src/app/site-owner/training/page.tsx
+++ b/src/app/site-owner/training/page.tsx
@@ -1,0 +1,209 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import Breadcrumbs from '@/components/Breadcrumbs'
+import { getPath, getModule, TIER_LABELS, TIER_BLURB, type Tier } from '@/data/training-modules'
+
+export const metadata: Metadata = {
+  title: 'Site Owner Training',
+  description:
+    'Everything a charity site owner is responsible for — accounts, content, your domain & DNS, Microsoft 365 email, security, publishing, governance, and working with AI — taught at operator depth. Understand each area and handle it safely with your AI assistant; no certifications required.',
+  keywords:
+    'charity site owner training, nonprofit website responsibilities, domain management, Microsoft 365 email, website security, AI website management, Free For Charity',
+  alternates: {
+    canonical: 'https://ffcadmin.org/site-owner/training/',
+  },
+}
+
+function DirectiveLink({ url, label }: { url: string; label: string }) {
+  if (url.startsWith('/')) {
+    return (
+      <Link href={url} className="text-teal-700 underline hover:text-teal-900">
+        {label}
+      </Link>
+    )
+  }
+  return (
+    <a
+      href={url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-teal-700 underline hover:text-teal-900"
+    >
+      {label}
+    </a>
+  )
+}
+
+export default function SiteOwnerTrainingPage() {
+  const path = getPath('site-owner')
+  if (!path) return null
+
+  const modules = path.entries
+    .map((entry) => ({ entry, module: getModule(entry.moduleId) }))
+    .filter(
+      (
+        m
+      ): m is {
+        entry: (typeof path.entries)[number]
+        module: NonNullable<ReturnType<typeof getModule>>
+      } => Boolean(m.module)
+    )
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Breadcrumbs
+        items={[
+          { label: 'Home', href: '/' },
+          { label: 'Edit My Charity Website', href: '/site-owner' },
+          { label: 'Site Owner Training' },
+        ]}
+      />
+
+      {/* Hero */}
+      <div className="bg-gradient-to-r from-emerald-500 via-teal-500 to-cyan-600 text-white py-16 px-4 sm:px-6 lg:px-8">
+        <div className="max-w-5xl mx-auto">
+          <div className="flex items-center mb-4">
+            <span className="text-5xl mr-4" aria-hidden="true">
+              🎓
+            </span>
+            <div>
+              <h1 className="text-3xl md:text-4xl font-bold">Site Owner Training</h1>
+              <p className="text-teal-50 text-sm mt-1">
+                What you&apos;re responsible for — and how to handle each part with AI
+              </p>
+            </div>
+          </div>
+          <p className="text-teal-50 text-lg max-w-3xl">{path.intro}</p>
+          <div className="mt-6 inline-flex items-center gap-2 bg-white/20 px-3 py-1 rounded-full text-sm font-medium">
+            <span aria-hidden="true">🟢</span>
+            {TIER_LABELS.T1} level — no certification required
+          </div>
+        </div>
+      </div>
+
+      <main className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        {/* What "operator level" means */}
+        <div className="bg-emerald-50 border-l-4 border-emerald-500 p-5 rounded mb-8 text-sm text-emerald-900">
+          <strong>Operator level.</strong> {TIER_BLURB.T1} You don&apos;t need to become a Microsoft
+          administrator or a developer — but you shouldn&apos;t miss the fundamentals either. Each
+          area below tells you what you own and the safe way to handle it. FFC volunteers go deeper
+          (Practitioner and Administrator levels with certifications); you can too if you ever want
+          to.
+        </div>
+
+        {/* What you're responsible for — quick list */}
+        <section className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-10">
+          <h2 className="text-2xl font-bold text-gray-900 mb-4">
+            What you&apos;re responsible for
+          </h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+            {modules.map(({ entry, module }) => (
+              <a
+                key={module.id}
+                href={`#${module.id}`}
+                className="flex items-start p-2 rounded-lg hover:bg-teal-50 transition-colors group"
+              >
+                <span className="text-xl mr-3" aria-hidden="true">
+                  {module.icon}
+                </span>
+                <span className="text-sm">
+                  <span className="font-semibold text-gray-900 group-hover:text-teal-700">
+                    {module.title}
+                  </span>
+                  {entry.optional && (
+                    <span className="ml-2 text-[10px] font-bold uppercase tracking-wide bg-gray-100 text-gray-500 px-1.5 py-0.5 rounded">
+                      Optional
+                    </span>
+                  )}
+                  <span className="block text-gray-600">{module.responsibility}</span>
+                </span>
+              </a>
+            ))}
+          </div>
+        </section>
+
+        {/* Module detail sections */}
+        <div className="space-y-8">
+          {modules.map(({ entry, module }) => {
+            const tier = entry.tier as Tier
+            const content = module.tiers[tier]
+            if (!content) return null
+            return (
+              <section
+                key={module.id}
+                id={module.id}
+                className="bg-white rounded-xl shadow-lg p-6 md:p-8 scroll-mt-20"
+              >
+                <div className="flex items-center mb-3">
+                  <span className="text-4xl mr-4" aria-hidden="true">
+                    {module.icon}
+                  </span>
+                  <div>
+                    <div className="flex items-center gap-2">
+                      <h2 className="text-2xl font-bold text-gray-900">{module.title}</h2>
+                      {entry.optional && (
+                        <span className="text-[10px] font-bold uppercase tracking-wide bg-gray-100 text-gray-500 px-2 py-0.5 rounded">
+                          Optional
+                        </span>
+                      )}
+                    </div>
+                    <p className="text-gray-600 text-sm">{module.responsibility}</p>
+                  </div>
+                </div>
+                <p className="text-gray-700 mb-4">
+                  <span className="font-semibold">Your goal:</span> {content.objective}
+                </p>
+                <ul className="space-y-3">
+                  {content.directives.map((d) => (
+                    <li key={d.id} className="flex items-start">
+                      <span className="text-teal-600 mr-2 mt-0.5" aria-hidden="true">
+                        &#10003;
+                      </span>
+                      <span className="text-sm text-gray-700">
+                        {d.text}
+                        {d.link && (
+                          <>
+                            {' '}
+                            (<DirectiveLink url={d.link.url} label={d.link.label} />)
+                          </>
+                        )}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            )
+          })}
+        </div>
+
+        {/* Footer nav */}
+        <div className="mt-10 bg-gradient-to-br from-gray-50 to-teal-50 rounded-xl shadow-lg p-6 md:p-8 border border-gray-200">
+          <h2 className="text-xl font-bold text-gray-900 mb-4">Where to next</h2>
+          <ul className="space-y-2 text-sm text-gray-700">
+            <li>
+              <Link href="/site-owner" className="text-teal-700 underline hover:text-teal-900">
+                Edit Your Charity&apos;s Website
+              </Link>
+              <span className="text-gray-500"> &mdash; the hands-on walkthrough</span>
+            </li>
+            <li>
+              <Link
+                href="/site-owner/common-edits"
+                className="text-teal-700 underline hover:text-teal-900"
+              >
+                Common Edits Cookbook
+              </Link>
+              <span className="text-gray-500"> &mdash; ready-to-paste prompts</span>
+            </li>
+            <li>
+              <Link href="/training-plan" className="text-teal-700 underline hover:text-teal-900">
+                Go deeper: Global Administrator track
+              </Link>
+              <span className="text-gray-500"> &mdash; full depth + certifications</span>
+            </li>
+          </ul>
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -56,6 +56,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.8,
     },
     {
+      url: `${SITE_URL}/site-owner/training/`,
+      lastModified: now,
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+    {
       url: `${SITE_URL}/developer-environment-setup/`,
       lastModified: now,
       changeFrequency: 'monthly',

--- a/src/data/training-modules.ts
+++ b/src/data/training-modules.ts
@@ -1,0 +1,340 @@
+import type { Directive } from './training-plan-data'
+
+/**
+ * Modular training model (Epic #320).
+ *
+ * Training is organized along two axes instead of one monolithic role track:
+ *  - Responsibility-aligned **modules** (what you are accountable for), and
+ *  - Depth **tiers** for the same module:
+ *      T1 Operator (AI-driven, no cert) · T2 Practitioner · T3 Administrator (certified).
+ *
+ * Roles (Site Owner, Web Developer, Global Admin, Designer) are *compositions*
+ * of modules at a chosen tier, so one content source feeds every path.
+ */
+
+export type Tier = 'T1' | 'T2' | 'T3'
+
+export const TIER_LABELS: Record<Tier, string> = {
+  T1: 'Operator',
+  T2: 'Practitioner',
+  T3: 'Administrator',
+}
+
+export const TIER_BLURB: Record<Tier, string> = {
+  T1: 'Understand the fundamental and do it safely with your AI assistant — no certification needed.',
+  T2: 'Hands-on mechanics you can perform yourself and help others with.',
+  T3: 'Full administrator depth, owned org-wide, backed by certification.',
+}
+
+export type ModuleTier = {
+  objective: string
+  directives: Directive[]
+}
+
+export type TrainingModule = {
+  id: string
+  title: string
+  icon: string
+  /** One-line "what you own" statement. */
+  responsibility: string
+  tiers: Partial<Record<Tier, ModuleTier>>
+}
+
+export type PathEntry = {
+  moduleId: string
+  tier: Tier
+  optional?: boolean
+}
+
+export type LearningPath = {
+  id: string
+  title: string
+  persona: string
+  intro: string
+  entries: PathEntry[]
+}
+
+/**
+ * Module catalog. This first pass authors the Operator (T1) tier for the
+ * modules a charity Site Owner is responsible for. Practitioner (T2) and
+ * Administrator (T3) tiers are added by their dedicated sub-issues of #320.
+ */
+export const TRAINING_MODULES: TrainingModule[] = [
+  {
+    id: 'accounts-access',
+    title: 'Accounts & Access',
+    icon: '🔑',
+    responsibility: 'The logins that prove the website and email are yours.',
+    tiers: {
+      T1: {
+        objective: 'Hold secure accounts and the access you need — nothing more.',
+        directives: [
+          {
+            id: 'm-accounts-t1-1',
+            text: 'Create a free GitHub account and turn on two-factor authentication (2FA).',
+            link: { url: 'https://github.com/signup', label: 'github.com/signup' },
+          },
+          {
+            id: 'm-accounts-t1-2',
+            text: 'Request access to your charity’s repository and accept the invitation (you’re added as a writer).',
+            link: { url: '/site-owner', label: 'Before you start' },
+          },
+          {
+            id: 'm-accounts-t1-3',
+            text: 'Sign in to Microsoft 365 and turn on MFA; store your recovery codes somewhere safe.',
+          },
+        ],
+      },
+    },
+  },
+  {
+    id: 'website-content',
+    title: 'Website Content',
+    icon: '📝',
+    responsibility: 'Everything visitors read and see on your pages.',
+    tiers: {
+      T1: {
+        objective: 'Make everyday content changes by describing them to your AI assistant.',
+        directives: [
+          {
+            id: 'm-content-t1-1',
+            text: 'Walk through one real change end to end (text, photo, contact info).',
+            link: { url: '/site-owner', label: 'Make your first edit' },
+          },
+          {
+            id: 'm-content-t1-2',
+            text: 'Keep the cookbook handy for the changes you’ll make most often.',
+            link: { url: '/site-owner/common-edits', label: 'Common Edits Cookbook' },
+          },
+          {
+            id: 'm-content-t1-3',
+            text: 'Habit: make one change at a time and read it before approving.',
+          },
+        ],
+      },
+    },
+  },
+  {
+    id: 'domains-dns',
+    title: 'Domains & DNS',
+    icon: '🌐',
+    responsibility: 'Your web address — and the email that depends on it.',
+    tiers: {
+      T1: {
+        objective: 'Understand your domain and keep it healthy, without breaking anything.',
+        directives: [
+          {
+            id: 'm-dns-t1-1',
+            text: 'Know your domain name and that it must be renewed (usually yearly). Confirm who renews it — FFC or your charity — so it never lapses.',
+          },
+          {
+            id: 'm-dns-t1-2',
+            text: 'Understand at a high level that DNS records point your web address at your site and route your charity email. Your site is mapped through Cloudflare to GitHub Pages.',
+          },
+          {
+            id: 'm-dns-t1-3',
+            text: 'Don’t edit DNS records yourself. If something needs changing, ask your AI assistant to explain it and have an FFC admin make the change.',
+          },
+          {
+            id: 'm-dns-t1-4',
+            text: 'Red flag: if your site won’t load or email suddenly stops, suspect DNS or an expired domain and escalate to FFC right away.',
+          },
+        ],
+      },
+    },
+  },
+  {
+    id: 'email-m365',
+    title: 'Email & Microsoft 365',
+    icon: '✉️',
+    responsibility: 'Your charity’s email and Microsoft 365 account.',
+    tiers: {
+      T1: {
+        objective: 'Operate your charity email safely day to day.',
+        directives: [
+          {
+            id: 'm-email-t1-1',
+            text: 'Know that your charity email lives in Microsoft 365, and turn on MFA — this is the single most important step for protecting it.',
+          },
+          {
+            id: 'm-email-t1-2',
+            text: 'Understand the difference between a mailbox (a real account someone signs into) and an alias (another address that lands in an existing mailbox).',
+          },
+          {
+            id: 'm-email-t1-3',
+            text: 'Need a new mailbox, alias, or license? Request it from your FFC admin rather than guessing in the admin center.',
+          },
+          {
+            id: 'm-email-t1-4',
+            text: 'Stay alert to phishing: never enter your password from an email link, and never share MFA codes.',
+            link: {
+              url: 'https://learn.microsoft.com/en-us/microsoft-365/admin/setup/setup',
+              label: 'Microsoft 365 basics',
+            },
+          },
+        ],
+      },
+    },
+  },
+  {
+    id: 'security-trust',
+    title: 'Security & Trust',
+    icon: '🛡️',
+    responsibility: 'Keeping your site and accounts safe.',
+    tiers: {
+      T1: {
+        objective: 'Build safe habits and understand the automatic safety checks.',
+        directives: [
+          {
+            id: 'm-sec-t1-1',
+            text: 'Turn on MFA/2FA everywhere — GitHub and Microsoft 365.',
+          },
+          {
+            id: 'm-sec-t1-2',
+            text: 'Never paste passwords or secret keys into the chat, your website, or GitHub.',
+          },
+          {
+            id: 'm-sec-t1-3',
+            text: 'Understand the checks: a green check means a change is safe to publish; a red one means it did not go live — ask your assistant to fix it.',
+          },
+          {
+            id: 'm-sec-t1-4',
+            text: 'Security alerts (Dependabot/CodeQL) may appear on your repository. Your AI assistant can read and resolve most of them — ask it to.',
+          },
+          {
+            id: 'm-sec-t1-5',
+            text: 'If you think an account is compromised, change the password, confirm MFA, and tell FFC immediately.',
+          },
+        ],
+      },
+    },
+  },
+  {
+    id: 'publishing-deploy',
+    title: 'Publishing & Deploy',
+    icon: '🚀',
+    responsibility: 'How your changes go from “approved” to live.',
+    tiers: {
+      T1: {
+        objective: 'Approve changes confidently and know when they’re live.',
+        directives: [
+          {
+            id: 'm-pub-t1-1',
+            text: 'Learn the publish flow: review what changed, approve, and it goes live automatically.',
+            link: { url: '/site-owner', label: 'See your change and publish it' },
+          },
+          {
+            id: 'm-pub-t1-2',
+            text: 'Set expectations: checks run for a minute or two, then your live site updates within a few minutes. Refresh to see it.',
+          },
+          {
+            id: 'm-pub-t1-3',
+            text: 'If a check fails, nothing went live — ask your assistant to read the error and fix it.',
+          },
+        ],
+      },
+    },
+  },
+  {
+    id: 'governance-privacy',
+    title: 'Governance & Privacy',
+    icon: '⚖️',
+    responsibility: 'Staying compliant, accessible, and trustworthy.',
+    tiers: {
+      T1: {
+        objective: 'Keep required policies current and publish responsibly.',
+        directives: [
+          {
+            id: 'm-gov-t1-1',
+            text: 'Your site has a privacy policy and cookie notice. Keep them accurate when what you collect changes — ask your assistant to update them.',
+          },
+          {
+            id: 'm-gov-t1-2',
+            text: 'Accessibility matters: ask your assistant to add descriptive alt text to images and keep color contrast readable.',
+          },
+          {
+            id: 'm-gov-t1-3',
+            text: 'Remember your site is public. Only post board minutes or documents your board approved for public release.',
+            link: { url: '/site-owner/common-edits', label: 'Board minutes caveat' },
+          },
+        ],
+      },
+    },
+  },
+  {
+    id: 'analytics-seo',
+    title: 'Analytics & SEO',
+    icon: '📈',
+    responsibility: 'Knowing who visits and being findable in search.',
+    tiers: {
+      T1: {
+        objective: 'See your traffic and keep your basic search presence healthy.',
+        directives: [
+          {
+            id: 'm-analytics-t1-1',
+            text: 'Ask your assistant to show you how many people visit and which pages are popular.',
+          },
+          {
+            id: 'm-analytics-t1-2',
+            text: 'Basic SEO (page titles and descriptions) is handled for you — ask your assistant to review it when you add pages.',
+          },
+        ],
+      },
+    },
+  },
+  {
+    id: 'building-with-ai',
+    title: 'Building with AI',
+    icon: '🤖',
+    responsibility: 'The one skill that powers everything above.',
+    tiers: {
+      T1: {
+        objective: 'Describe what you want, review it, and approve — let the agent do the work.',
+        directives: [
+          {
+            id: 'm-ai-t1-1',
+            text: 'Describe changes in plain English; the assistant figures out the technical steps.',
+          },
+          {
+            id: 'm-ai-t1-2',
+            text: 'Always read the summary of what changed before you approve.',
+          },
+          {
+            id: 'm-ai-t1-3',
+            text: 'When you’re unsure or something looks wrong, ask the assistant to explain — or escalate to FFC.',
+            link: { url: '/site-owner', label: 'Site Owner walkthrough' },
+          },
+        ],
+      },
+    },
+  },
+]
+
+export const LEARNING_PATHS: LearningPath[] = [
+  {
+    id: 'site-owner',
+    title: 'Site Owner',
+    persona: 'You run one charity and manage its FFC-built website with AI.',
+    intro:
+      'Everything you are responsible for as a charity site owner — at operator depth. You don’t need certifications; you need to understand each area and handle it safely with your AI assistant, and know when to ask FFC for help.',
+    entries: [
+      { moduleId: 'accounts-access', tier: 'T1' },
+      { moduleId: 'building-with-ai', tier: 'T1' },
+      { moduleId: 'website-content', tier: 'T1' },
+      { moduleId: 'publishing-deploy', tier: 'T1' },
+      { moduleId: 'domains-dns', tier: 'T1' },
+      { moduleId: 'email-m365', tier: 'T1' },
+      { moduleId: 'security-trust', tier: 'T1' },
+      { moduleId: 'governance-privacy', tier: 'T1' },
+      { moduleId: 'analytics-seo', tier: 'T1', optional: true },
+    ],
+  },
+]
+
+export function getModule(id: string): TrainingModule | undefined {
+  return TRAINING_MODULES.find((m) => m.id === id)
+}
+
+export function getPath(id: string): LearningPath | undefined {
+  return LEARNING_PATHS.find((p) => p.id === id)
+}


### PR DESCRIPTION
## Summary

First implementation slice of the training restructure (#320). Organizes training as **responsibility-aligned modules** at **depth tiers** (T1 Operator / T2 Practitioner / T3 Administrator) that roles compose — instead of one monolithic certification track — and ships the **Site Owner training track**.

### What's in this PR
- **Module data model** (`src/data/training-modules.ts`) — `TrainingModule` (per-tier objective + directives) and `LearningPath` compositions. Authors the **Operator (T1)** tier for the nine modules a charity site owner owns. (#321)
- **`/site-owner/training`** — composes the Site Owner path at operator depth: *what you're responsible for* + how to handle each area safely with AI, no certifications. Linked from `/site-owner` and added to the sitemap. (#322)
- **Integrity test** — every learning-path entry resolves to a module that defines that tier; the must-not-miss modules are present.

### Directly addresses the brief
The Site Owner path now **mandatorily includes Domains & DNS and Email & Microsoft 365** (plus Accounts & Access, Website Content, Publishing & Deploy, Security & Trust, Governance & Privacy, Analytics & SEO [optional], and Building with AI) — at operator depth, so owners **don't miss the fundamentals** like domain management and Microsoft email, **without** the full MS-900 / GitHub Foundations grind. Those certs are preserved as the T3 layer for the Global Admin track (later sub-issues).

## Verification
`pnpm run format` ✓ · `pnpm run lint` ✓ (0 errors) · `pnpm run type-check` ✓ · `pnpm run build` ✓ (43 routes, incl. `/site-owner/training`) · `pnpm test` ✓ (336, +5 new) · `pnpm run test:e2e` ✓ (12) · visual-checked locally.

Closes #321, closes #322
Refs #320, #323, #324, #325, #326, #327 (their T1 tiers are authored here; T2/T3 remain in those issues)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X4omPQW2ErDyZsMtxypuMe)_