### PR TITLE
feat: onboarding follow-ups — site-owner FAQ, dev on-ramp, template guide, ladder links

### DIFF
--- a/__tests__/components/ContributorLadderPage.test.tsx
+++ b/__tests__/components/ContributorLadderPage.test.tsx
@@ -184,8 +184,8 @@ describe('Contributor Ladder Page', () => {
       // h1 for page title
       expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument()
 
-      // h2 for call to action section
-      expect(screen.getByRole('heading', { level: 2 })).toBeInTheDocument()
+      // h2 for section headings (call to action, "is the ladder for you?", etc.)
+      expect(screen.getAllByRole('heading', { level: 2 }).length).toBeGreaterThanOrEqual(1)
 
       // h3 for each level (× 2 for mobile and desktop)
       const h3Headings = screen.getAllByRole('heading', { level: 3 })

--- a/src/app/contributor-ladder/page.tsx
+++ b/src/app/contributor-ladder/page.tsx
@@ -302,17 +302,17 @@ export default function ContributorLadder() {
       {/* Who the ladder is for */}
       <section className="px-4 sm:px-6 lg:px-8 -mt-8 relative z-10">
         <div className="max-w-5xl mx-auto bg-white rounded-xl shadow-lg border border-gray-200 p-6">
-          <h2 className="text-lg font-bold text-gray-900 mb-2">Is the ladder for you?</h2>
+          <h2 className="text-lg font-bold text-gray-900 mb-2">Where do you fit?</h2>
           <p className="text-sm text-gray-700 mb-3">
-            The ladder is for <strong>volunteers who want to grow with FFC</strong> across many
-            charities. It enters at <strong>Contributor</strong> — web developers begin there by
-            setting up their environment. Two groups don&apos;t need the ladder:
+            The ladder is for <strong>volunteers growing with FFC</strong> across many charities,
+            starting at <strong>Contributor</strong>. Not sure where to begin? Start here:
           </p>
           <ul className="space-y-1.5 text-sm text-gray-700">
             <li className="flex items-start">
               <span className="text-emerald-600 mr-2 mt-0.5">&#8226;</span>
               <span>
-                <strong>Charity site owners</strong> editing their own FFC-built site — start with{' '}
+                <strong>Just editing your own charity&apos;s FFC site?</strong> You don&apos;t need
+                the ladder — start with{' '}
                 <Link href="/site-owner" className="text-blue-600 underline hover:text-blue-800">
                   Edit Your Charity&apos;s Website
                 </Link>
@@ -322,14 +322,14 @@ export default function ContributorLadder() {
             <li className="flex items-start">
               <span className="text-blue-600 mr-2 mt-0.5">&#8226;</span>
               <span>
-                <strong>Developers getting started</strong> — set up your agent on{' '}
+                <strong>New to development?</strong> Set up your agent on{' '}
                 <Link
                   href="/developer-environment-setup"
                   className="text-blue-600 underline hover:text-blue-800"
                 >
                   Developer Environment Setup
                 </Link>
-                , then climb the ladder as you contribute.
+                , then you&apos;ll enter the ladder at Contributor as you start shipping changes.
               </span>
             </li>
           </ul>

--- a/src/app/contributor-ladder/page.tsx
+++ b/src/app/contributor-ladder/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import type { ReactElement } from 'react'
+import Link from 'next/link'
 import Breadcrumbs from '@/components/Breadcrumbs'
 
 export const metadata: Metadata = {
@@ -295,6 +296,43 @@ export default function ContributorLadder() {
               </div>
             </a>
           </div>
+        </div>
+      </section>
+
+      {/* Who the ladder is for */}
+      <section className="px-4 sm:px-6 lg:px-8 -mt-8 relative z-10">
+        <div className="max-w-5xl mx-auto bg-white rounded-xl shadow-lg border border-gray-200 p-6">
+          <h2 className="text-lg font-bold text-gray-900 mb-2">Is the ladder for you?</h2>
+          <p className="text-sm text-gray-700 mb-3">
+            The ladder is for <strong>volunteers who want to grow with FFC</strong> across many
+            charities. It enters at <strong>Contributor</strong> — web developers begin there by
+            setting up their environment. Two groups don&apos;t need the ladder:
+          </p>
+          <ul className="space-y-1.5 text-sm text-gray-700">
+            <li className="flex items-start">
+              <span className="text-emerald-600 mr-2 mt-0.5">&#8226;</span>
+              <span>
+                <strong>Charity site owners</strong> editing their own FFC-built site — start with{' '}
+                <Link href="/site-owner" className="text-blue-600 underline hover:text-blue-800">
+                  Edit Your Charity&apos;s Website
+                </Link>
+                .
+              </span>
+            </li>
+            <li className="flex items-start">
+              <span className="text-blue-600 mr-2 mt-0.5">&#8226;</span>
+              <span>
+                <strong>Developers getting started</strong> — set up your agent on{' '}
+                <Link
+                  href="/developer-environment-setup"
+                  className="text-blue-600 underline hover:text-blue-800"
+                >
+                  Developer Environment Setup
+                </Link>
+                , then climb the ladder as you contribute.
+              </span>
+            </li>
+          </ul>
         </div>
       </section>
 

--- a/src/app/developer-environment-setup/page.tsx
+++ b/src/app/developer-environment-setup/page.tsx
@@ -688,6 +688,26 @@ export default function DeveloperEnvironmentSetupPage() {
               automatically.
             </p>
           </div>
+
+          <div className="mt-6 bg-blue-50 border-l-4 border-blue-600 p-4 rounded">
+            <p className="text-blue-900 text-sm mb-2">
+              <strong>Find your first task.</strong> New here? Pick something small and well-scoped
+              to start. Browse open issues labeled{' '}
+              <a
+                href="https://github.com/search?q=org%3AFreeForCharity+is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22&type=issues"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-800 underline font-medium"
+              >
+                good first issue
+              </a>{' '}
+              across FFC, or ask your agent:
+            </p>
+            <p className="font-mono text-xs text-blue-900 bg-white/60 rounded p-3">
+              &ldquo;List the open issues labeled &lsquo;good first issue&rsquo; in the
+              FreeForCharity organization and help me pick one I can finish, then start it.&rdquo;
+            </p>
+          </div>
         </section>
 
         {/* Related */}

--- a/src/app/guides/build-charity-site-from-template/page.tsx
+++ b/src/app/guides/build-charity-site-from-template/page.tsx
@@ -1,0 +1,231 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import Breadcrumbs from '@/components/Breadcrumbs'
+import PromptBox from '@/components/PromptBox'
+
+export const metadata: Metadata = {
+  title: 'Build a Charity Site from the Template',
+  description:
+    'Stand up a new charity website from the FreeForCharity single-page template using your AI agent — create the repository, customize the content, run the checks, open a pull request, and deploy. Prompt-driven, no stale step-by-step.',
+  keywords:
+    'build charity website, FFC template, FFC_Single_Page_Template, Next.js charity site, GitHub Pages, AI agent, Free For Charity guide',
+  alternates: {
+    canonical: 'https://ffcadmin.org/guides/build-charity-site-from-template/',
+  },
+}
+
+const tocItems = [
+  { id: 'before', label: '1. Before you start' },
+  { id: 'create', label: '2. Create the repo from the template' },
+  { id: 'point', label: '3. Point your AI agent at it' },
+  { id: 'customize', label: '4. Customize the content' },
+  { id: 'checks', label: '5. Run the checks' },
+  { id: 'ship', label: '6. Open a PR and deploy' },
+  { id: 'next', label: '7. Hand off to the site owner' },
+]
+
+export default function BuildFromTemplateGuide() {
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Breadcrumbs
+        items={[
+          { label: 'Home', href: '/' },
+          { label: 'Guides', href: '/guides' },
+          { label: 'Build from Template' },
+        ]}
+      />
+
+      {/* Hero */}
+      <div className="bg-gradient-to-r from-blue-600 to-indigo-600 text-white py-16 px-4 sm:px-6 lg:px-8">
+        <div className="max-w-4xl mx-auto">
+          <div className="flex items-center mb-4">
+            <span className="text-5xl mr-4" aria-hidden="true">
+              🧩
+            </span>
+            <div>
+              <h1 className="text-3xl md:text-4xl font-bold">
+                Build a Charity Site from the Template
+              </h1>
+              <p className="text-blue-100 text-sm mt-1">
+                From empty repo to deployed site — driven by your AI agent
+              </p>
+            </div>
+          </div>
+          <p className="text-blue-50 text-lg max-w-3xl">
+            This guide takes a developer from the{' '}
+            <strong>FreeForCharity/FFC_Single_Page_Template</strong> to a live, deployed charity
+            site. It&apos;s prompt-driven: you hand each step to your AI agent and review the
+            result, using <strong>FreeForCharity/FFC-IN-ffcadmin.org</strong> as a finished example
+            to match.
+          </p>
+        </div>
+      </div>
+
+      <main className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        {/* TOC */}
+        <div className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-10">
+          <h2 className="text-2xl font-bold text-gray-900 mb-6">On this page</h2>
+          <ul className="grid grid-cols-1 md:grid-cols-2 gap-2 text-sm">
+            {tocItems.map((t) => (
+              <li key={t.id}>
+                <a href={`#${t.id}`} className="text-blue-700 underline hover:text-blue-900">
+                  {t.label}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        {/* 1 */}
+        <section id="before" className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8 scroll-mt-20">
+          <h2 className="text-2xl font-bold text-gray-900 mb-4">1. Before you start</h2>
+          <ul className="space-y-2 text-sm text-gray-700 list-disc ml-5">
+            <li>
+              A working AI agent connected to GitHub — set this up first on the{' '}
+              <Link
+                href="/developer-environment-setup"
+                className="text-blue-700 underline hover:text-blue-900"
+              >
+                Developer Environment Setup
+              </Link>{' '}
+              hub (newcomers: start with{' '}
+              <Link
+                href="/developer-environment-setup/claude-desktop"
+                className="text-blue-700 underline hover:text-blue-900"
+              >
+                Claude Desktop
+              </Link>
+              ).
+            </li>
+            <li>Write access to the FreeForCharity organization (a maintainer can grant it).</li>
+            <li>The charity&apos;s basic content on hand: name, mission, contact info, logo.</li>
+          </ul>
+        </section>
+
+        {/* 2 */}
+        <section id="create" className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8 scroll-mt-20">
+          <h2 className="text-2xl font-bold text-gray-900 mb-4">
+            2. Create the repo from the template
+          </h2>
+          <p className="text-gray-700 mb-4">
+            The template is a GitHub <strong>template repository</strong>, so a new site starts as a
+            clean copy with its own history.
+          </p>
+          <PromptBox accent="blue" label="Paste this into your AI agent">
+            &ldquo;Create a new repository in the FreeForCharity organization from the template{' '}
+            <strong>FreeForCharity/FFC_Single_Page_Template</strong>, named{' '}
+            <strong>&lt;charity-slug&gt;</strong>. Then confirm you can see it and summarize what
+            the template contains.&rdquo;
+          </PromptBox>
+        </section>
+
+        {/* 3 */}
+        <section id="point" className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8 scroll-mt-20">
+          <h2 className="text-2xl font-bold text-gray-900 mb-4">3. Point your AI agent at it</h2>
+          <p className="text-gray-700 mb-4">
+            Have the agent read the repo&apos;s conventions before changing anything.
+          </p>
+          <PromptBox accent="blue" label="Paste this into your AI agent">
+            &ldquo;Read the <code>AGENTS.md</code> in <strong>&lt;charity-slug&gt;</strong> and
+            follow its conventions. Use <strong>FreeForCharity/FFC-IN-ffcadmin.org</strong> as a
+            reference for how a finished FFC site is structured. Don&apos;t change anything yet —
+            tell me your plan first.&rdquo;
+          </PromptBox>
+        </section>
+
+        {/* 4 */}
+        <section
+          id="customize"
+          className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8 scroll-mt-20"
+        >
+          <h2 className="text-2xl font-bold text-gray-900 mb-4">4. Customize the content</h2>
+          <p className="text-gray-700 mb-4">
+            Work in small, reviewable changes on a branch — name, mission, sections, branding.
+          </p>
+          <PromptBox accent="blue" label="Paste this into your AI agent">
+            &ldquo;On a new branch, customize <strong>&lt;charity-slug&gt;</strong> for{' '}
+            <strong>&lt;Charity Name&gt;</strong>: set the site title and mission to
+            &lsquo;&lt;mission&gt;&rsquo;, update contact details to &lt;details&gt;, and swap in
+            the logo I&apos;ll provide. Use <code>assetPath()</code> for images, keep it accessible
+            (alt text, contrast), and show me what changed before opening anything.&rdquo;
+          </PromptBox>
+        </section>
+
+        {/* 5 */}
+        <section id="checks" className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8 scroll-mt-20">
+          <h2 className="text-2xl font-bold text-gray-900 mb-4">5. Run the checks</h2>
+          <p className="text-gray-700 mb-4">
+            Run the project&apos;s checks in the order its <code>AGENTS.md</code> documents, rather
+            than a hard-coded list that can go stale.
+          </p>
+          <PromptBox accent="blue" label="Paste this into your AI agent">
+            &ldquo;Run the formatting, lint, build, and test checks in the order described in{' '}
+            <code>AGENTS.md</code> for this repo, and fix anything that fails until they all
+            pass.&rdquo;
+          </PromptBox>
+        </section>
+
+        {/* 6 */}
+        <section id="ship" className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8 scroll-mt-20">
+          <h2 className="text-2xl font-bold text-gray-900 mb-4">6. Open a PR and deploy</h2>
+          <p className="text-gray-700 mb-4">
+            Open a pull request and let CI validate it; once it merges, GitHub Pages publishes the
+            site.
+          </p>
+          <PromptBox accent="blue" label="Paste this into your AI agent">
+            &ldquo;Open a pull request with a Conventional Commit title, watch the CI checks, and
+            fix any failures. Once everything is green and it merges, confirm the site deployed and
+            give me the live URL.&rdquo;
+          </PromptBox>
+          <div className="mt-4 bg-blue-50 border-l-4 border-blue-600 p-4 rounded text-sm text-blue-900">
+            Custom domain &amp; DNS (Cloudflare → GitHub Pages) is a Global Admin task — see the{' '}
+            <Link href="/training" className="underline font-medium">
+              Domains &amp; DNS module
+            </Link>
+            .
+          </div>
+        </section>
+
+        {/* 7 */}
+        <section id="next" className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8 scroll-mt-20">
+          <h2 className="text-2xl font-bold text-gray-900 mb-4">7. Hand off to the site owner</h2>
+          <p className="text-gray-700">
+            Once the site is live, the charity&apos;s owner maintains it themselves. Point them to{' '}
+            <Link href="/site-owner" className="text-blue-700 underline hover:text-blue-900">
+              Edit Your Charity&apos;s Website
+            </Link>{' '}
+            and add them as a writer on the repository so they can make everyday changes with AI.
+          </p>
+        </section>
+
+        {/* Footer nav */}
+        <div className="bg-gradient-to-br from-gray-50 to-blue-50 rounded-xl shadow-lg p-6 md:p-8 border border-gray-200">
+          <h2 className="text-xl font-bold text-gray-900 mb-4">Related</h2>
+          <ul className="space-y-2 text-sm text-gray-700">
+            <li>
+              <Link href="/guides" className="text-blue-700 underline hover:text-blue-900">
+                &larr; All Guides
+              </Link>
+            </li>
+            <li>
+              <Link
+                href="/training/web-developer"
+                className="text-blue-700 underline hover:text-blue-900"
+              >
+                Web Developer training track
+              </Link>
+            </li>
+            <li>
+              <Link
+                href="/developer-environment-setup"
+                className="text-blue-700 underline hover:text-blue-900"
+              >
+                Developer Environment Setup
+              </Link>
+            </li>
+          </ul>
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/src/app/guides/page.tsx
+++ b/src/app/guides/page.tsx
@@ -25,6 +25,22 @@ const guideDisplayProps: Record<
     icon: ReactNode
   }
 > = {
+  '/guides/build-charity-site-from-template': {
+    longDescription:
+      'Stand up a new charity website from the FFC single-page template with your AI agent — create the repo, customize the content, run the checks, open a pull request, deploy, and hand it off to the site owner.',
+    version: 'v1',
+    date: 'June 2026',
+    tags: ['Template', 'Next.js', 'AI Agent', 'GitHub Pages'],
+    gradient: 'from-blue-500 to-indigo-600',
+    icon: (
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M11 4a2 2 0 114 0v1a1 1 0 001 1h3a1 1 0 011 1v3a1 1 0 01-1 1h-1a2 2 0 100 4h1a1 1 0 011 1v3a1 1 0 01-1 1h-3a1 1 0 01-1-1v-1a2 2 0 10-4 0v1a1 1 0 01-1 1H7a1 1 0 01-1-1v-3a1 1 0 00-1-1H4a2 2 0 110-4h1a1 1 0 001-1V7a1 1 0 011-1h3a1 1 0 001-1V4z"
+      />
+    ),
+  },
   '/guides/wordpress-to-nextjs-guide': {
     longDescription:
       'Step-by-step guide for FFC volunteers to convert WordPress/Divi charity sites to Next.js static sites on GitHub Pages. Covers content audit, export, CI/CD, testing, and DNS cutover.',

--- a/src/app/site-owner/page.tsx
+++ b/src/app/site-owner/page.tsx
@@ -138,6 +138,61 @@ export default function SiteOwnerPage() {
           </p>
         </div>
 
+        {/* What to expect */}
+        <section className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
+          <div className="flex items-center mb-4">
+            <span className="text-4xl mr-4" aria-hidden="true">
+              🤝
+            </span>
+            <div>
+              <h2 className="text-2xl font-bold text-gray-900">What to expect</h2>
+              <p className="text-gray-600">How this works between you and FFC</p>
+            </div>
+          </div>
+          <ul className="space-y-2 text-sm text-gray-700">
+            <li className="flex items-start">
+              <span className="text-teal-600 mr-2 mt-0.5">&#10003;</span>
+              <span>
+                <strong>FFC builds and hosts your site for free.</strong> You keep the content
+                current — that&apos;s your part.
+              </span>
+            </li>
+            <li className="flex items-start">
+              <span className="text-teal-600 mr-2 mt-0.5">&#10003;</span>
+              <span>
+                <strong>You&apos;re always the approver.</strong> Nothing reaches your live site
+                until you read the change and say yes.
+              </span>
+            </li>
+            <li className="flex items-start">
+              <span className="text-teal-600 mr-2 mt-0.5">&#10003;</span>
+              <span>
+                <strong>After you request access</strong> (you&apos;ll text FFC in step&nbsp;2
+                below), expect your repository invitation within a day or so.
+              </span>
+            </li>
+            <li className="flex items-start">
+              <span className="text-teal-600 mr-2 mt-0.5">&#10003;</span>
+              <span>
+                <strong>Want to see what a finished site looks like?</strong> This very site (
+                <a
+                  href="https://ffcadmin.org"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-teal-700 underline hover:text-teal-900"
+                >
+                  ffcadmin.org
+                </a>
+                ) is an example built the same way, and you can browse more on the{' '}
+                <Link href="/sites-list" className="text-teal-700 underline hover:text-teal-900">
+                  Sites List
+                </Link>
+                .
+              </span>
+            </li>
+          </ul>
+        </section>
+
         {/* TL;DR */}
         <section className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
           <div className="flex items-center mb-6">
@@ -610,11 +665,56 @@ export default function SiteOwnerPage() {
             <li className="flex items-start">
               <span className="text-teal-600 mr-2 mt-0.5">&#10003;</span>
               <span>
-                <strong>Stuck?</strong> Ask your assistant to explain in simpler terms, or email
-                your FFC contact — we&apos;re happy to help.
+                <strong>Stuck?</strong> Ask your assistant to explain in simpler terms, or text your
+                FFC contact (Clarke Moyer, (520)&nbsp;222-8104) — we&apos;re happy to help.
               </span>
             </li>
           </ul>
+
+          <h3 className="text-lg font-bold text-gray-900 mt-8 mb-3">Quick answers</h3>
+          <dl className="space-y-4">
+            <div className="border-l-4 border-teal-200 pl-4">
+              <dt className="font-bold text-gray-900 text-sm">I think I broke something — help!</dt>
+              <dd className="text-sm text-gray-700">
+                Don&apos;t worry: nothing is live until you approve it, and every past version is
+                saved. Ask your assistant to &ldquo;undo the last change&rdquo; or revert to how the
+                site looked before, then tell FFC if you&apos;re unsure.
+              </dd>
+            </div>
+            <div className="border-l-4 border-teal-200 pl-4">
+              <dt className="font-bold text-gray-900 text-sm">
+                How do I get a photo to my assistant?
+              </dt>
+              <dd className="text-sm text-gray-700">
+                Save the photo on your computer or phone, then attach or upload it in the chat with
+                your assistant and say where it should go on the site.
+              </dd>
+            </div>
+            <div className="border-l-4 border-teal-200 pl-4">
+              <dt className="font-bold text-gray-900 text-sm">
+                The assistant did something I didn&apos;t want.
+              </dt>
+              <dd className="text-sm text-gray-700">
+                Just tell it in plain English — &ldquo;that&apos;s not what I meant, please change
+                it back&rdquo; — and review again. You only approve when it&apos;s right.
+              </dd>
+            </div>
+            <div className="border-l-4 border-teal-200 pl-4">
+              <dt className="font-bold text-gray-900 text-sm">Who do I contact at FFC?</dt>
+              <dd className="text-sm text-gray-700">
+                Text Clarke Moyer at (520)&nbsp;222-8104 or message{' '}
+                <a
+                  href="https://github.com/clarkemoyer"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-teal-700 underline hover:text-teal-900"
+                >
+                  github.com/clarkemoyer
+                </a>
+                .
+              </dd>
+            </div>
+          </dl>
         </section>
 
         {/* Footer nav */}

--- a/src/app/site-owner/page.tsx
+++ b/src/app/site-owner/page.tsx
@@ -666,7 +666,11 @@ export default function SiteOwnerPage() {
               <span className="text-teal-600 mr-2 mt-0.5">&#10003;</span>
               <span>
                 <strong>Stuck?</strong> Ask your assistant to explain in simpler terms, or text your
-                FFC contact (Clarke Moyer, (520)&nbsp;222-8104) — we&apos;re happy to help.
+                FFC contact (Clarke Moyer,{' '}
+                <a href="tel:520-222-8104" className="text-teal-700 underline hover:text-teal-900">
+                  (520)&nbsp;222-8104
+                </a>
+                ) — we&apos;re happy to help.
               </span>
             </li>
           </ul>
@@ -702,7 +706,11 @@ export default function SiteOwnerPage() {
             <div className="border-l-4 border-teal-200 pl-4">
               <dt className="font-bold text-gray-900 text-sm">Who do I contact at FFC?</dt>
               <dd className="text-sm text-gray-700">
-                Text Clarke Moyer at (520)&nbsp;222-8104 or message{' '}
+                Text Clarke Moyer at{' '}
+                <a href="tel:520-222-8104" className="text-teal-700 underline hover:text-teal-900">
+                  (520)&nbsp;222-8104
+                </a>{' '}
+                or message{' '}
                 <a
                   href="https://github.com/clarkemoyer"
                   target="_blank"

--- a/src/data/guides.ts
+++ b/src/data/guides.ts
@@ -12,6 +12,13 @@ export interface Guide {
 
 export const guides: Guide[] = [
   {
+    title: 'Build a Charity Site from the Template',
+    shortTitle: 'Build from Template',
+    description:
+      'Stand up a new charity website from the FFC single-page template with your AI agent — from repo to deployed site.',
+    href: '/guides/build-charity-site-from-template',
+  },
+  {
     title: 'WordPress to Next.js Conversion Guide',
     shortTitle: 'WordPress to Next.js',
     description: 'Convert WordPress/Divi charity sites to Next.js static sites on GitHub Pages.',


### PR DESCRIPTION
## Summary
Completes the remaining #310 onboarding follow-ups.

- **Site Owner (#314):** a "What to expect" section (FFC builds/hosts for free, you're always the approver, invite turnaround, link to a live example + Sites List) and a "Quick answers" FAQ (I broke something, getting a photo to the assistant, the assistant did the wrong thing, who to contact).
- **Dev-env hub (#315):** a "Find your first task" on-ramp pointing to the org **good first issue** label search, plus a ready-to-paste agent prompt.
- **Guides (#316):** new **"Build a Charity Site from the Template"** guide (repo → customize → checks → PR → deploy → hand off), prompt-driven, wired into the guides data + landing page.
- **Contributor Ladder (#317):** an "Is the ladder for you?" card cross-linking the Site Owner and Web Developer entry points.

## Verification
`format` ✓ · `lint` ✓ (0 errors) · `type-check` ✓ · `build` ✓ (46 routes, incl. the new guide) · `test` ✓ (336) · `e2e` ✓ (12) · visual-checked the guide, ladder, and site-owner pages locally.

Closes #314, closes #315, closes #316, closes #317
Refs #310

---
_Generated by [Claude Code](https://claude.ai/code/session_01X4omPQW2ErDyZsMtxypuMe)_