### PR TITLE
feat: add volunteer recruitment landing pages (#189)

### DIFF
--- a/__tests__/route-generation.test.js
+++ b/__tests__/route-generation.test.js
@@ -110,6 +110,35 @@ describe('Route Generation Tests', () => {
     })
   })
 
+  describe('Test Case 4.3b: Volunteer Recruitment Landing Pages', () => {
+    const roleSlugs = [
+      'web-developer',
+      'microsoft-365-admin',
+      'google-workspace-admin',
+      'data-analytics',
+      'canva-designer',
+      'military-volunteers',
+    ]
+
+    it('should generate index.html for every volunteer role page', () => {
+      for (const slug of roleSlugs) {
+        const rolePath = path.join(outDir, 'volunteer', slug, 'index.html')
+        expect(fs.existsSync(rolePath)).toBe(true)
+      }
+    })
+
+    it('every role page sets a self-canonical URL', () => {
+      for (const slug of roleSlugs) {
+        const rolePath = path.join(outDir, 'volunteer', slug, 'index.html')
+        if (fs.existsSync(rolePath)) {
+          const content = fs.readFileSync(rolePath, 'utf-8')
+          const expected = `https://ffcadmin.org/volunteer/${slug}/`
+          expect(content).toContain(`<link rel="canonical" href="${expected}"/>`)
+        }
+      }
+    })
+  })
+
   describe('Test Case 4.4: Legacy WordPress Administration Section', () => {
     const sectionRoot = path.join(outDir, 'legacy-wordpress-administration')
     const hubPath = path.join(sectionRoot, 'index.html')

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -2,6 +2,7 @@ import type { MetadataRoute } from 'next'
 import { blogPosts } from '@/data/blog'
 import { guides } from '@/data/guides'
 import { LEGACY_WP_ADMIN_BASE, LEGACY_WP_ADMIN_PAGES } from '@/data/legacy-wordpress-administration'
+import { VOLUNTEER_ROLES } from '@/data/volunteer-roles'
 
 export const dynamic = 'force-static'
 
@@ -179,5 +180,13 @@ export default function sitemap(): MetadataRoute.Sitemap {
     priority: 0.6,
   }))
 
-  return [...corePages, ...guidePages, ...blogPages, ...legacyWpAdminPages]
+  // Volunteer recruitment landing pages
+  const volunteerRolePages: MetadataRoute.Sitemap = VOLUNTEER_ROLES.map((role) => ({
+    url: `${SITE_URL}/volunteer/${role.slug}/`,
+    lastModified: now,
+    changeFrequency: 'monthly' as const,
+    priority: 0.6,
+  }))
+
+  return [...corePages, ...guidePages, ...blogPages, ...legacyWpAdminPages, ...volunteerRolePages]
 }

--- a/src/app/volunteer/[role]/page.tsx
+++ b/src/app/volunteer/[role]/page.tsx
@@ -1,0 +1,118 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import Breadcrumbs from '@/components/Breadcrumbs'
+import { VOLUNTEER_ROLES, getVolunteerRole } from '@/data/volunteer-roles'
+
+export function generateStaticParams() {
+  return VOLUNTEER_ROLES.map((r) => ({ role: r.slug }))
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ role: string }>
+}): Promise<Metadata> {
+  const { role: slug } = await params
+  const role = getVolunteerRole(slug)
+  if (!role) return {}
+  return {
+    title: role.title,
+    description: role.intro,
+    keywords: role.keywords,
+    alternates: { canonical: `https://ffcadmin.org/volunteer/${role.slug}/` },
+  }
+}
+
+export default async function VolunteerRolePage({ params }: { params: Promise<{ role: string }> }) {
+  const { role: slug } = await params
+  const role = getVolunteerRole(slug)
+  if (!role) return null
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Breadcrumbs
+        items={[
+          { label: 'Home', href: '/' },
+          { label: 'Volunteer', href: '/volunteer' },
+          { label: role.title },
+        ]}
+      />
+
+      {/* Hero */}
+      <div className={`bg-gradient-to-r ${role.gradient} text-white py-16 px-4 sm:px-6 lg:px-8`}>
+        <div className="max-w-4xl mx-auto">
+          <div className="flex items-center mb-4">
+            <span className="text-5xl mr-4" aria-hidden="true">
+              {role.icon}
+            </span>
+            <div>
+              <h1 className="text-3xl md:text-4xl font-bold">{role.title}</h1>
+              <p className="text-white/90 text-sm mt-1">{role.tagline}</p>
+            </div>
+          </div>
+          <p className="text-white/90 text-lg max-w-3xl">{role.intro}</p>
+        </div>
+      </div>
+
+      <main className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        <section className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
+          <h2 className="text-2xl font-bold text-gray-900 mb-4">What you&apos;ll do</h2>
+          <ul className="space-y-2 text-sm text-gray-700">
+            {role.responsibilities.map((r) => (
+              <li key={r} className="flex items-start">
+                <span className="text-emerald-600 mr-2 mt-0.5">&#10003;</span>
+                <span>{r}</span>
+              </li>
+            ))}
+          </ul>
+          <div className="mt-6 flex flex-col sm:flex-row gap-3">
+            <Link
+              href={role.startHref}
+              className="inline-flex items-center justify-center px-6 py-3 bg-gray-900 text-white rounded-lg font-semibold hover:bg-gray-800 transition-colors text-sm"
+            >
+              {role.startLabel}
+            </Link>
+            <a
+              href="sms:520-222-8104"
+              className="inline-flex items-center justify-center px-6 py-3 border border-gray-300 text-gray-700 rounded-lg font-semibold hover:bg-gray-50 transition-colors text-sm"
+            >
+              Text FFC to get started
+            </a>
+          </div>
+        </section>
+
+        {/* Other roles */}
+        <section className="bg-white rounded-xl shadow-lg p-6 md:p-8">
+          <h2 className="text-xl font-bold text-gray-900 mb-4">Other ways to volunteer</h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+            {VOLUNTEER_ROLES.filter((r) => r.slug !== role.slug).map((r) => (
+              <Link
+                key={r.slug}
+                href={`/volunteer/${r.slug}`}
+                className="flex items-center p-2 rounded-lg hover:bg-gray-50 transition-colors group"
+              >
+                <span className="text-xl mr-3" aria-hidden="true">
+                  {r.icon}
+                </span>
+                <span className="text-sm font-semibold text-gray-900 group-hover:text-blue-700">
+                  {r.title}
+                </span>
+              </Link>
+            ))}
+          </div>
+          <p className="mt-4 text-sm text-gray-600">
+            Not sure?{' '}
+            <Link href="/get-involved" className="text-blue-600 underline hover:text-blue-800">
+              See all volunteer tracks
+            </Link>{' '}
+            or{' '}
+            <Link href="/site-owner" className="text-blue-600 underline hover:text-blue-800">
+              edit your own charity&apos;s site
+            </Link>
+            .
+          </p>
+        </section>
+      </main>
+    </div>
+  )
+}

--- a/src/app/volunteer/page.tsx
+++ b/src/app/volunteer/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
 import Breadcrumbs from '@/components/Breadcrumbs'
+import { VOLUNTEER_ROLES } from '@/data/volunteer-roles'
 
 export const metadata: Metadata = {
   title: 'Volunteer with Free For Charity',
@@ -455,8 +456,40 @@ export default function VolunteerPage() {
         </div>
       </section>
 
+      {/* Explore all roles */}
+      <section className="py-12 px-4 sm:px-6 lg:px-8 bg-gray-50 border-t border-gray-100">
+        <div className="max-w-5xl mx-auto">
+          <div className="text-center mb-8">
+            <h2 className="text-3xl font-bold text-gray-900 mb-3">Explore Volunteer Roles</h2>
+            <p className="text-lg text-gray-600 max-w-3xl mx-auto">
+              Each role has its own landing page with what you&apos;ll do and how to start. Not sure
+              which fits? Text us and we&apos;ll help you choose.
+            </p>
+          </div>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {VOLUNTEER_ROLES.map((role) => (
+              <Link
+                key={role.slug}
+                href={`/volunteer/${role.slug}`}
+                className="group block bg-white rounded-xl border border-gray-200 p-5 hover:shadow-lg hover:border-gray-300 transition-all"
+              >
+                <div className="flex items-center mb-2">
+                  <span className="text-3xl mr-3" aria-hidden="true">
+                    {role.icon}
+                  </span>
+                  <h3 className="text-base font-bold text-gray-900 group-hover:text-blue-700">
+                    {role.title}
+                  </h3>
+                </div>
+                <p className="text-sm text-gray-600">{role.tagline}</p>
+              </Link>
+            ))}
+          </div>
+        </div>
+      </section>
+
       {/* Site owner callout */}
-      <section className="px-4 sm:px-6 lg:px-8 -mt-4 pb-4">
+      <section className="px-4 sm:px-6 lg:px-8 mt-4 pb-4">
         <div className="max-w-5xl mx-auto">
           <div className="bg-emerald-50 border-l-4 border-emerald-500 rounded p-5 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
             <p className="text-sm text-emerald-900">

--- a/src/data/volunteer-roles.ts
+++ b/src/data/volunteer-roles.ts
@@ -1,0 +1,143 @@
+/**
+ * Volunteer recruitment landing pages (#189).
+ *
+ * Each entry renders a keyword-tuned landing page at /volunteer/<slug> via the
+ * dynamic route src/app/volunteer/[role]/page.tsx. Keep these focused on
+ * recruitment intent; the deep curriculum lives in the training tracks.
+ */
+
+export interface VolunteerRole {
+  slug: string
+  /** Page <h1> + nav/breadcrumb label. */
+  title: string
+  tagline: string
+  intro: string
+  keywords: string
+  responsibilities: string[]
+  /** Where the "start" CTA points (a training track or the dev-env hub). */
+  startHref: string
+  startLabel: string
+  gradient: string
+  icon: string
+}
+
+export const VOLUNTEER_ROLES: VolunteerRole[] = [
+  {
+    slug: 'web-developer',
+    title: 'Web Developer Volunteer',
+    tagline: 'Build and maintain charity websites with an AI agent',
+    intro:
+      'Help nonprofits get a fast, modern website by building and updating Next.js sites with your AI agent — describe changes in plain English, open pull requests, and let CI handle the checks. No heavy local setup required.',
+    keywords:
+      'volunteer web developer nonprofit, Next.js volunteer, React volunteer, AI agent developer, GitHub volunteer, free nonprofit website developer',
+    responsibilities: [
+      'Build and customize charity sites from the FFC template',
+      'Run the Issue → PR → merge workflow with your AI agent',
+      'Keep sites accessible, fast, and secure',
+      'Help charity owners hand off to self-service editing',
+    ],
+    startHref: '/training/web-developer',
+    startLabel: 'Start the Web Developer track',
+    gradient: 'from-blue-500 to-indigo-600',
+    icon: '💻',
+  },
+  {
+    slug: 'microsoft-365-admin',
+    title: 'Microsoft 365 Administrator Volunteer',
+    tagline: 'Run email, identity, and security for charities',
+    intro:
+      'Administer Microsoft 365 for nonprofits — mailboxes, identity, MFA, and security baselines — and earn the MS-900 certification along the way. This is the infrastructure backbone every charity relies on.',
+    keywords:
+      'Microsoft 365 admin volunteer, MS-900 volunteer, nonprofit IT volunteer, Entra ID volunteer, email administration volunteer',
+    responsibilities: [
+      'Provision mailboxes, licenses, and security policies',
+      'Enforce MFA and Conditional Access',
+      'Manage compliance and data retention',
+      'Earn MS-900 (FFC sponsors the exam)',
+    ],
+    startHref: '/training-plan',
+    startLabel: 'Start the Global Admin track',
+    gradient: 'from-teal-500 to-emerald-600',
+    icon: '🛡️',
+  },
+  {
+    slug: 'google-workspace-admin',
+    title: 'Google Workspace Administrator Volunteer',
+    tagline: 'Manage Google Workspace for charities',
+    intro:
+      'Set up and run Google Workspace for nonprofits — accounts, groups, sharing, and security. A first-class role that used to be folded into general admin work.',
+    keywords:
+      'Google Workspace admin volunteer, GSuite nonprofit volunteer, Google admin volunteer, nonprofit Google Workspace',
+    responsibilities: [
+      'Provision users, groups, and shared drives',
+      'Configure security and sharing controls',
+      'Support charity staff on Workspace tools',
+      'Coordinate with the analytics and web roles',
+    ],
+    startHref: '/training',
+    startLabel: 'See the training tracks',
+    gradient: 'from-amber-500 to-orange-600',
+    icon: '🗂️',
+  },
+  {
+    slug: 'data-analytics',
+    title: 'Data & Analytics Volunteer',
+    tagline: 'Measure impact with analytics and dashboards',
+    intro:
+      'Help charities understand their reach — set up analytics (GA4 / Tag Manager), build impact dashboards, and turn data into clear reporting. Deeply connected to the initial website build.',
+    keywords:
+      'data analytics volunteer, Google Analytics volunteer, GA4 volunteer, nonprofit data volunteer, impact reporting volunteer',
+    responsibilities: [
+      'Configure analytics and event tracking (consent-gated)',
+      'Build dashboards and impact reports',
+      'Maintain on-page SEO and search presence',
+      'Partner with web developers during site builds',
+    ],
+    startHref: '/training',
+    startLabel: 'See the training tracks',
+    gradient: 'from-violet-500 to-purple-600',
+    icon: '📈',
+  },
+  {
+    slug: 'canva-designer',
+    title: 'Canva Designer Volunteer',
+    tagline: 'Create brand identities and marketing materials',
+    intro:
+      'Design professional brand kits, social templates, and marketing collateral for nonprofits using Canva Pro — and earn Canva Design School recognition.',
+    keywords:
+      'Canva designer volunteer, nonprofit graphic design volunteer, brand kit volunteer, Canva Pro volunteer',
+    responsibilities: [
+      'Build complete brand kits and style guides',
+      'Create social media and email templates',
+      'Design print and marketing collateral',
+      'Complete Canva Design School courses',
+    ],
+    startHref: '/canva-designer-path',
+    startLabel: 'Start the Designer path',
+    gradient: 'from-orange-500 to-amber-500',
+    icon: '🎨',
+  },
+  {
+    slug: 'military-volunteers',
+    title: 'Military Volunteers (MOVSM)',
+    tagline: 'Serve charities and earn recognition for it',
+    intro:
+      'Service members who perform sustained volunteer work for charities may qualify for the Military Outstanding Volunteer Service Medal (MOVSM). FFC welcomes military volunteers across every role and can help document your qualifying hours.',
+    keywords:
+      'military volunteer, MOVSM, Military Outstanding Volunteer Service Medal, service member volunteer, veteran volunteer nonprofit',
+    responsibilities: [
+      'Contribute in any FFC role (dev, admin, design, analytics)',
+      'Track qualifying volunteer hours (self-report + board attestation)',
+      'Work toward MOVSM eligibility',
+      'Get started by texting FFC to find your fit',
+    ],
+    startHref: '/get-involved',
+    startLabel: 'Find your role',
+    gradient: 'from-slate-600 to-slate-800',
+    icon: '🎖️',
+  },
+]
+
+export function getVolunteerRole(slug: string): VolunteerRole | undefined {
+  return VOLUNTEER_ROLES.find((r) => r.slug === slug)
+}


### PR DESCRIPTION
## Summary

Completes the landing-pages half of #189 (the Meta Pixel removal landed in #348). Adds a data-driven `/volunteer/[role]` dynamic route with six keyword-tuned recruitment landing pages so each volunteer track has a dedicated, SEO-friendly entry point.

Roles:
- Web Developer
- Microsoft 365 Administrator
- Google Workspace Administrator (new first-class role)
- Data & Analytics (new first-class role)
- Canva Designer
- Military Volunteers (MOVSM)

## Changes

- **`src/data/volunteer-roles.ts`** — new single source of truth (`VolunteerRole` interface + `VOLUNTEER_ROLES` + `getVolunteerRole`).
- **`src/app/volunteer/[role]/page.tsx`** — dynamic route; `generateStaticParams` prerenders all six as static SSG pages; per-role metadata + self-canonical; hero, "What you'll do", start CTA + text-to-start, and cross-links to other roles.
- **`src/app/sitemap.ts`** — adds the six landing pages.
- **`src/app/volunteer/page.tsx`** — new "Explore Volunteer Roles" grid linking to each landing page.
- **`__tests__/route-generation.test.js`** — asserts each page builds with a self-canonical URL.

## Verification

- `pnpm run format` / `pnpm run lint` — clean (only pre-existing warnings)
- `pnpm run build` — six pages prerendered as static SSG
- `pnpm test` — 342 passed

Refs #189

---
_Generated by [Claude Code](https://claude.ai/code/session_01X4omPQW2ErDyZsMtxypuMe)_