### PR TITLE
docs: add DNS cutover runbook + redirect-test script

### DIFF
--- a/docs/dns-cutover-runbook.md
+++ b/docs/dns-cutover-runbook.md
@@ -10,7 +10,7 @@ the maintainer's to perform.
 
 - [x] Audience-split routing live on ffcadmin.org (SisterSiteBanner, nav + footer
       "For Charities & Donors", `/site-owner` for owners).
-- [x] `app/sitemap.ts` includes all current routes; legacy leaves set self-canonicals.
+- [x] `src/app/sitemap.ts` includes all current routes; legacy leaves set self-canonicals.
 - [x] Bulk-redirect map committed: `docs/cloudflare-bulk-redirects-cutover.csv`.
 
 ## Cutover day (external — maintainer)

--- a/docs/dns-cutover-runbook.md
+++ b/docs/dns-cutover-runbook.md
@@ -1,0 +1,52 @@
+# DNS Cutover Runbook
+
+In-repo support for the freeforcharity.org ↔ ffcadmin.org cutover (#240). The
+code-side work (audience-split content, sitemap, canonicals, the redirect map in
+`cloudflare-bulk-redirects-cutover.csv`) lives here; the **execution steps below
+run in external systems** (Cloudflare, the host, Google Search Console) and are
+the maintainer's to perform.
+
+## Pre-cutover checklist (in-repo — already done)
+
+- [x] Audience-split routing live on ffcadmin.org (SisterSiteBanner, nav + footer
+      "For Charities & Donors", `/site-owner` for owners).
+- [x] `app/sitemap.ts` includes all current routes; legacy leaves set self-canonicals.
+- [x] Bulk-redirect map committed: `docs/cloudflare-bulk-redirects-cutover.csv`.
+
+## Cutover day (external — maintainer)
+
+1. **Load redirects (Cloudflare).** Import `cloudflare-bulk-redirects-cutover.csv`
+   into the freeforcharity.org zone as a Bulk Redirect list, then enable the rule.
+2. **Flip DNS.** Point the apex/records to the new origin per the host plan.
+   Lower TTLs ~24h ahead so the change propagates quickly.
+3. **Verify redirects.** Run `scripts/test-cutover-redirects.sh` (see below) once
+   DNS resolves; every source URL must return `301` to its target.
+4. **Smoke-test key pages** on both domains (home, donate, submit-information,
+   a few migrated paths).
+5. **Decommission the old WordPress origin** only after redirects + smoke tests pass.
+
+## Google Search Console (external — maintainer)
+
+1. Confirm both properties (`freeforcharity.org`, `ffcadmin.org`) are verified.
+2. Submit the updated `sitemap.xml` for each property.
+3. For any URL that **moved domains**, use the **Change of Address** tool
+   (Settings → Change of Address) where applicable.
+4. Spot-check **Coverage / Pages** for redirect (3xx) handling and crawl errors
+   over the following days; re-submit the sitemap if needed.
+5. Watch **Performance** for impression continuity on the top moved URLs.
+
+## Redirect verification script
+
+`scripts/test-cutover-redirects.sh` reads the CSV and curls each `source_url`,
+asserting it returns the expected `status` and `Location`. Run it after the
+redirect list is enabled:
+
+```bash
+bash scripts/test-cutover-redirects.sh
+```
+
+## Related
+
+- Redirect map: [`cloudflare-bulk-redirects-cutover.csv`](./cloudflare-bulk-redirects-cutover.csv)
+- Content split plan: [`dns-cutover-site-plan.md`](./dns-cutover-site-plan.md)
+- Companion marketing-site changes live in the **FreeForCharity/FreeForCharity.org** repo (#246).

--- a/scripts/test-cutover-redirects.sh
+++ b/scripts/test-cutover-redirects.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+#
+# Verify the cutover bulk-redirect map (#244).
+# Reads docs/cloudflare-bulk-redirects-cutover.csv and checks that each
+# source_url returns the expected HTTP status and redirects to target_url.
+#
+# Usage:
+#   bash scripts/test-cutover-redirects.sh
+#
+# Exit code is non-zero if any redirect does not match, so this can gate a
+# post-cutover verification step.
+
+set -u
+
+CSV="$(dirname "$0")/../docs/cloudflare-bulk-redirects-cutover.csv"
+
+if [ ! -f "$CSV" ]; then
+  echo "ERROR: redirect CSV not found at $CSV" >&2
+  exit 2
+fi
+
+fail=0
+checked=0
+
+# Skip the header row; read source,target,status as the first three columns.
+tail -n +2 "$CSV" | while IFS=',' read -r source target status _rest; do
+  [ -z "${source:-}" ] && continue
+  checked=$((checked + 1))
+
+  # Follow no redirects; capture the status code and Location header.
+  code=$(curl -s -o /dev/null -w '%{http_code}' "$source")
+  location=$(curl -s -o /dev/null -D - "$source" | awk 'tolower($1)=="location:"{print $2}' | tr -d '\r')
+
+  if [ "$code" = "$status" ] && [ "$location" = "$target" ]; then
+    echo "OK   $source -> $location ($code)"
+  else
+    echo "FAIL $source -> got [$code -> ${location:-<none>}], expected [$status -> $target]" >&2
+    fail=1
+  fi
+done
+
+if [ "$fail" -ne 0 ]; then
+  echo "One or more redirects did not match the expected map." >&2
+  exit 1
+fi
+
+echo "All redirects verified."

--- a/scripts/test-cutover-redirects.sh
+++ b/scripts/test-cutover-redirects.sh
@@ -13,6 +13,7 @@
 set -u
 
 CSV="$(dirname "$0")/../docs/cloudflare-bulk-redirects-cutover.csv"
+CURL_MAX_TIME=15
 
 if [ ! -f "$CSV" ]; then
   echo "ERROR: redirect CSV not found at $CSV" >&2
@@ -22,14 +23,16 @@ fi
 fail=0
 checked=0
 
-# Skip the header row; read source,target,status as the first three columns.
-tail -n +2 "$CSV" | while IFS=',' read -r source target status _rest; do
+# Process substitution (not `tail | while`) so fail/checked update in THIS shell.
+while IFS=',' read -r source target status _rest; do
   [ -z "${source:-}" ] && continue
   checked=$((checked + 1))
 
-  # Follow no redirects; capture the status code and Location header.
-  code=$(curl -s -o /dev/null -w '%{http_code}' "$source")
-  location=$(curl -s -o /dev/null -D - "$source" | awk 'tolower($1)=="location:"{print $2}' | tr -d '\r')
+  # Follow no redirects; capture status code and Location header. Time-bounded
+  # so a misbehaving edge during cutover can't hang the script.
+  code=$(curl -s -m "$CURL_MAX_TIME" -o /dev/null -w '%{http_code}' "$source")
+  location=$(curl -s -m "$CURL_MAX_TIME" -o /dev/null -D - "$source" \
+    | awk 'tolower($1)=="location:"{print $2}' | tr -d '\r')
 
   if [ "$code" = "$status" ] && [ "$location" = "$target" ]; then
     echo "OK   $source -> $location ($code)"
@@ -37,11 +40,16 @@ tail -n +2 "$CSV" | while IFS=',' read -r source target status _rest; do
     echo "FAIL $source -> got [$code -> ${location:-<none>}], expected [$status -> $target]" >&2
     fail=1
   fi
-done
+done < <(tail -n +2 "$CSV")
+
+if [ "$checked" -eq 0 ]; then
+  echo "ERROR: no redirect rows found in $CSV" >&2
+  exit 2
+fi
 
 if [ "$fail" -ne 0 ]; then
-  echo "One or more redirects did not match the expected map." >&2
+  echo "One or more redirects did not match the expected map ($checked checked)." >&2
   exit 1
 fi
 
-echo "All redirects verified."
+echo "All $checked redirects verified."


### PR DESCRIPTION
In-repo support for the DNS cutover (the external Cloudflare/DNS/Search-Console execution stays with the maintainer).

- **`docs/dns-cutover-runbook.md`** — cutover-day checklist + Google Search Console procedure (#240, #245).
- **`scripts/test-cutover-redirects.sh`** — verifies every row of `cloudflare-bulk-redirects-cutover.csv` returns the expected `301 → target` (#244); non-zero exit on mismatch so it can gate post-cutover verification.

`format` ✓ · `lint` ✓ · `test` ✓ (336).

Refs #240, #244, #245 (in-repo portions; external cutover actions remain).

---
_Generated by [Claude Code](https://claude.ai/code/session_01X4omPQW2ErDyZsMtxypuMe)_