### PR TITLE
feat: remove unused Meta Pixel + correct privacy copy (#189)

### DIFF
--- a/src/app/cookie-policy/page.tsx
+++ b/src/app/cookie-policy/page.tsx
@@ -217,42 +217,12 @@ export default function CookiePolicy() {
                     for publishers and advertisers.
                   </p>
                   <div className="bg-gray-50 p-4 rounded-lg">
-                    <h4 className="font-semibold mb-2">Meta Pixel (Facebook Pixel)</h4>
-                    <p className="text-sm mb-2">
-                      The Meta Pixel is an analytics tool that helps us measure the effectiveness of
-                      advertising by understanding the actions people take on our website.
-                    </p>
-                    <table className="w-full text-sm">
-                      <thead>
-                        <tr className="border-b">
-                          <th className="text-left py-2 pr-4">Cookie Name</th>
-                          <th className="text-left py-2 pr-4">Purpose</th>
-                          <th className="text-left py-2">Duration</th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        <tr className="border-b">
-                          <td className="py-2 pr-4 font-mono">_fbp</td>
-                          <td className="py-2 pr-4">Tracks user behavior for advertising</td>
-                          <td className="py-2">3 months</td>
-                        </tr>
-                        <tr>
-                          <td className="py-2 pr-4 font-mono">fr</td>
-                          <td className="py-2 pr-4">Enables ad delivery and targeting</td>
-                          <td className="py-2">3 months</td>
-                        </tr>
-                      </tbody>
-                    </table>
-                    <p className="text-xs mt-2 text-gray-600">
-                      Privacy Policy:{' '}
-                      <a
-                        href="https://www.facebook.com/privacy/policy/"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-blue-600 hover:underline"
-                      >
-                        https://www.facebook.com/privacy/policy/
-                      </a>
+                    <p className="text-sm">
+                      <strong>
+                        We do not currently use any marketing or advertising trackers.
+                      </strong>{' '}
+                      The marketing preference is reserved in case we add one in the future; if we
+                      do, we will list it here and it will load only with your consent.
                     </p>
                   </div>
                 </div>

--- a/src/app/privacy-policy/page.tsx
+++ b/src/app/privacy-policy/page.tsx
@@ -123,8 +123,9 @@ export default function PrivacyPolicy() {
                   our website (Google Analytics, Microsoft Clarity). Requires consent.
                 </li>
                 <li>
-                  <strong>Marketing Cookies:</strong> Used to track visitors across websites for
-                  advertising purposes (Meta Pixel). Requires consent.
+                  <strong>Marketing Cookies:</strong> Would be used to track visitors across
+                  websites for advertising. We do not currently use any; reserved for future use and
+                  would require consent.
                 </li>
               </ul>
               <p>
@@ -147,10 +148,6 @@ export default function PrivacyPolicy() {
                 </li>
                 <li>
                   <strong>Microsoft Clarity:</strong> User behavior analytics (only with consent)
-                </li>
-                <li>
-                  <strong>Meta Pixel:</strong> Marketing and advertising analytics (only with
-                  consent)
                 </li>
               </ul>
               <p>

--- a/src/components/CookieConsent.tsx
+++ b/src/components/CookieConsent.tsx
@@ -4,7 +4,6 @@ import { useState, useEffect, useRef } from 'react'
 
 // Environment variables for tracking IDs (replace with actual values)
 const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID || 'G-XXXXXXXXXX'
-const META_PIXEL_ID = process.env.NEXT_PUBLIC_META_PIXEL_ID || 'XXXXXXXXXXXXXXX'
 
 type ConsentPreferences = {
   necessary: boolean
@@ -169,9 +168,7 @@ export default function CookieConsent() {
       // Microsoft Clarity is now managed via Google Tag Manager
       // No direct Clarity initialization needed
     }
-    if (prefs.marketing) {
-      loadMetaPixel()
-    }
+    // Marketing consent currently loads no third-party tags (Meta Pixel removed, #189).
   }
 
   const loadGoogleAnalytics = () => {
@@ -197,38 +194,6 @@ export default function CookieConsent() {
         });
       `
       document.head.appendChild(gaConfigScript)
-    }
-  }
-
-  const loadMetaPixel = () => {
-    // Skip loading if Meta Pixel ID is not configured (placeholder value)
-    if (!META_PIXEL_ID || META_PIXEL_ID === 'XXXXXXXXXXXXXXX') {
-      return
-    }
-    if (typeof window !== 'undefined' && !document.querySelector('script[src*="fbevents.js"]')) {
-      const fbScript = document.createElement('script')
-      fbScript.textContent = `
-        !function(f,b,e,v,n,t,s)
-        {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
-        n.callMethod.apply(n,arguments):n.queue.push(arguments)};
-        if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
-        n.queue=[];t=b.createElement(e);t.async=!0;
-        t.src=v;s=b.getElementsByTagName(e)[0];
-        s.parentNode.insertBefore(t,s)}(window, document,'script',
-        'https://connect.facebook.net/en_US/fbevents.js');
-        fbq('init', '${META_PIXEL_ID}');
-        fbq('track', 'PageView');
-      `
-      document.head.appendChild(fbScript)
-
-      const fbNoScript = document.createElement('noscript')
-      const img = document.createElement('img')
-      img.height = 1
-      img.width = 1
-      img.style.display = 'none'
-      img.src = `https://www.facebook.com/tr?id=${META_PIXEL_ID}&ev=PageView&noscript=1`
-      fbNoScript.appendChild(img)
-      document.body.appendChild(fbNoScript)
     }
   }
 
@@ -418,10 +383,11 @@ export default function CookieConsent() {
                 </label>
               </div>
               <p className="text-sm text-gray-600 mb-2">
-                These cookies are used to track visitors across websites. The intention is to
-                display ads that are relevant and engaging for the individual user.
+                These cookies would be used to track visitors across websites to display relevant
+                ads. We do not currently use any marketing trackers; this preference is reserved in
+                case we add one in the future.
               </p>
-              <p className="text-xs text-gray-500">Services: Meta Pixel (Facebook)</p>
+              <p className="text-xs text-gray-500">Services: none currently active</p>
             </div>
 
             <div className="flex flex-col sm:flex-row gap-3 mt-6">


### PR DESCRIPTION
First half of #189 — remove the unused Meta Pixel.

The pixel was gated behind a placeholder ID and never actually loaded. This removes the loader, the `META_PIXEL_ID` constant, and the call from `CookieConsent`, and corrects the **cookie-policy**, **privacy-policy**, and consent-modal copy to accurately state we use **no marketing/advertising trackers** (the marketing preference is reserved for future use, consent-gated).

`format` ✓ · `lint` ✓ · `build` ✓ · `test` ✓ (340).

Refs #189 (volunteer-recruitment landing pages follow in a second PR).

---
_Generated by [Claude Code](https://claude.ai/code/session_01X4omPQW2ErDyZsMtxypuMe)_