### PR TITLE
refactor: rename legacy leaf → wordpress-volunteer-core-competencies (#257)

### DIFF
--- a/__tests__/route-generation.test.js
+++ b/__tests__/route-generation.test.js
@@ -109,7 +109,7 @@ describe('Route Generation Tests', () => {
       'wordpress-training-programs',
       'wordpress-web-developer-training',
       'wordpress-tools-for-success',
-      'wordpress-volunteer-proving-ground',
+      'wordpress-volunteer-core-competencies',
     ]
 
     it('should generate the hub page', () => {

--- a/src/app/contributor-ladder/page.tsx
+++ b/src/app/contributor-ladder/page.tsx
@@ -473,12 +473,12 @@ export default function ContributorLadder() {
             Legacy reference
           </p>
           <p className="text-gray-700">
-            The WordPress-era proving-ground curriculum is preserved at{' '}
+            The WordPress-era core-competencies curriculum is preserved at{' '}
             <a
-              href="/legacy-wordpress-administration/wordpress-volunteer-proving-ground"
+              href="/legacy-wordpress-administration/wordpress-volunteer-core-competencies"
               className="text-blue-600 underline hover:text-blue-800"
             >
-              wordpress-volunteer-proving-ground
+              wordpress-volunteer-core-competencies
             </a>{' '}
             — seven core competencies (LastPass, AI assistants, MS-900, MS-700, OneDrive, Planner,
             M365 Apps) covering 33–46 hours of self-study. Use it as supplemental reading when

--- a/src/app/legacy-wordpress-administration/wordpress-volunteer-core-competencies/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-volunteer-core-competencies/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next'
 import LeafPageShell from '@/components/legacy-wordpress-administration/LeafPageShell'
 import { getLegacyWpAdminPageBySlug } from '@/data/legacy-wordpress-administration'
 
-const SLUG = 'wordpress-volunteer-proving-ground'
+const SLUG = 'wordpress-volunteer-core-competencies'
 const page = getLegacyWpAdminPageBySlug(SLUG)
 
 export const metadata: Metadata = {

--- a/src/app/legacy-wordpress-administration/wordpress-web-developer-training/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-web-developer-training/page.tsx
@@ -227,10 +227,10 @@ export default function Page() {
           — the layered model these platforms fit into.
         </li>
         <li>
-          <a href="/legacy-wordpress-administration/wordpress-volunteer-proving-ground/">
-            wordpress-volunteer-proving-ground
+          <a href="/legacy-wordpress-administration/wordpress-volunteer-core-competencies/">
+            wordpress-volunteer-core-competencies
           </a>{' '}
-          — the proving-ground checklist developers complete before getting admin access to charity
+          — the core-competency checklist developers complete before getting admin access to charity
           sites.
         </li>
         <li>

--- a/src/data/legacy-wordpress-administration.ts
+++ b/src/data/legacy-wordpress-administration.ts
@@ -215,9 +215,9 @@ export const LEGACY_WP_ADMIN_PAGES: LegacyWpAdminPage[] = [
     publicSourceUrl: 'https://freeforcharity.org/free-for-charitys-tools-for-success/',
   },
   {
-    slug: 'wordpress-volunteer-proving-ground',
-    title: 'FFC Volunteer Proving Ground: Core Competencies',
-    shortLabel: 'Volunteer Proving Ground',
+    slug: 'wordpress-volunteer-core-competencies',
+    title: 'FFC Volunteer Core Competencies',
+    shortLabel: 'Volunteer Core Competencies',
     summary:
       'Core-competency checklist volunteers complete to advance through the FFC contributor ladder.',
     category: 'volunteer-programs',


### PR DESCRIPTION
Renames the legacy leaf `wordpress-volunteer-proving-ground` → **`wordpress-volunteer-core-competencies`** (#257).

- Slug, directory, title ("FFC Volunteer Core Competencies"), and shortLabel updated.
- `SLUG` const, both cross-leaf links (web-developer-training, contributor-ladder), and the route-generation test slug list updated.
- Directory-sync + route-generation + full suite pass (336).

`format` ✓ · `lint` ✓ (0 errors) · `build` ✓ · `test` ✓ (336).

Closes #257

---
_Generated by [Claude Code](https://claude.ai/code/session_01X4omPQW2ErDyZsMtxypuMe)_