### PR TITLE
refactor: replace bare internal a-href links with next/link (#268)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -22,6 +22,19 @@ export default defineConfig([
   {
     rules: {
       'react/no-unescaped-entities': 'off',
+      // Internal navigation must use next/link so links respect basePath
+      // (e.g. NEXT_PUBLIC_BASE_PATH). Bare <a href="/..."> breaks under a
+      // configured basePath. External, mailto/tel/sms, and #anchor links are
+      // unaffected because their href does not start with "/". (#268)
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector:
+            'JSXOpeningElement[name.name="a"]:has(JSXAttribute[name.name="href"] Literal[value=/^\\//])',
+          message:
+            'Use <Link> from next/link for internal links (href starting with "/") so they respect basePath. Bare <a href="/..."> breaks under a configured basePath.',
+        },
+      ],
     },
   },
   {

--- a/src/app/contributor-ladder/page.tsx
+++ b/src/app/contributor-ladder/page.tsx
@@ -422,7 +422,7 @@ export default function ContributorLadder() {
             training programs and start making an impact today.
           </p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
-            <a
+            <Link
               href="/training-plan"
               className="inline-flex items-center justify-center px-8 py-4 bg-gradient-to-r from-blue-600 to-indigo-600 text-white rounded-lg font-semibold hover:from-blue-700 hover:to-indigo-700 transition-all shadow-lg hover:shadow-xl"
             >
@@ -441,8 +441,8 @@ export default function ContributorLadder() {
                   d="M13 7l5 5m0 0l-5 5m5-5H6"
                 />
               </svg>
-            </a>
-            <a
+            </Link>
+            <Link
               href="/canva-designer-path"
               className="inline-flex items-center justify-center px-8 py-4 bg-gradient-to-r from-pink-600 to-purple-600 text-white rounded-lg font-semibold hover:from-pink-700 hover:to-purple-700 transition-all shadow-lg hover:shadow-xl"
             >
@@ -461,7 +461,7 @@ export default function ContributorLadder() {
                   d="M13 7l5 5m0 0l-5 5m5-5H6"
                 />
               </svg>
-            </a>
+            </Link>
           </div>
         </div>
       </section>
@@ -474,12 +474,12 @@ export default function ContributorLadder() {
           </p>
           <p className="text-gray-700">
             The WordPress-era core-competencies curriculum is preserved at{' '}
-            <a
+            <Link
               href="/legacy-wordpress-administration/wordpress-volunteer-core-competencies"
               className="text-blue-600 underline hover:text-blue-800"
             >
               wordpress-volunteer-core-competencies
-            </a>{' '}
+            </Link>{' '}
             — seven core competencies (LastPass, AI assistants, MS-900, MS-700, OneDrive, Planner,
             M365 Apps) covering 33–46 hours of self-study. Use it as supplemental reading when
             moving through the modern contributor ladder.

--- a/src/app/cookie-policy/page.tsx
+++ b/src/app/cookie-policy/page.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link'
 import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
@@ -349,9 +350,9 @@ export default function CookiePolicy() {
               <h2 className="text-2xl font-bold text-gray-900 mb-4">8. More Information</h2>
               <p className="mb-4">
                 For more information about how we handle your personal data, please see our{' '}
-                <a href="/privacy-policy" className="text-blue-600 hover:underline">
+                <Link href="/privacy-policy" className="text-blue-600 hover:underline">
                   Privacy Policy
-                </a>
+                </Link>
                 .
               </p>
             </section>

--- a/src/app/guides/wordpress-to-nextjs-guide/page.tsx
+++ b/src/app/guides/wordpress-to-nextjs-guide/page.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link'
 import type { Metadata } from 'next'
 import Breadcrumbs from '@/components/Breadcrumbs'
 
@@ -1855,30 +1856,30 @@ export default function WordPressToNextJSGuide() {
             <h3 className="font-bold text-gray-900 mb-3">FFC Admin Documentation</h3>
             <ul className="space-y-2 text-sm text-gray-700">
               <li>
-                <a href="/documentation" className="text-blue-600 underline hover:text-blue-800">
+                <Link href="/documentation" className="text-blue-600 underline hover:text-blue-800">
                   Documentation Center
-                </a>
+                </Link>
                 <span className="text-gray-500"> &mdash; All admin portal documentation</span>
               </li>
               <li>
-                <a href="/tech-stack" className="text-blue-600 underline hover:text-blue-800">
+                <Link href="/tech-stack" className="text-blue-600 underline hover:text-blue-800">
                   Tech Stack Overview
-                </a>
+                </Link>
                 <span className="text-gray-500"> &mdash; Complete technology stack details</span>
               </li>
               <li>
-                <a href="/sites-list" className="text-blue-600 underline hover:text-blue-800">
+                <Link href="/sites-list" className="text-blue-600 underline hover:text-blue-800">
                   Sites List
-                </a>
+                </Link>
                 <span className="text-gray-500">
                   {' '}
                   &mdash; All managed charity domains and health status
                 </span>
               </li>
               <li>
-                <a href="/testing" className="text-blue-600 underline hover:text-blue-800">
+                <Link href="/testing" className="text-blue-600 underline hover:text-blue-800">
                   Testing Documentation
-                </a>
+                </Link>
                 <span className="text-gray-500"> &mdash; Test suites and quality assurance</span>
               </li>
             </ul>
@@ -1942,12 +1943,12 @@ export default function WordPressToNextJSGuide() {
           </p>
           <p className="mt-4 text-sm text-gray-600">
             For the WordPress side that this guide migrates <em>away</em> from, see the{' '}
-            <a
+            <Link
               href="/legacy-wordpress-administration"
               className="text-blue-600 underline hover:text-blue-800"
             >
               Legacy WordPress Administration hub
-            </a>{' '}
+            </Link>{' '}
             — operations runbook covering hosting, domains, charity onboarding, and the legacy
             volunteer training curriculum that this conversion guide replaces.
           </p>

--- a/src/app/legacy-wordpress-administration/wordpress-charity-offboarding/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-charity-offboarding/page.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link'
 import type { Metadata } from 'next'
 import HowToSchema from '@/components/legacy-wordpress-administration/HowToSchema'
 import LeafPageShell from '@/components/legacy-wordpress-administration/LeafPageShell'
@@ -133,19 +134,19 @@ export default function Page() {
       <h2>Cross-references</h2>
       <ul>
         <li>
-          <a href="/legacy-wordpress-administration/wordpress-domains/">wordpress-domains</a> — the
-          registration flow this reverses (transfer-out, EPP codes, WHOIS privacy).
+          <Link href="/legacy-wordpress-administration/wordpress-domains/">wordpress-domains</Link>{' '}
+          — the registration flow this reverses (transfer-out, EPP codes, WHOIS privacy).
         </li>
         <li>
-          <a href="/legacy-wordpress-administration/wordpress-cpanel-backup-sop/">
+          <Link href="/legacy-wordpress-administration/wordpress-cpanel-backup-sop/">
             wordpress-cpanel-backup-sop
-          </a>{' '}
+          </Link>{' '}
           — the final backup before archival.
         </li>
         <li>
-          <a href="/legacy-wordpress-administration/wordpress-service-delivery-stages/">
+          <Link href="/legacy-wordpress-administration/wordpress-service-delivery-stages/">
             wordpress-service-delivery-stages
-          </a>{' '}
+          </Link>{' '}
           — offboarding closes this lifecycle.
         </li>
       </ul>

--- a/src/app/legacy-wordpress-administration/wordpress-charity-validation/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-charity-validation/page.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link'
 import type { Metadata } from 'next'
 import LeafPageShell from '@/components/legacy-wordpress-administration/LeafPageShell'
 import { getLegacyWpAdminPageBySlug } from '@/data/legacy-wordpress-administration'
@@ -209,9 +210,9 @@ export default function Page() {
       <p>
         Validation runs during <strong>Stage 1 — Intake</strong> in the FFC service-delivery
         lifecycle. See{' '}
-        <a href="/legacy-wordpress-administration/wordpress-service-delivery-stages/">
+        <Link href="/legacy-wordpress-administration/wordpress-service-delivery-stages/">
           service delivery stages
-        </a>{' '}
+        </Link>{' '}
         for how this fits into the broader engagement.
       </p>
 

--- a/src/app/legacy-wordpress-administration/wordpress-cpanel-backup-sop/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-cpanel-backup-sop/page.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link'
 import type { Metadata } from 'next'
 import HowToSchema from '@/components/legacy-wordpress-administration/HowToSchema'
 import LeafPageShell from '@/components/legacy-wordpress-administration/LeafPageShell'
@@ -126,9 +127,9 @@ export default function Page() {
           <li>Block ~90 minutes of uninterrupted time — full backups can take 30-90 minutes.</li>
           <li>
             New to FFC&apos;s hosting layers? Read{' '}
-            <a href="/legacy-wordpress-administration/wordpress-hosting-techstack/">
+            <Link href="/legacy-wordpress-administration/wordpress-hosting-techstack/">
               wordpress-hosting-techstack
-            </a>{' '}
+            </Link>{' '}
             first.
           </li>
         </ul>

--- a/src/app/legacy-wordpress-administration/wordpress-domains/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-domains/page.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link'
 import type { Metadata } from 'next'
 import HowToSchema from '@/components/legacy-wordpress-administration/HowToSchema'
 import LeafPageShell from '@/components/legacy-wordpress-administration/LeafPageShell'
@@ -185,30 +186,30 @@ export default function Page() {
       <p>
         Once the domain resolves through Cloudflare, the charity moves to Microsoft 365 Business
         Premium for email — free for verified 501(c)(3) organizations, up to 10 mailboxes. See{' '}
-        <a href="/legacy-wordpress-administration/wordpress-online-impacts-onboarding/">
+        <Link href="/legacy-wordpress-administration/wordpress-online-impacts-onboarding/">
           wordpress-online-impacts-onboarding
-        </a>{' '}
+        </Link>{' '}
         for the M365 provisioning steps.
       </p>
 
       <h2>Cross-references</h2>
       <ul>
         <li>
-          <a href="/legacy-wordpress-administration/wordpress-web-hosting/">
+          <Link href="/legacy-wordpress-administration/wordpress-web-hosting/">
             wordpress-web-hosting
-          </a>{' '}
+          </Link>{' '}
           — host setup that pairs with this domain registration.
         </li>
         <li>
-          <a href="/legacy-wordpress-administration/wordpress-hosting-techstack/">
+          <Link href="/legacy-wordpress-administration/wordpress-hosting-techstack/">
             wordpress-hosting-techstack
-          </a>{' '}
+          </Link>{' '}
           — DNS / SSL layer.
         </li>
         <li>
-          <a href="/legacy-wordpress-administration/wordpress-service-delivery-stages/">
+          <Link href="/legacy-wordpress-administration/wordpress-service-delivery-stages/">
             wordpress-service-delivery-stages
-          </a>{' '}
+          </Link>{' '}
           — Stage 4-5 (Basic Services + Charity System & Website Setup).
         </li>
       </ul>

--- a/src/app/legacy-wordpress-administration/wordpress-escalation-runbook/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-escalation-runbook/page.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link'
 import type { Metadata } from 'next'
 import LeafPageShell from '@/components/legacy-wordpress-administration/LeafPageShell'
 import {
@@ -175,15 +176,15 @@ export default function Page() {
       <h2>Cross-references</h2>
       <ul>
         <li>
-          <a href="/legacy-wordpress-administration/wordpress-hosting-techstack/">
+          <Link href="/legacy-wordpress-administration/wordpress-hosting-techstack/">
             wordpress-hosting-techstack
-          </a>{' '}
+          </Link>{' '}
           — the layered stack so you know which vendor owns a given failure.
         </li>
         <li>
-          <a href="/legacy-wordpress-administration/wordpress-web-hosting/">
+          <Link href="/legacy-wordpress-administration/wordpress-web-hosting/">
             wordpress-web-hosting
-          </a>{' '}
+          </Link>{' '}
           — host-level operations.
         </li>
       </ul>

--- a/src/app/legacy-wordpress-administration/wordpress-guidestar-guide/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-guidestar-guide/page.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link'
 import type { Metadata } from 'next'
 import LeafPageShell from '@/components/legacy-wordpress-administration/LeafPageShell'
 import { getLegacyWpAdminPageBySlug } from '@/data/legacy-wordpress-administration'
@@ -180,16 +181,16 @@ export default function Page() {
       <ul>
         <li>
           Charity validation gate that requires this seal:{' '}
-          <a href="/legacy-wordpress-administration/wordpress-charity-validation/">
+          <Link href="/legacy-wordpress-administration/wordpress-charity-validation/">
             wordpress-charity-validation
-          </a>
+          </Link>
           .
         </li>
         <li>
           Stage where this typically blocks delivery:{' '}
-          <a href="/legacy-wordpress-administration/wordpress-service-delivery-stages/">
+          <Link href="/legacy-wordpress-administration/wordpress-service-delivery-stages/">
             wordpress-service-delivery-stages
-          </a>
+          </Link>
           .
         </li>
       </ul>

--- a/src/app/legacy-wordpress-administration/wordpress-hosting-techstack/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-hosting-techstack/page.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link'
 import type { Metadata } from 'next'
 import LeafPageShell from '@/components/legacy-wordpress-administration/LeafPageShell'
 import {
@@ -202,9 +203,9 @@ export default function Page() {
       </p>
       <p>
         Read the{' '}
-        <a href="/guides/wordpress-to-nextjs-guide">WordPress-to-Next.js conversion guide</a> for
-        the migration playbook, and the <a href="/tech-stack">current FFC tech stack</a> for the
-        modern equivalent of this page.
+        <Link href="/guides/wordpress-to-nextjs-guide">WordPress-to-Next.js conversion guide</Link>{' '}
+        for the migration playbook, and the <Link href="/tech-stack">current FFC tech stack</Link>{' '}
+        for the modern equivalent of this page.
       </p>
     </LeafPageShell>
   )

--- a/src/app/legacy-wordpress-administration/wordpress-online-impacts-onboarding/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-online-impacts-onboarding/page.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link'
 import type { Metadata } from 'next'
 import HowToSchema from '@/components/legacy-wordpress-administration/HowToSchema'
 import LeafPageShell from '@/components/legacy-wordpress-administration/LeafPageShell'
@@ -192,16 +193,16 @@ export default function Page() {
           <li>Microsoft 365 nonprofit tenant ready to receive the new charity domain.</li>
           <li>
             The charity has already completed the validation gate (see{' '}
-            <a href="/legacy-wordpress-administration/wordpress-charity-validation/">
+            <Link href="/legacy-wordpress-administration/wordpress-charity-validation/">
               wordpress-charity-validation
-            </a>
+            </Link>
             ).
           </li>
           <li>
             New to FFC&apos;s overall lifecycle? Read{' '}
-            <a href="/legacy-wordpress-administration/wordpress-service-delivery-stages/">
+            <Link href="/legacy-wordpress-administration/wordpress-service-delivery-stages/">
               wordpress-service-delivery-stages
-            </a>{' '}
+            </Link>{' '}
             first — Online Impacts onboarding is Stage 5 of that broader flow.
           </li>
         </ul>
@@ -230,9 +231,9 @@ export default function Page() {
       <h2>External validation accounts</h2>
       <p>
         Each account below maps to a check from{' '}
-        <a href="/legacy-wordpress-administration/wordpress-charity-validation/">
+        <Link href="/legacy-wordpress-administration/wordpress-charity-validation/">
           wordpress-charity-validation
-        </a>
+        </Link>
         :
       </p>
       <ul>
@@ -292,21 +293,21 @@ export default function Page() {
       <h2>Cross-references</h2>
       <ul>
         <li>
-          <a href="/legacy-wordpress-administration/wordpress-service-delivery-stages/">
+          <Link href="/legacy-wordpress-administration/wordpress-service-delivery-stages/">
             wordpress-service-delivery-stages
-          </a>{' '}
+          </Link>{' '}
           — broader lifecycle this fits into.
         </li>
         <li>
-          <a href="/legacy-wordpress-administration/wordpress-charity-validation/">
+          <Link href="/legacy-wordpress-administration/wordpress-charity-validation/">
             wordpress-charity-validation
-          </a>{' '}
+          </Link>{' '}
           — checks that gate each step.
         </li>
         <li>
-          <a href="/legacy-wordpress-administration/wordpress-guidestar-guide/">
+          <Link href="/legacy-wordpress-administration/wordpress-guidestar-guide/">
             wordpress-guidestar-guide
-          </a>{' '}
+          </Link>{' '}
           — seal progression requirement.
         </li>
       </ul>

--- a/src/app/legacy-wordpress-administration/wordpress-service-delivery-stages/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-service-delivery-stages/page.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link'
 import type { Metadata } from 'next'
 import HowToSchema from '@/components/legacy-wordpress-administration/HowToSchema'
 import LeafPageShell from '@/components/legacy-wordpress-administration/LeafPageShell'
@@ -185,32 +186,34 @@ export default function Page() {
         (post a few news items, respond to a contact-form submission, manage their own user
         accounts), FFC unlocks advanced services: full design polish, custom functionality, advocacy
         tooling, and increasingly, a static-site migration to the modern{' '}
-        <a href="/tech-stack">FFC Next.js stack</a>.
+        <Link href="/tech-stack">FFC Next.js stack</Link>.
       </p>
 
       <h2>Cross-references</h2>
       <ul>
         <li>
-          <a href="/legacy-wordpress-administration/wordpress-charity-validation/">
+          <Link href="/legacy-wordpress-administration/wordpress-charity-validation/">
             wordpress-charity-validation
-          </a>{' '}
+          </Link>{' '}
           — Stage 2 detail.
         </li>
         <li>
-          <a href="/legacy-wordpress-administration/wordpress-guidestar-guide/">
+          <Link href="/legacy-wordpress-administration/wordpress-guidestar-guide/">
             wordpress-guidestar-guide
-          </a>{' '}
+          </Link>{' '}
           — Eligibility floor.
         </li>
         <li>
-          <a href="/legacy-wordpress-administration/wordpress-hosting-techstack/">
+          <Link href="/legacy-wordpress-administration/wordpress-hosting-techstack/">
             wordpress-hosting-techstack
-          </a>{' '}
+          </Link>{' '}
           — Stages 4-8 vendor map.
         </li>
         <li>
-          <a href="/guides/wordpress-to-nextjs-guide">WordPress-to-Next.js conversion guide</a> —
-          Where charities go after they outgrow the WordPress delivery.
+          <Link href="/guides/wordpress-to-nextjs-guide">
+            WordPress-to-Next.js conversion guide
+          </Link>{' '}
+          — Where charities go after they outgrow the WordPress delivery.
         </li>
       </ul>
     </LeafPageShell>

--- a/src/app/legacy-wordpress-administration/wordpress-tools-for-success/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-tools-for-success/page.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link'
 import type { Metadata } from 'next'
 import LeafPageShell from '@/components/legacy-wordpress-administration/LeafPageShell'
 import { getLegacyWpAdminPageBySlug } from '@/data/legacy-wordpress-administration'
@@ -284,19 +285,20 @@ export default function Page() {
       <h2>Cross-references</h2>
       <ul>
         <li>
-          <a href="/legacy-wordpress-administration/wordpress-online-impacts-onboarding/">
+          <Link href="/legacy-wordpress-administration/wordpress-online-impacts-onboarding/">
             wordpress-online-impacts-onboarding
-          </a>{' '}
+          </Link>{' '}
           — the external-validation account checklist.
         </li>
         <li>
-          <a href="/legacy-wordpress-administration/wordpress-guidestar-guide/">
+          <Link href="/legacy-wordpress-administration/wordpress-guidestar-guide/">
             wordpress-guidestar-guide
-          </a>{' '}
+          </Link>{' '}
           — Candid is the most-required tool on this list.
         </li>
         <li>
-          <a href="/training-plan">/training-plan</a> — the FFC volunteer-side toolkit alignment.
+          <Link href="/training-plan">/training-plan</Link> — the FFC volunteer-side toolkit
+          alignment.
         </li>
       </ul>
     </LeafPageShell>

--- a/src/app/legacy-wordpress-administration/wordpress-training-programs/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-training-programs/page.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link'
 import type { Metadata } from 'next'
 import LeafPageShell from '@/components/legacy-wordpress-administration/LeafPageShell'
 import { getLegacyWpAdminPageBySlug } from '@/data/legacy-wordpress-administration'
@@ -142,10 +143,10 @@ export default function Page() {
 
       <h2>Where to point volunteers today</h2>
       <p>
-        The modern FFC volunteer pipeline starts at <a href="/get-involved">/get-involved</a>,
+        The modern FFC volunteer pipeline starts at <Link href="/get-involved">/get-involved</Link>,
         splits into the Global Administrator and Canva Designer paths, and progresses through the{' '}
-        <a href="/contributor-ladder">contributor ladder</a>. The legacy three-track catalog feeds
-        into those paths but is no longer the primary intake.
+        <Link href="/contributor-ladder">contributor ladder</Link>. The legacy three-track catalog
+        feeds into those paths but is no longer the primary intake.
       </p>
     </LeafPageShell>
   )

--- a/src/app/legacy-wordpress-administration/wordpress-volunteer-core-competencies/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-volunteer-core-competencies/page.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link'
 import type { Metadata } from 'next'
 import LeafPageShell from '@/components/legacy-wordpress-administration/LeafPageShell'
 import { getLegacyWpAdminPageBySlug } from '@/data/legacy-wordpress-administration'
@@ -227,37 +228,37 @@ export default function Page() {
       <h2>What comes after</h2>
       <p>
         Volunteers who complete the proving ground graduate into the{' '}
-        <a href="/contributor-ladder">contributor ladder</a> and pick one of the two modern training
-        paths:
+        <Link href="/contributor-ladder">contributor ladder</Link> and pick one of the two modern
+        training paths:
       </p>
       <ul>
         <li>
-          <a href="/training-plan">Global Administrator</a> — Microsoft 365 + GitHub + DNS
+          <Link href="/training-plan">Global Administrator</Link> — Microsoft 365 + GitHub + DNS
           administration.
         </li>
         <li>
-          <a href="/canva-designer-path">Canva Designer</a> — brand identities + marketing materials
-          for charities.
+          <Link href="/canva-designer-path">Canva Designer</Link> — brand identities + marketing
+          materials for charities.
         </li>
       </ul>
 
       <h2>Cross-references</h2>
       <ul>
         <li>
-          <a href="/legacy-wordpress-administration/wordpress-training-programs/">
+          <Link href="/legacy-wordpress-administration/wordpress-training-programs/">
             wordpress-training-programs
-          </a>{' '}
+          </Link>{' '}
           — the broader catalog this proving ground sits inside.
         </li>
         <li>
-          <a href="/legacy-wordpress-administration/wordpress-web-developer-training/">
+          <Link href="/legacy-wordpress-administration/wordpress-web-developer-training/">
             wordpress-web-developer-training
-          </a>{' '}
+          </Link>{' '}
           — the developer-specific platform tour that follows the proving ground.
         </li>
         <li>
-          <a href="/contributor-ladder">/contributor-ladder</a> — modern progression path beyond the
-          proving ground.
+          <Link href="/contributor-ladder">/contributor-ladder</Link> — modern progression path
+          beyond the proving ground.
         </li>
       </ul>
     </LeafPageShell>

--- a/src/app/legacy-wordpress-administration/wordpress-web-developer-training/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-web-developer-training/page.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link'
 import type { Metadata } from 'next'
 import LeafPageShell from '@/components/legacy-wordpress-administration/LeafPageShell'
 import { getLegacyWpAdminPageBySlug } from '@/data/legacy-wordpress-administration'
@@ -217,25 +218,27 @@ export default function Page() {
       <h2>Cross-references</h2>
       <ul>
         <li>
-          <a href="/training-plan">/training-plan</a> — the modern Global Admin training plan this
-          developer guide partially pre-dates.
+          <Link href="/training-plan">/training-plan</Link> — the modern Global Admin training plan
+          this developer guide partially pre-dates.
         </li>
         <li>
-          <a href="/legacy-wordpress-administration/wordpress-hosting-techstack/">
+          <Link href="/legacy-wordpress-administration/wordpress-hosting-techstack/">
             wordpress-hosting-techstack
-          </a>{' '}
+          </Link>{' '}
           — the layered model these platforms fit into.
         </li>
         <li>
-          <a href="/legacy-wordpress-administration/wordpress-volunteer-core-competencies/">
+          <Link href="/legacy-wordpress-administration/wordpress-volunteer-core-competencies/">
             wordpress-volunteer-core-competencies
-          </a>{' '}
+          </Link>{' '}
           — the core-competency checklist developers complete before getting admin access to charity
           sites.
         </li>
         <li>
-          <a href="/guides/wordpress-to-nextjs-guide">WordPress-to-Next.js conversion guide</a> —
-          what to read next once you understand the WP stack.
+          <Link href="/guides/wordpress-to-nextjs-guide">
+            WordPress-to-Next.js conversion guide
+          </Link>{' '}
+          — what to read next once you understand the WP stack.
         </li>
       </ul>
     </LeafPageShell>

--- a/src/app/legacy-wordpress-administration/wordpress-web-hosting/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-web-hosting/page.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link'
 import type { Metadata } from 'next'
 import LeafPageShell from '@/components/legacy-wordpress-administration/LeafPageShell'
 import { getLegacyWpAdminPageBySlug } from '@/data/legacy-wordpress-administration'
@@ -165,31 +166,33 @@ export default function Page() {
       <h2>Source of truth for per-charity mapping</h2>
       <p>
         The full list of FFC-managed charity domains, the host each lives on, and the migration
-        status is at <a href="/sites-list">/sites-list</a> — refreshed automatically from{' '}
+        status is at <Link href="/sites-list">/sites-list</Link> — refreshed automatically from{' '}
         <code>docs/SITES_LIST.md</code> on every push to main.
       </p>
 
       <h2>Cross-references</h2>
       <ul>
         <li>
-          <a href="/legacy-wordpress-administration/wordpress-hosting-techstack/">
+          <Link href="/legacy-wordpress-administration/wordpress-hosting-techstack/">
             wordpress-hosting-techstack
-          </a>{' '}
+          </Link>{' '}
           — the layered model these hosts fit into.
         </li>
         <li>
-          <a href="/legacy-wordpress-administration/wordpress-cpanel-backup-sop/">
+          <Link href="/legacy-wordpress-administration/wordpress-cpanel-backup-sop/">
             wordpress-cpanel-backup-sop
-          </a>{' '}
+          </Link>{' '}
           — what to run before risky host operations.
         </li>
         <li>
-          <a href="/legacy-wordpress-administration/wordpress-domains/">wordpress-domains</a> — DNS
-          and registrar side.
+          <Link href="/legacy-wordpress-administration/wordpress-domains/">wordpress-domains</Link>{' '}
+          — DNS and registrar side.
         </li>
         <li>
-          <a href="/guides/wordpress-to-nextjs-guide">WordPress-to-Next.js conversion guide</a> —
-          the modern destination for charity sites.
+          <Link href="/guides/wordpress-to-nextjs-guide">
+            WordPress-to-Next.js conversion guide
+          </Link>{' '}
+          — the modern destination for charity sites.
         </li>
       </ul>
     </LeafPageShell>

--- a/src/app/privacy-policy/page.tsx
+++ b/src/app/privacy-policy/page.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link'
 import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
@@ -130,9 +131,9 @@ export default function PrivacyPolicy() {
               </ul>
               <p>
                 For more detailed information about cookies, please see our{' '}
-                <a href="/cookie-policy" className="text-blue-600 hover:underline">
+                <Link href="/cookie-policy" className="text-blue-600 hover:underline">
                   Cookie Policy
-                </a>
+                </Link>
                 .
               </p>
             </section>

--- a/src/app/tech-stack/page.tsx
+++ b/src/app/tech-stack/page.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link'
 import type { Metadata } from 'next'
 import CollapsibleSection from '@/components/CollapsibleSection'
 import NonprofitCallout from '@/components/NonprofitCallout'
@@ -620,9 +621,9 @@ export default function TechStack() {
               </ul>
               <p className="text-gray-700 text-sm italic">
                 Access the Sites List at{' '}
-                <a href="/sites-list" className="text-blue-600 hover:underline">
+                <Link href="/sites-list" className="text-blue-600 hover:underline">
                   /sites-list
-                </a>{' '}
+                </Link>{' '}
                 for weekly-updated domain inventory and health status.
               </p>
             </CollapsibleSection>
@@ -1117,12 +1118,12 @@ export default function TechStack() {
               </p>
               <p className="mt-4 text-sm text-gray-600">
                 Still running WordPress? The legacy hosting layered model is preserved at{' '}
-                <a
+                <Link
                   href="/legacy-wordpress-administration/wordpress-hosting-techstack"
                   className="text-blue-600 hover:text-blue-800 underline"
                 >
                   wordpress-hosting-techstack
-                </a>{' '}
+                </Link>{' '}
                 — vendor-by-vendor escalation paths for InterServer, Hostinger, WPMUDEV, Divi,
                 Cloudflare, and Microsoft 365.
               </p>

--- a/src/app/testing/page.tsx
+++ b/src/app/testing/page.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link'
 import type { Metadata } from 'next'
 import CollapsibleSection from '@/components/CollapsibleSection'
 
@@ -880,17 +881,17 @@ export default function Testing() {
                 GitHub Issues
               </a>{' '}
               or review the{' '}
-              <a href="/documentation" className="text-blue-600 hover:underline">
+              <Link href="/documentation" className="text-blue-600 hover:underline">
                 Documentation Center
-              </a>
+              </Link>
               . Ready to contribute? Check the{' '}
-              <a href="/contributor-ladder" className="text-blue-600 hover:underline">
+              <Link href="/contributor-ladder" className="text-blue-600 hover:underline">
                 Contributor Ladder
-              </a>{' '}
+              </Link>{' '}
               or explore our{' '}
-              <a href="/tech-stack" className="text-blue-600 hover:underline">
+              <Link href="/tech-stack" className="text-blue-600 hover:underline">
                 Tech Stack
-              </a>
+              </Link>
               .
             </p>
           </div>

--- a/src/app/training-plan/page.tsx
+++ b/src/app/training-plan/page.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import Link from 'next/link'
 import Breadcrumbs from '@/components/Breadcrumbs'
 import { TRAINING_CURRICULUM } from '@/data/training-plan-data'
 import { useTrainingProgress } from './hooks/useTrainingProgress'
@@ -435,21 +436,21 @@ export default function TrainingPlan() {
           <p className="text-gray-700 mb-3">
             The legacy three-track FFC training catalog (Researcher / Business Analyst / Web
             Developer) lives at{' '}
-            <a
+            <Link
               href="/legacy-wordpress-administration/wordpress-training-programs"
               className="text-blue-600 underline hover:text-blue-800"
             >
               wordpress-training-programs
-            </a>{' '}
+            </Link>{' '}
             — useful for the salary anchors and the win-win-win pitch. The WordPress-era
             developer-specific curriculum (WHMCS, Cloudflare, M365, InterServer, Divi, WPMUDEV,
             Clarity, Tawk.to, Azure AI) is preserved at{' '}
-            <a
+            <Link
               href="/legacy-wordpress-administration/wordpress-web-developer-training"
               className="text-blue-600 underline hover:text-blue-800"
             >
               wordpress-web-developer-training
-            </a>{' '}
+            </Link>{' '}
             with per-module modern equivalents called out.
           </p>
         </section>

--- a/src/components/CookieConsent.tsx
+++ b/src/components/CookieConsent.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import Link from 'next/link'
 import { useState, useEffect, useRef } from 'react'
 
 // Environment variables for tracking IDs (replace with actual values)
@@ -427,12 +428,12 @@ export default function CookieConsent() {
               non-essential cookies.
             </p>
             <div className="flex items-center gap-4 text-xs text-gray-500">
-              <a href="/privacy-policy" className="text-blue-600 hover:underline">
+              <Link href="/privacy-policy" className="text-blue-600 hover:underline">
                 Privacy Policy
-              </a>
-              <a href="/cookie-policy" className="text-blue-600 hover:underline">
+              </Link>
+              <Link href="/cookie-policy" className="text-blue-600 hover:underline">
                 Cookie Policy
-              </a>
+              </Link>
             </div>
           </div>
           <div className="flex flex-col sm:flex-row gap-2 w-full md:w-auto">


### PR DESCRIPTION
## Summary

Codebase-wide sweep replacing bare `<a href="/...">` internal links with `<Link>` from `next/link`, so internal navigation respects a configured `basePath` (`NEXT_PUBLIC_BASE_PATH`). Bare anchors work under custom-domain deploys (no basePath) but break when a basePath is set. Resolves #268.

## Changes

- **65 internal anchors converted to `<Link>` across 22 files** — legacy WordPress admin leaves, the WordPress→Next.js guide, privacy/cookie policies, tech-stack, testing, contributor-ladder, training-plan, and `CookieConsent`. External links (`https://`), `mailto:`/`tel:`/`sms:`, and `#anchor` links are intentionally left as `<a>` because their href does not start with `/`.
- **New ESLint rule** (`no-restricted-syntax`) that blocks any new bare `<a href="/...">` internal link, with a message pointing contributors at `next/link`.

## Acceptance criteria
- [x] No bare `<a>` for internal paths remains (`grep` and the ESLint rule confirm 0).
- [x] ESLint rule enforced (fails the build on a bare internal anchor).
- [x] All tests pass — `pnpm test` → 355 passed.
- [x] basePath deployment verified — `NEXT_PUBLIC_BASE_PATH=/test pnpm build` succeeds, and converted links render with the prefix (e.g. `href="/test/cookie-policy/"`).

Refs #248.

Closes #268

---
_Generated by [Claude Code](https://claude.ai/code/session_01X4omPQW2ErDyZsMtxypuMe)_