### PR TITLE
feat: legacy WP-admin section polish (Reference category, elevated cards)

### DIFF
--- a/__tests__/legacy-wordpress-administration.test.ts
+++ b/__tests__/legacy-wordpress-administration.test.ts
@@ -47,10 +47,11 @@ describe('Legacy WordPress Administration data', () => {
     }
   })
 
-  test('category counts match the documented structure (5 / 3 / 4)', () => {
+  test('category counts match the documented structure (5 / 3 / 3 / 1)', () => {
     expect(getLegacyWpAdminPagesByCategory('wordpress-operations')).toHaveLength(5)
     expect(getLegacyWpAdminPagesByCategory('charity-onboarding')).toHaveLength(3)
-    expect(getLegacyWpAdminPagesByCategory('volunteer-programs')).toHaveLength(4)
+    expect(getLegacyWpAdminPagesByCategory('volunteer-programs')).toHaveLength(3)
+    expect(getLegacyWpAdminPagesByCategory('reference')).toHaveLength(1)
   })
 
   test('getLegacyWpAdminHref returns the canonical path shape', () => {

--- a/src/app/legacy-wordpress-administration/page.tsx
+++ b/src/app/legacy-wordpress-administration/page.tsx
@@ -24,7 +24,8 @@ export default function LegacyWordPressAdministrationHubPage() {
         items={[{ label: 'Home', href: '/' }, { label: 'Legacy WordPress Administration' }]}
       />
 
-      {/* Hero */}
+      {/* Hero — intentional slate gradient: signals this is an archival/legacy
+          section, deliberately distinct from the FFC-branded (teal/blue) pages (#264). */}
       <header className="bg-gradient-to-r from-slate-700 to-slate-900 text-white py-16 px-4 sm:px-6 lg:px-8">
         <div className="max-w-5xl mx-auto">
           <p className="text-xs uppercase tracking-wider text-slate-300 mb-3">

--- a/src/components/legacy-wordpress-administration/CategoryGrid.tsx
+++ b/src/components/legacy-wordpress-administration/CategoryGrid.tsx
@@ -16,19 +16,33 @@ export default function CategoryGrid() {
         const pages = getLegacyWpAdminPagesByCategory(category.id)
         return (
           <section key={category.id} id={category.id}>
-            <div className="mb-4">
-              <h2 className="text-2xl font-bold text-gray-900">{category.label}</h2>
-              <p className="text-gray-600 text-sm mt-1">{category.description}</p>
+            <div className="mb-4 flex items-start gap-3">
+              <span
+                className={`flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-xl bg-gradient-to-br ${category.accent} text-2xl shadow-sm`}
+                aria-hidden="true"
+              >
+                {category.icon}
+              </span>
+              <div>
+                <h2 className="text-2xl font-bold text-gray-900">{category.label}</h2>
+                <p className="text-gray-600 text-sm mt-1">{category.description}</p>
+              </div>
             </div>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
               {pages.map((page) => (
                 <Link
                   key={page.slug}
                   href={getLegacyWpAdminHref(page.slug)}
-                  className="block bg-white rounded-lg border border-gray-200 p-5 hover:border-blue-400 hover:shadow-md transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
+                  className="group block overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm transition-all hover:-translate-y-0.5 hover:border-gray-300 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
                 >
-                  <h3 className="text-base font-semibold text-gray-900 mb-2">{page.title}</h3>
-                  <p className="text-sm text-gray-600">{page.summary}</p>
+                  <span
+                    className={`block h-1.5 bg-gradient-to-r ${category.accent}`}
+                    aria-hidden="true"
+                  />
+                  <div className="p-5">
+                    <h3 className="text-base font-semibold text-gray-900 mb-2">{page.title}</h3>
+                    <p className="text-sm text-gray-600">{page.summary}</p>
+                  </div>
                 </Link>
               ))}
             </div>

--- a/src/data/legacy-wordpress-administration.ts
+++ b/src/data/legacy-wordpress-administration.ts
@@ -32,11 +32,16 @@ export type LegacyWpAdminCategoryId =
   | 'wordpress-operations'
   | 'charity-onboarding'
   | 'volunteer-programs'
+  | 'reference'
 
 export interface LegacyWpAdminCategory {
   id: LegacyWpAdminCategoryId
   label: string
   description: string
+  /** Emoji icon shown in the hub category header. */
+  icon: string
+  /** Tailwind gradient classes for the category accent (matches the /guides card style). */
+  accent: string
 }
 
 export const LEGACY_WP_ADMIN_CATEGORIES: LegacyWpAdminCategory[] = [
@@ -44,16 +49,30 @@ export const LEGACY_WP_ADMIN_CATEGORIES: LegacyWpAdminCategory[] = [
     id: 'wordpress-operations',
     label: 'WordPress Operations',
     description: 'Hosting, domains, cPanel, and the layered WordPress stack FFC operates.',
+    icon: '🛠️',
+    accent: 'from-blue-500 to-indigo-600',
   },
   {
     id: 'charity-onboarding',
     label: 'Charity Onboarding',
     description: 'Validation, GuideStar maintenance, and the service-delivery lifecycle.',
+    icon: '🤝',
+    accent: 'from-teal-500 to-emerald-600',
   },
   {
     id: 'volunteer-programs',
     label: 'Volunteer Programs',
-    description: 'Training programs, web-developer paths, tools, and proving-ground competencies.',
+    description: 'Training programs, web-developer paths, and proving-ground competencies.',
+    icon: '🎓',
+    accent: 'from-violet-500 to-purple-600',
+  },
+  {
+    id: 'reference',
+    label: 'Reference',
+    description:
+      'Cross-cutting tooling and reference material. Note: validation, volunteer-management, and financial tools (e.g. LastPass) also function as charity onboarding steps.',
+    icon: '📚',
+    accent: 'from-slate-500 to-slate-700',
   },
 ]
 
@@ -191,8 +210,8 @@ export const LEGACY_WP_ADMIN_PAGES: LegacyWpAdminPage[] = [
     title: "Free For Charity's Tools for Success",
     shortLabel: 'Tools for Success',
     summary:
-      'The full toolset (productivity, design, communication, finance) FFC issues to partner charities and volunteers.',
-    category: 'volunteer-programs',
+      'The full toolset (productivity, design, communication, finance) FFC issues to partner charities and volunteers — also a core part of charity onboarding.',
+    category: 'reference',
     publicSourceUrl: 'https://freeforcharity.org/free-for-charitys-tools-for-success/',
   },
   {


### PR DESCRIPTION
Legacy WordPress-admin section polish (decided in #310 backlog review).

- **#258** — New **Reference** category; `wordpress-tools-for-success` moved into it. Category description notes that validation/volunteer-management/financial tools (e.g. LastPass) also serve as charity-onboarding steps.
- **#267** — Elevated the hub `CategoryGrid`: a gradient icon per category header + a per-category accent bar on each card, matching the `/guides` card richness.
- **#264** — Kept the slate hero gradient (intentional archival look) + added a code comment documenting the choice.
- Updated the category-count test to **5 / 3 / 3 / 1**.

`format` ✓ · `lint` ✓ (0 errors) · `build` ✓ · `test` ✓ (336).

Closes #258, closes #267, closes #264

---
_Generated by [Claude Code](https://claude.ai/code/session_01X4omPQW2ErDyZsMtxypuMe)_