### PR TITLE
feat: blue sister-site banner + cookie-policy storage note + finalize preview docs

### DIFF
--- a/src/app/cookie-policy/page.tsx
+++ b/src/app/cookie-policy/page.tsx
@@ -70,15 +70,17 @@ export default function CookiePolicy() {
                     3.1 Necessary Cookies (Always Active)
                   </h3>
                   <p className="mb-4">
-                    These cookies are essential for the website to function properly. They enable
-                    basic features like storing your cookie consent preferences. These cookies do
-                    not store any personally identifiable information and cannot be disabled.
+                    These cookies (and equivalent browser storage) are essential for the website to
+                    function properly. They enable basic features like storing your cookie consent
+                    preferences and remembering interface choices. They do not store any personally
+                    identifiable information and cannot be disabled.
                   </p>
                   <div className="bg-gray-50 p-4 rounded-lg">
                     <table className="w-full text-sm">
                       <thead>
                         <tr className="border-b">
-                          <th className="text-left py-2 pr-4">Cookie Name</th>
+                          <th className="text-left py-2 pr-4">Name</th>
+                          <th className="text-left py-2 pr-4">Type</th>
                           <th className="text-left py-2 pr-4">Purpose</th>
                           <th className="text-left py-2">Duration</th>
                         </tr>
@@ -86,8 +88,21 @@ export default function CookiePolicy() {
                       <tbody>
                         <tr className="border-b">
                           <td className="py-2 pr-4 font-mono">cookie-consent</td>
+                          <td className="py-2 pr-4">Cookie</td>
                           <td className="py-2 pr-4">Stores your cookie preferences</td>
                           <td className="py-2">12 months</td>
+                        </tr>
+                        <tr className="border-b">
+                          <td className="py-2 pr-4 font-mono">
+                            ffc-sister-site-banner-dismissed-v1
+                          </td>
+                          <td className="py-2 pr-4">Local storage</td>
+                          <td className="py-2 pr-4">
+                            Remembers that you dismissed the &ldquo;looking for a free site or to
+                            donate?&rdquo; banner so it stays hidden. No personal data; never leaves
+                            your device.
+                          </td>
+                          <td className="py-2">Until cleared</td>
                         </tr>
                       </tbody>
                     </table>

--- a/src/app/cookie-policy/page.tsx
+++ b/src/app/cookie-policy/page.tsx
@@ -7,7 +7,7 @@ export const metadata: Metadata = {
 }
 
 // Update this date when the policy changes
-const LAST_UPDATED = 'November 16, 2025'
+const LAST_UPDATED = 'June 6, 2026'
 
 export default function CookiePolicy() {
   return (
@@ -73,7 +73,9 @@ export default function CookiePolicy() {
                     These cookies (and equivalent browser storage) are essential for the website to
                     function properly. They enable basic features like storing your cookie consent
                     preferences and remembering interface choices. They do not store any personally
-                    identifiable information and cannot be disabled.
+                    identifiable information and are always active (they are not controlled by the
+                    consent banner). You can still block cookies and site storage in your browser
+                    settings, but doing so may break core functionality.
                   </p>
                   <div className="bg-gray-50 p-4 rounded-lg">
                     <table className="w-full text-sm">

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -233,7 +233,7 @@ export default function Navigation() {
               href="https://freeforcharity.org/"
               target="_blank"
               rel="noopener noreferrer"
-              className="font-medium text-amber-700 hover:text-amber-900 inline-flex items-center whitespace-nowrap transition-colors"
+              className="font-medium text-blue-700 hover:text-blue-900 inline-flex items-center whitespace-nowrap transition-colors"
             >
               For Charities &amp; Donors
               <svg
@@ -382,7 +382,7 @@ export default function Navigation() {
               href="https://freeforcharity.org/"
               target="_blank"
               rel="noopener noreferrer"
-              className="block px-3 py-2 rounded-md text-amber-700 font-medium hover:bg-amber-50 transition-colors"
+              className="block px-3 py-2 rounded-md text-blue-700 font-medium hover:bg-blue-50 transition-colors"
               onClick={() => setIsMenuOpen(false)}
             >
               For Charities &amp; Donors ↗

--- a/src/components/SisterSiteBanner.tsx
+++ b/src/components/SisterSiteBanner.tsx
@@ -53,7 +53,7 @@ export default function SisterSiteBanner() {
     <div
       role="region"
       aria-label="Sister site routing"
-      className="bg-amber-50 border-b border-amber-200 text-amber-900"
+      className="bg-blue-50 border-b border-blue-200 text-blue-900"
     >
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-2.5 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 text-sm">
         <p>
@@ -71,7 +71,7 @@ export default function SisterSiteBanner() {
         <button
           type="button"
           onClick={dismiss}
-          className="self-end sm:self-auto inline-flex items-center text-amber-900/80 hover:text-amber-900 text-sm px-3 py-2 rounded hover:bg-amber-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-600 focus-visible:ring-offset-2 focus-visible:ring-offset-amber-50"
+          className="self-end sm:self-auto inline-flex items-center text-blue-900/80 hover:text-blue-900 text-sm px-3 py-2 rounded hover:bg-blue-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 focus-visible:ring-offset-blue-50"
           aria-label="Dismiss this notice"
         >
           Dismiss


### PR DESCRIPTION
- **#265** — SisterSiteBanner + Navigation "For Charities & Donors" external link switched from amber to the site's **blue** informational palette.
- **#273** — Documented the banner's dismissal flag (`ffc-sister-site-banner-dismissed-v1`) in the cookie policy as **strictly-necessary local storage** (no personal data, never leaves the device, no consent gate).
- **#307** — No PR previews; the existing `/site-owner` "preview = ask your assistant to show you the change before approving" copy stands. Closing.

`format` ✓ · `lint` ✓ (0 errors) · `build` ✓ · `test` ✓ (336).

Closes #265, closes #273, closes #307

---
_Generated by [Claude Code](https://claude.ai/code/session_01X4omPQW2ErDyZsMtxypuMe)_