### PR TITLE
feat: add volunteer recognition badge system (#336)

### DIFF
--- a/__tests__/recognition.test.ts
+++ b/__tests__/recognition.test.ts
@@ -1,0 +1,58 @@
+import {
+  RECOGNITION_TIERS,
+  RECOGNIZED_VOLUNTEERS,
+  getTier,
+  publicVolunteers,
+  recognitionAggregate,
+} from '../src/data/recognition'
+
+describe('Volunteer recognition data model (#336)', () => {
+  it('has six tiers with unique, sequential ids', () => {
+    const ids = RECOGNITION_TIERS.map((t) => t.id)
+    expect(ids).toEqual([1, 2, 3, 4, 5, 6])
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it('maps tiers 1:1 to GitHub access roles in ascending order', () => {
+    const roles = RECOGNITION_TIERS.map((t) => t.role)
+    expect(roles).toEqual(['none', 'read', 'triage', 'write', 'maintain', 'admin'])
+  })
+
+  it('every tier defines grants and criteria and a ladder alignment', () => {
+    for (const t of RECOGNITION_TIERS) {
+      expect(t.grants.length).toBeGreaterThan(0)
+      expect(t.criteria.length).toBeGreaterThan(0)
+      expect(t.ladderAlignment.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('getTier resolves by id', () => {
+    expect(getTier(1)?.name).toBe('Spark')
+    expect(getTier(6)?.name).toBe('Captain')
+    expect(getTier(99)).toBeUndefined()
+  })
+
+  it('every recognized volunteer references a real tier', () => {
+    for (const v of RECOGNIZED_VOLUNTEERS) {
+      expect(getTier(v.tierId)).toBeDefined()
+      expect(v.since).toMatch(/^\d{4}-\d{2}$/)
+    }
+  })
+
+  it('publicVolunteers only returns opt-in entries, highest tier first', () => {
+    const pub = publicVolunteers()
+    expect(pub.every((v) => v.publicOptIn)).toBe(true)
+    for (let i = 1; i < pub.length; i++) {
+      expect(pub[i - 1].tierId).toBeGreaterThanOrEqual(pub[i].tierId)
+    }
+  })
+
+  it('aggregate counts lifetime and slices by year', () => {
+    const agg = recognitionAggregate(new Date('2026-06-06T00:00:00Z'))
+    expect(agg.lifetime).toBe(RECOGNIZED_VOLUNTEERS.length)
+    const total = agg.byYear.reduce((sum, y) => sum + y.count, 0)
+    expect(total).toBe(RECOGNIZED_VOLUNTEERS.length)
+    expect(agg.thisYear).toBeLessThanOrEqual(agg.lifetime)
+    expect(agg.thisMonth).toBeLessThanOrEqual(agg.thisYear)
+  })
+})

--- a/__tests__/route-generation.test.js
+++ b/__tests__/route-generation.test.js
@@ -110,6 +110,23 @@ describe('Route Generation Tests', () => {
     })
   })
 
+  describe('Test Case 4.2b: Volunteer Recognition Page', () => {
+    const pagePath = path.join(outDir, 'recognition', 'index.html')
+
+    it('should generate index.html for the recognition page', () => {
+      expect(fs.existsSync(pagePath)).toBe(true)
+    })
+
+    it('should set a self-canonical URL', () => {
+      if (fs.existsSync(pagePath)) {
+        const content = fs.readFileSync(pagePath, 'utf-8')
+        expect(content).toContain(
+          '<link rel="canonical" href="https://ffcadmin.org/recognition/"/>'
+        )
+      }
+    })
+  })
+
   describe('Test Case 4.3a: New Volunteer Training Tracks', () => {
     const trackSlugs = ['google-workspace-admin', 'data-analytics']
 

--- a/src/app/recognition/page.tsx
+++ b/src/app/recognition/page.tsx
@@ -1,0 +1,243 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import Breadcrumbs from '@/components/Breadcrumbs'
+import {
+  RECOGNITION_TIERS,
+  getTier,
+  publicVolunteers,
+  recognitionAggregate,
+} from '@/data/recognition'
+
+export const metadata: Metadata = {
+  title: 'Volunteer Recognition',
+  description:
+    'Free For Charity recognizes sustained volunteer work with warm, progression-based badges that map 1:1 to GitHub access roles. Validated manually against commit history and charity-board certification.',
+  keywords:
+    'volunteer recognition, contributor badges, nonprofit volunteer awards, GitHub roles, Free For Charity recognition',
+  alternates: {
+    canonical: 'https://ffcadmin.org/recognition/',
+  },
+}
+
+export default function RecognitionPage() {
+  const tiers = RECOGNITION_TIERS
+  const volunteers = publicVolunteers()
+  const agg = recognitionAggregate()
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Breadcrumbs items={[{ label: 'Home', href: '/' }, { label: 'Recognition' }]} />
+
+      {/* Hero */}
+      <div className="bg-gradient-to-r from-amber-500 via-orange-500 to-rose-500 text-white py-16 px-4 sm:px-6 lg:px-8">
+        <div className="max-w-5xl mx-auto">
+          <div className="flex items-center mb-4">
+            <span className="text-5xl mr-4" aria-hidden="true">
+              🏅
+            </span>
+            <div>
+              <h1 className="text-3xl md:text-4xl font-bold">Volunteer Recognition</h1>
+              <p className="text-amber-50 text-sm mt-1">
+                Earned by real contributions — never self-claimed
+              </p>
+            </div>
+          </div>
+          <p className="text-amber-50 text-lg max-w-3xl">
+            We recognize sustained volunteer work with warm, progression-based badges. Each badge
+            maps <strong>one-to-one to a GitHub access role</strong>, so your recognition and the
+            rights you hold grow together — mirroring the{' '}
+            <Link href="/contributor-ladder" className="underline">
+              Contributor Ladder
+            </Link>
+            .
+          </p>
+        </div>
+      </div>
+
+      <main className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        {/* Aggregate */}
+        <section className="mb-12">
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+            <div className="bg-white rounded-xl shadow border border-gray-200 p-6 text-center">
+              <div className="text-4xl font-bold text-gray-900">{agg.lifetime}</div>
+              <div className="text-sm text-gray-600 mt-1">Recognized volunteers (lifetime)</div>
+            </div>
+            <div className="bg-white rounded-xl shadow border border-gray-200 p-6 text-center">
+              <div className="text-4xl font-bold text-gray-900">{agg.thisYear}</div>
+              <div className="text-sm text-gray-600 mt-1">Recognized this year</div>
+            </div>
+            <div className="bg-white rounded-xl shadow border border-gray-200 p-6 text-center">
+              <div className="text-4xl font-bold text-gray-900">{agg.thisMonth}</div>
+              <div className="text-sm text-gray-600 mt-1">Recognized this month</div>
+            </div>
+          </div>
+          <p className="text-xs text-gray-500 mt-3">
+            An always-rolling count for annual reporting, sliced by month, year, and lifetime. The
+            aggregate includes every recognized volunteer; names below are shown only with consent.
+          </p>
+        </section>
+
+        {/* Badge tiers */}
+        <section className="mb-12">
+          <h2 className="text-2xl font-bold text-gray-900 mb-2">Badge tiers</h2>
+          <p className="text-gray-600 text-sm mb-6">
+            Six tiers, each mapped to the GitHub access role it grants. You move up as your
+            contribution history grows and the board certifies your work.
+          </p>
+          <div className="space-y-4">
+            {tiers.map((tier) => (
+              <div
+                key={tier.id}
+                className="bg-white rounded-xl shadow border border-gray-200 overflow-hidden"
+              >
+                <div
+                  className={`bg-gradient-to-r ${tier.gradient} p-4 flex items-center gap-3 text-white`}
+                >
+                  <span className="text-3xl" aria-hidden="true">
+                    {tier.icon}
+                  </span>
+                  <div>
+                    <div className="flex items-center gap-2">
+                      <h3 className="text-lg font-bold">
+                        {tier.id}. {tier.name}
+                      </h3>
+                      <span className="text-[11px] font-bold uppercase tracking-wide bg-white/20 px-2 py-0.5 rounded">
+                        {tier.githubRole}
+                      </span>
+                    </div>
+                    <p className="text-white/90 text-sm">{tier.blurb}</p>
+                  </div>
+                </div>
+                <div className="p-5 grid grid-cols-1 md:grid-cols-2 gap-6">
+                  <div>
+                    <h4 className="text-sm font-bold text-gray-900 mb-2">What this role grants</h4>
+                    <ul className="space-y-1.5 text-sm text-gray-700">
+                      {tier.grants.map((g) => (
+                        <li key={g} className="flex items-start">
+                          <span className="text-blue-600 mr-2 mt-0.5">&#8226;</span>
+                          <span>{g}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                  <div>
+                    <h4 className="text-sm font-bold text-gray-900 mb-2">How it&apos;s earned</h4>
+                    <ul className="space-y-1.5 text-sm text-gray-700">
+                      {tier.criteria.map((c) => (
+                        <li key={c} className="flex items-start">
+                          <span className="text-emerald-600 mr-2 mt-0.5">&#10003;</span>
+                          <span>{c}</span>
+                        </li>
+                      ))}
+                    </ul>
+                    <p className="text-xs text-gray-500 mt-3">
+                      Ladder alignment:{' '}
+                      <span className="font-semibold text-gray-700">{tier.ladderAlignment}</span>
+                    </p>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* Validation model */}
+        <section className="mb-12 bg-white rounded-xl shadow-lg p-6 md:p-8 border border-gray-200">
+          <h2 className="text-2xl font-bold text-gray-900 mb-4">How recognition is validated</h2>
+          <p className="text-gray-700 text-sm mb-4">
+            Badges are awarded by maintainers — never self-claimed. Every award is validated against
+            two independent sources of truth:
+          </p>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
+              <h3 className="text-sm font-bold text-blue-900 mb-1">1. GitHub commit history</h3>
+              <p className="text-sm text-blue-900/80">
+                Your merged contributions are the public, tamper-evident record of the work you did.
+              </p>
+            </div>
+            <div className="bg-emerald-50 border border-emerald-200 rounded-lg p-4">
+              <h3 className="text-sm font-bold text-emerald-900 mb-1">
+                2. Charity-board certification
+              </h3>
+              <p className="text-sm text-emerald-900/80">
+                The charity board (or FFC) directly certifies the contribution and its impact.
+              </p>
+            </div>
+          </div>
+          <p className="text-xs text-gray-500 mt-4">
+            Recognized volunteers are recorded in a committed data file (
+            <code className="bg-gray-100 px-1 py-0.5 rounded">src/data/recognition.ts</code>),
+            updated by maintainers. This also feeds the military volunteer pathway —{' '}
+            <Link href="/volunteer/military-volunteers" className="text-blue-600 underline">
+              MOVSM
+            </Link>{' '}
+            — where certified hours matter.
+          </p>
+        </section>
+
+        {/* Honor roll */}
+        <section className="bg-white rounded-xl shadow-lg p-6 md:p-8 border border-gray-200">
+          <h2 className="text-2xl font-bold text-gray-900 mb-2">Recognized volunteers</h2>
+          <p className="text-gray-600 text-sm mb-6">
+            Shown with each volunteer&apos;s consent. Recognition is opt-in — volunteers can be
+            counted in the aggregate above without appearing here.
+          </p>
+          {volunteers.length === 0 ? (
+            <p className="text-sm text-gray-600">
+              Our public honor roll is being assembled. Check back soon.
+            </p>
+          ) : (
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              {volunteers.map((v) => {
+                const tier = getTier(v.tierId)
+                return (
+                  <div
+                    key={v.name}
+                    className="flex items-center gap-3 rounded-lg border border-gray-200 p-4"
+                  >
+                    <span
+                      className={`flex-shrink-0 w-12 h-12 rounded-full bg-gradient-to-br ${tier?.gradient ?? 'from-gray-400 to-gray-500'} flex items-center justify-center text-2xl`}
+                      aria-hidden="true"
+                    >
+                      {tier?.icon ?? '🏅'}
+                    </span>
+                    <div className="min-w-0">
+                      <p className="font-semibold text-gray-900">
+                        {v.githubHandle ? (
+                          <a
+                            href={`https://github.com/${v.githubHandle}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="hover:text-blue-700"
+                          >
+                            {v.name}
+                          </a>
+                        ) : (
+                          v.name
+                        )}
+                      </p>
+                      <p className="text-xs text-gray-600">
+                        <span className="font-medium">{tier?.name}</span>
+                        {tier ? ` · ${tier.githubRole}` : ''}
+                      </p>
+                      {v.roles.length > 0 && (
+                        <p className="text-xs text-gray-500 mt-0.5">{v.roles.join(', ')}</p>
+                      )}
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          )}
+          <div className="mt-6 text-sm text-gray-600">
+            Want to be recognized?{' '}
+            <Link href="/get-involved" className="text-blue-600 underline hover:text-blue-800">
+              Start contributing
+            </Link>{' '}
+            — your merged work builds the commit history we recognize.
+          </div>
+        </section>
+      </main>
+    </div>
+  )
+}

--- a/src/app/recognition/page.tsx
+++ b/src/app/recognition/page.tsx
@@ -192,7 +192,7 @@ export default function RecognitionPage() {
                 const tier = getTier(v.tierId)
                 return (
                   <div
-                    key={v.name}
+                    key={v.githubHandle ?? `${v.name}-${v.since}`}
                     className="flex items-center gap-3 rounded-lg border border-gray-200 p-4"
                   >
                     <span

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -75,6 +75,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.7,
     },
     {
+      url: `${SITE_URL}/recognition/`,
+      lastModified: now,
+      changeFrequency: 'monthly',
+      priority: 0.6,
+    },
+    {
       url: `${SITE_URL}/site-owner/`,
       lastModified: now,
       changeFrequency: 'monthly',

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -40,6 +40,16 @@ export const trainingDropdown: NavDropdown = {
       description: 'Microsoft 365 Global Administrator certification path.',
     },
     {
+      label: 'Google Workspace Admin',
+      href: '/training/google-workspace-admin',
+      description: 'Manage Google Workspace for charities, backed by certification.',
+    },
+    {
+      label: 'Data & Analytics',
+      href: '/training/data-analytics',
+      description: 'GA4, dashboards, and impact reporting for nonprofits.',
+    },
+    {
       label: 'Canva Designer',
       href: '/canva-designer-path',
       description: 'Canva Designer certification path for nonprofits.',
@@ -48,6 +58,11 @@ export const trainingDropdown: NavDropdown = {
       label: 'Contributor Ladder',
       href: '/contributor-ladder',
       description: 'Progress from Contributor to Maintainer to Mentor.',
+    },
+    {
+      label: 'Recognition',
+      href: '/recognition',
+      description: 'Volunteer badges that map 1:1 to GitHub access roles.',
     },
   ],
 }

--- a/src/data/recognition.ts
+++ b/src/data/recognition.ts
@@ -218,8 +218,11 @@ export interface RecognitionAggregate {
  * broken down further later.
  */
 export function recognitionAggregate(now: Date = new Date()): RecognitionAggregate {
-  const year = String(now.getFullYear())
-  const month = `${year}-${String(now.getMonth() + 1).padStart(2, '0')}`
+  // Derive the slice from the UTC date so results don't depend on the runtime
+  // timezone (build server / test runner) around month/year boundaries.
+  const iso = now.toISOString() // YYYY-MM-DDTHH:mm:ss.sssZ
+  const year = iso.slice(0, 4)
+  const month = iso.slice(0, 7)
 
   const byYearMap = new Map<string, number>()
   for (const v of RECOGNIZED_VOLUNTEERS) {

--- a/src/data/recognition.ts
+++ b/src/data/recognition.ts
@@ -1,0 +1,238 @@
+/**
+ * Volunteer recognition / badge system (#336).
+ *
+ * Design decisions (owner, recorded on the issue):
+ *  - Taxonomy is a warm "Growth + Crew" blend with a clear progression.
+ *  - Badge tiers map **1:1 to GitHub access roles**, so each tier grants the
+ *    exact corresponding rights/permissions and mirrors the Contributor Ladder.
+ *    Start (public-repo work) → Read → Triage → Write → Maintain → Admin.
+ *  - Validation is **manual**: contribution evidence in **GitHub commit history**
+ *    plus **direct charity-board certification**. There is no self-service claim.
+ *  - This committed file is the **single source of truth**. Maintainers add
+ *    recognized volunteers here; nothing is awarded automatically.
+ *  - Display is **opt-in public** per volunteer (name + badges) PLUS an
+ *    always-rolling **aggregate** (per-month / per-year / lifetime) for reports.
+ */
+
+/** GitHub access roles, lowest to highest. */
+export type GitHubRole = 'none' | 'read' | 'triage' | 'write' | 'maintain' | 'admin'
+
+export interface RecognitionTier {
+  /** 1 = entry, ascending. Doubles as the ladder rung number. */
+  id: number
+  /** Warm badge name (Growth + Crew blend). */
+  name: string
+  /** Human label for the GitHub access role this tier maps to 1:1. */
+  githubRole: string
+  /** The raw GitHub role key. */
+  role: GitHubRole
+  /** One-line description of who holds this badge. */
+  blurb: string
+  /** Exactly what the mapped GitHub role grants. */
+  grants: string[]
+  /** How the badge is earned (commit history + board certification). */
+  criteria: string[]
+  /** The Contributor Ladder rung this aligns with. */
+  ladderAlignment: string
+  icon: string
+  gradient: string
+}
+
+/**
+ * Badge tiers. Each maps 1:1 to a GitHub access role; `grants` reflects the
+ * permissions GitHub attaches to that role.
+ */
+export const RECOGNITION_TIERS: RecognitionTier[] = [
+  {
+    id: 1,
+    name: 'Spark',
+    githubRole: 'Public contributor (no special access)',
+    role: 'none',
+    blurb: 'Your first contributions, made from public forks — no special access needed.',
+    grants: [
+      'Fork public repositories and open pull requests',
+      'Comment on issues and pull requests',
+      'No write access to FFC repositories',
+    ],
+    criteria: [
+      'At least one merged pull request in your commit history',
+      'Followed the code of conduct and contribution guidelines',
+    ],
+    ladderAlignment: 'Contributor',
+    icon: '✨',
+    gradient: 'from-sky-500 to-blue-600',
+  },
+  {
+    id: 2,
+    name: 'Crew',
+    githubRole: 'Read (organization member)',
+    role: 'read',
+    blurb: 'Welcomed into the org as a member with read access across FFC repositories.',
+    grants: [
+      'Read and clone organization repositories',
+      'Be @-mentioned and added to teams',
+      'Open issues and pull requests from branches',
+    ],
+    criteria: [
+      'A few merged contributions evidenced in commit history',
+      'Board/maintainer confirmation you are an active volunteer',
+    ],
+    ladderAlignment: 'Contributor → Unpaid Intern',
+    icon: '🧭',
+    gradient: 'from-teal-500 to-emerald-600',
+  },
+  {
+    id: 3,
+    name: 'Trusted Crew',
+    githubRole: 'Triage',
+    role: 'triage',
+    blurb: 'Trusted to help manage the backlog and keep contributions moving.',
+    grants: [
+      'Everything Read grants, plus:',
+      'Label, assign, and close issues and pull requests',
+      'Request pull-request reviews and apply milestones',
+    ],
+    criteria: [
+      'Sustained, reviewed contributions in commit history',
+      'Demonstrated good judgement triaging others’ work',
+      'Board/maintainer certification',
+    ],
+    ladderAlignment: 'Unpaid Intern',
+    icon: '🛟',
+    gradient: 'from-cyan-500 to-teal-600',
+  },
+  {
+    id: 4,
+    name: 'Builder',
+    githubRole: 'Write',
+    role: 'write',
+    blurb: 'Ships directly: pushes branches and merges reviewed work.',
+    grants: [
+      'Everything Triage grants, plus:',
+      'Push to branches and merge approved pull requests',
+      'Manage releases and edit repository wikis',
+    ],
+    criteria: [
+      'A solid body of merged work in commit history',
+      'Relevant certification (MS-900, GitHub Foundations, Canva, GA4, or Workspace)',
+      'Board/maintainer certification',
+    ],
+    ladderAlignment: 'Paid Intern',
+    icon: '🔧',
+    gradient: 'from-indigo-500 to-purple-600',
+  },
+  {
+    id: 5,
+    name: 'Steward',
+    githubRole: 'Maintain',
+    role: 'maintain',
+    blurb: 'Maintains repositories and guides the next generation of contributors.',
+    grants: [
+      'Everything Write grants, plus:',
+      'Manage repository settings (except destructive/admin actions)',
+      'Manage branch protection and repository topics',
+    ],
+    criteria: [
+      'A long, consistent contribution history',
+      'Mentored other contributors through their growth',
+      'Board/maintainer certification',
+    ],
+    ladderAlignment: 'Mentor',
+    icon: '🌳',
+    gradient: 'from-orange-500 to-amber-600',
+  },
+  {
+    id: 6,
+    name: 'Captain',
+    githubRole: 'Admin',
+    role: 'admin',
+    blurb: 'Owns the platform: full administrative authority across the organization.',
+    grants: [
+      'Everything Maintain grants, plus:',
+      'Full repository administration and team management',
+      'Manage organization members, roles, and security policy',
+    ],
+    criteria: [
+      'Demonstrated excellence as a Steward over time',
+      'Trusted with organization-wide administration',
+      'Board certification',
+    ],
+    ladderAlignment: 'Maintainer',
+    icon: '⚓',
+    gradient: 'from-rose-500 to-red-600',
+  },
+]
+
+export interface RecognizedVolunteer {
+  name: string
+  /** GitHub handle, used to point at commit-history evidence. */
+  githubHandle?: string
+  /** Only rendered publicly when true (opt-in). */
+  publicOptIn: boolean
+  /** Highest RecognitionTier id reached. */
+  tierId: number
+  /** Volunteer role badges earned (matches the volunteer-roles taxonomy). */
+  roles: string[]
+  /** First recognized, as YYYY-MM (drives the rolling aggregate). */
+  since: string
+}
+
+/**
+ * Recognized volunteers (maintainer-curated; manual validation only).
+ *
+ * Seeded with the FFC founder. Maintainers append new, board-certified
+ * volunteers here as they are recognized — set `publicOptIn: false` to count a
+ * volunteer in the aggregate without listing their name publicly.
+ */
+export const RECOGNIZED_VOLUNTEERS: RecognizedVolunteer[] = [
+  {
+    name: 'Clarke Moyer',
+    githubHandle: 'clarkemoyer',
+    publicOptIn: true,
+    tierId: 6,
+    roles: ['Global Administrator'],
+    since: '2013-01',
+  },
+]
+
+export function getTier(id: number): RecognitionTier | undefined {
+  return RECOGNITION_TIERS.find((t) => t.id === id)
+}
+
+/** Volunteers who opted in to public display, highest tier first. */
+export function publicVolunteers(): RecognizedVolunteer[] {
+  return RECOGNIZED_VOLUNTEERS.filter((v) => v.publicOptIn).sort((a, b) => b.tierId - a.tierId)
+}
+
+export interface RecognitionAggregate {
+  lifetime: number
+  thisYear: number
+  thisMonth: number
+  /** Recognized-volunteer count per calendar year, ascending by year. */
+  byYear: { year: string; count: number }[]
+}
+
+/**
+ * Always-rolling aggregate for annual reports. Counts every recognized
+ * volunteer (opt-in or not); designed so month/year/lifetime slices can be
+ * broken down further later.
+ */
+export function recognitionAggregate(now: Date = new Date()): RecognitionAggregate {
+  const year = String(now.getFullYear())
+  const month = `${year}-${String(now.getMonth() + 1).padStart(2, '0')}`
+
+  const byYearMap = new Map<string, number>()
+  for (const v of RECOGNIZED_VOLUNTEERS) {
+    const y = v.since.slice(0, 4)
+    byYearMap.set(y, (byYearMap.get(y) ?? 0) + 1)
+  }
+
+  return {
+    lifetime: RECOGNIZED_VOLUNTEERS.length,
+    thisYear: RECOGNIZED_VOLUNTEERS.filter((v) => v.since.startsWith(year)).length,
+    thisMonth: RECOGNIZED_VOLUNTEERS.filter((v) => v.since === month).length,
+    byYear: [...byYearMap.entries()]
+      .map(([y, count]) => ({ year: y, count }))
+      .sort((a, b) => a.year.localeCompare(b.year)),
+  }
+}


### PR DESCRIPTION
## Summary

Implements the volunteer recognition / badge system (#336) per the owner's recorded decisions:

- **Warm "Growth + Crew" taxonomy** with clear progression.
- **Badge tiers map 1:1 to GitHub access roles**, so each tier grants the exact corresponding rights and mirrors the Contributor Ladder: Spark (public-repo, no access) → Crew (Read) → Trusted Crew (Triage) → Builder (Write) → Steward (Maintain) → Captain (Admin).
- **Manual validation only** — against (1) GitHub commit history and (2) charity-board certification. No self-service claims.
- **Opt-in public** per-volunteer display, **plus** an always-rolling **aggregate** (per-month / per-year / lifetime) for annual reports.
- **Committed source of truth**: `src/data/recognition.ts`, maintainer-updated.

## Changes

- **`src/data/recognition.ts`** — `RECOGNITION_TIERS` (six tiers, each with `role`, `grants`, `criteria`, `ladderAlignment`), `RECOGNIZED_VOLUNTEERS` (seeded with the founder; `publicOptIn` controls public listing), and helpers (`getTier`, `publicVolunteers`, `recognitionAggregate`).
- **`/recognition` page** — aggregate stat cards, per-tier "what this role grants" + "how it's earned" with ladder alignment, the two-source validation model, and an opt-in public honor roll. Cross-links the Contributor Ladder and the MOVSM pathway.
- **Navigation** — adds Recognition to the Training dropdown, and (sync gap from #338) the two new tracks Google Workspace Admin and Data & Analytics.
- **Sitemap** + **tests**: a `recognition` data-model test (tier↔role mapping, aggregate math) and a route-generation test for the page.

## Verification
- `pnpm run lint` — clean (pre-existing warnings only)
- `pnpm run build` — `/recognition` prerenders as static
- `pnpm test` — 353 passed

Refs #186. Recognition badges for the new roles (#338) are supported by the role-badge field.

Closes #336

---
_Generated by [Claude Code](https://claude.ai/code/session_01X4omPQW2ErDyZsMtxypuMe)_