### PR TITLE
feat: continuing-education credentialing pathway — data, pillar & landing pages (#356, #357, #363)

### DIFF
--- a/__tests__/ce-bodies.test.ts
+++ b/__tests__/ce-bodies.test.ts
@@ -35,7 +35,7 @@ describe('CE compliance matrix (#356)', () => {
 
   it('every supported body defines all three channels and a source URL', () => {
     for (const b of SUPPORTED_CE_BODIES) {
-      for (const ch of ['education', 'teaching', 'work']) {
+      for (const ch of ['education', 'teaching', 'work'] as const) {
         expect(['yes', 'limited', 'no']).toContain(b.channels[ch].support)
         expect(b.channels[ch].note.length).toBeGreaterThan(0)
       }
@@ -44,7 +44,7 @@ describe('CE compliance matrix (#356)', () => {
   })
 
   it('landing bodies have unique, keyword-front-loaded slugs', () => {
-    const slugs = CE_LANDING_BODIES.map((b) => b.landing.slug)
+    const slugs = CE_LANDING_BODIES.map((b) => b.landing!.slug)
     expect(new Set(slugs).size).toBe(slugs.length)
     expect(slugs).toContain('free-cpe-credits-isc2')
     expect(slugs).toContain('free-pdus-pmi')

--- a/__tests__/ce-bodies.test.ts
+++ b/__tests__/ce-bodies.test.ts
@@ -1,0 +1,67 @@
+import {
+  CE_BODIES,
+  SUPPORTED_CE_BODIES,
+  UNSUPPORTED_CE_BODIES,
+  CE_LANDING_BODIES,
+  getCeBody,
+  getCeBodyByLandingSlug,
+  CE_DISCLAIMER,
+} from '../src/data/ce-bodies'
+
+describe('CE compliance matrix (#356)', () => {
+  it('has unique body slugs', () => {
+    const slugs = CE_BODIES.map((b) => b.slug)
+    expect(new Set(slugs).size).toBe(slugs.length)
+  })
+
+  it('includes the in-scope supported bodies and unsupported vendors', () => {
+    const supported = SUPPORTED_CE_BODIES.map((b) => b.slug)
+    for (const s of ['isc2', 'pmi', 'comptia', 'isaca', 'cfre', 'giac', 'ec-council']) {
+      expect(supported).toContain(s)
+    }
+    const unsupported = UNSUPPORTED_CE_BODIES.map((b) => b.slug)
+    for (const s of ['microsoft', 'google-cloud', 'aws']) {
+      expect(unsupported).toContain(s)
+    }
+  })
+
+  it('every unsupported body explains why and carries a source', () => {
+    for (const b of UNSUPPORTED_CE_BODIES) {
+      expect(b.unsupportedReason && b.unsupportedReason.length).toBeGreaterThan(0)
+      expect(b.sourceUrl).toMatch(/^https:\/\//)
+      expect(b.landing).toBeUndefined()
+    }
+  })
+
+  it('every supported body defines all three channels and a source URL', () => {
+    for (const b of SUPPORTED_CE_BODIES) {
+      for (const ch of ['education', 'teaching', 'work']) {
+        expect(['yes', 'limited', 'no']).toContain(b.channels[ch].support)
+        expect(b.channels[ch].note.length).toBeGreaterThan(0)
+      }
+      expect(b.sourceUrl).toMatch(/^https:\/\//)
+    }
+  })
+
+  it('landing bodies have unique, keyword-front-loaded slugs', () => {
+    const slugs = CE_LANDING_BODIES.map((b) => b.landing.slug)
+    expect(new Set(slugs).size).toBe(slugs.length)
+    expect(slugs).toContain('free-cpe-credits-isc2')
+    expect(slugs).toContain('free-pdus-pmi')
+    expect(slugs).toContain('free-ceus-comptia')
+  })
+
+  it('lookup helpers resolve by slug and landing slug', () => {
+    expect(getCeBody('isc2')?.name).toBe('ISC2')
+    expect(getCeBodyByLandingSlug('free-pdus-pmi')?.slug).toBe('pmi')
+    expect(getCeBody('nope')).toBeUndefined()
+  })
+
+  it('ships the compliance disclaimer', () => {
+    expect(CE_DISCLAIMER).toMatch(/not an accredited\/approved CE provider/)
+  })
+
+  it('CompTIA does not credit volunteer work (headline rule)', () => {
+    expect(getCeBody('comptia')?.channels.work.support).toBe('no')
+  })
+})

--- a/__tests__/route-generation.test.js
+++ b/__tests__/route-generation.test.js
@@ -127,6 +127,34 @@ describe('Route Generation Tests', () => {
     })
   })
 
+  describe('Test Case 4.2d: Continuing Education Pages', () => {
+    const pillarPath = path.join(outDir, 'continuing-education', 'index.html')
+    const landingSlugs = ['free-cpe-credits-isc2', 'free-pdus-pmi', 'free-ceus-comptia']
+
+    it('should generate the CE pillar page with a self-canonical URL', () => {
+      expect(fs.existsSync(pillarPath)).toBe(true)
+      if (fs.existsSync(pillarPath)) {
+        const content = fs.readFileSync(pillarPath, 'utf-8')
+        expect(content).toContain(
+          '<link rel="canonical" href="https://ffcadmin.org/continuing-education/"/>'
+        )
+      }
+    })
+
+    it('should generate each per-body landing page with a self-canonical URL', () => {
+      for (const slug of landingSlugs) {
+        const p = path.join(outDir, 'continuing-education', slug, 'index.html')
+        expect(fs.existsSync(p)).toBe(true)
+        if (fs.existsSync(p)) {
+          const content = fs.readFileSync(p, 'utf-8')
+          expect(content).toContain(
+            `<link rel="canonical" href="https://ffcadmin.org/continuing-education/${slug}/"/>`
+          )
+        }
+      }
+    })
+  })
+
   describe('Test Case 4.2c: MOVSM Funnel Page', () => {
     const pagePath = path.join(outDir, 'movsm', 'index.html')
 

--- a/__tests__/route-generation.test.js
+++ b/__tests__/route-generation.test.js
@@ -129,7 +129,9 @@ describe('Route Generation Tests', () => {
 
   describe('Test Case 4.2d: Continuing Education Pages', () => {
     const pillarPath = path.join(outDir, 'continuing-education', 'index.html')
-    const landingSlugs = ['free-cpe-credits-isc2', 'free-pdus-pmi', 'free-ceus-comptia']
+    // Derive slugs from the data so the test never drifts as bodies are added/removed.
+    const { CE_LANDING_BODIES } = require('../src/data/ce-bodies')
+    const landingSlugs = CE_LANDING_BODIES.map((b) => b.landing.slug)
 
     it('should generate the CE pillar page with a self-canonical URL', () => {
       expect(fs.existsSync(pillarPath)).toBe(true)

--- a/src/app/continuing-education/[body]/page.tsx
+++ b/src/app/continuing-education/[body]/page.tsx
@@ -1,0 +1,219 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import Breadcrumbs from '@/components/Breadcrumbs'
+import {
+  CE_LANDING_BODIES,
+  getCeBodyByLandingSlug,
+  CHANNEL_LABELS,
+  CE_DISCLAIMER,
+  type CreditChannel,
+  type ChannelSupport,
+} from '@/data/ce-bodies'
+
+export function generateStaticParams() {
+  return CE_LANDING_BODIES.map((b) => ({ body: b.landing!.slug }))
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ body: string }>
+}): Promise<Metadata> {
+  const { body: slug } = await params
+  const body = getCeBodyByLandingSlug(slug)
+  if (!body?.landing) return {}
+  return {
+    title: body.landing.title,
+    description: body.landing.description,
+    keywords: body.landing.keywords,
+    alternates: { canonical: `https://ffcadmin.org/continuing-education/${body.landing.slug}/` },
+  }
+}
+
+const SUPPORT_STYLE: Record<ChannelSupport, { label: string; chip: string }> = {
+  yes: { label: 'Counts', chip: 'bg-green-100 text-green-800' },
+  limited: { label: 'Limited', chip: 'bg-yellow-100 text-yellow-800' },
+  no: { label: 'Does not count', chip: 'bg-gray-100 text-gray-500' },
+}
+
+export default async function CeBodyLandingPage({ params }: { params: Promise<{ body: string }> }) {
+  const { body: slug } = await params
+  const body = getCeBodyByLandingSlug(slug)
+  if (!body?.landing) return null
+
+  const channelOrder: CreditChannel[] = ['education', 'teaching', 'work']
+
+  const faqJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: [
+      {
+        '@type': 'Question',
+        name: `Can I earn free ${body.unitPlural} for ${body.name} by volunteering?`,
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text: `${body.landing.description}`,
+        },
+      },
+      {
+        '@type': 'Question',
+        name: `What is the ${body.name} recertification cycle?`,
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text: `${body.total}.${body.annualMin ? ' ' + body.annualMin + '.' : ''}`,
+        },
+      },
+      {
+        '@type': 'Question',
+        name: `Does FFC guarantee ${body.name} will accept these hours?`,
+        acceptedAnswer: { '@type': 'Answer', text: CE_DISCLAIMER },
+      },
+    ],
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
+      />
+      <Breadcrumbs
+        items={[
+          { label: 'Home', href: '/' },
+          { label: 'Continuing Education', href: '/continuing-education' },
+          { label: body.name },
+        ]}
+      />
+
+      {/* Hero */}
+      <div className="bg-gradient-to-r from-emerald-600 to-teal-700 text-white py-16 px-4 sm:px-6 lg:px-8">
+        <div className="max-w-4xl mx-auto">
+          <h1 className="text-3xl md:text-4xl font-bold mb-3">{body.landing.title}</h1>
+          <p className="text-teal-50 text-lg max-w-3xl">{body.landing.description}</p>
+          <div className="mt-5 inline-flex items-center gap-2 bg-white/15 px-3 py-1.5 rounded-lg text-sm">
+            <span aria-hidden="true">💸</span>
+            {body.landing.costContrast}
+          </div>
+        </div>
+      </div>
+
+      <main className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        {/* Cycle facts */}
+        <section className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
+          <h2 className="text-2xl font-bold text-gray-900 mb-4">
+            {body.name} recertification at a glance
+          </h2>
+          <dl className="grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm">
+            <div>
+              <dt className="font-semibold text-gray-900">Credit unit</dt>
+              <dd className="text-gray-700">{body.unitPlural}</dd>
+            </div>
+            <div>
+              <dt className="font-semibold text-gray-900">Cycle</dt>
+              <dd className="text-gray-700">{body.cycleYears} years</dd>
+            </div>
+            <div className="sm:col-span-2">
+              <dt className="font-semibold text-gray-900">Requirement</dt>
+              <dd className="text-gray-700">{body.total}</dd>
+            </div>
+            {body.annualMin && (
+              <div className="sm:col-span-2">
+                <dt className="font-semibold text-gray-900">Annual minimum</dt>
+                <dd className="text-gray-700">{body.annualMin}</dd>
+              </div>
+            )}
+          </dl>
+          <p className="mt-4 text-xs text-gray-500">
+            Certs: {body.certs.join(', ')} ·{' '}
+            <a
+              href={body.sourceUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-600 underline hover:text-blue-800"
+            >
+              official source
+            </a>{' '}
+            (verify current figures)
+          </p>
+        </section>
+
+        {/* How your hours count */}
+        <section className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
+          <h2 className="text-2xl font-bold text-gray-900 mb-4">
+            How your FFC hours count toward {body.name}
+          </h2>
+          <ul className="space-y-3">
+            {channelOrder.map((ch) => {
+              const s = SUPPORT_STYLE[body.channels[ch].support]
+              return (
+                <li key={ch} className="flex items-start gap-3">
+                  <span
+                    className={`flex-shrink-0 mt-0.5 px-2 py-0.5 rounded-full text-xs font-semibold ${s.chip}`}
+                  >
+                    {s.label}
+                  </span>
+                  <span className="text-sm text-gray-700">
+                    <span className="font-semibold text-gray-900">{CHANNEL_LABELS[ch]}:</span>{' '}
+                    {body.channels[ch].note}
+                  </span>
+                </li>
+              )
+            })}
+          </ul>
+          {body.relevance === 'domain-relevant-only' && (
+            <p className="mt-4 text-xs text-amber-700">
+              Note: {body.name} only credits volunteer work that is relevant to the
+              credential&apos;s profession — generic charity volunteering does not qualify.
+            </p>
+          )}
+        </section>
+
+        {/* How to claim */}
+        <section className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
+          <h2 className="text-2xl font-bold text-gray-900 mb-4">How to claim</h2>
+          <ol className="space-y-2 text-sm text-gray-700 list-decimal pl-5">
+            <li>
+              Pick an{' '}
+              <Link href="/volunteer" className="text-blue-600 underline hover:text-blue-800">
+                FFC volunteer track
+              </Link>{' '}
+              and start contributing and training.
+            </li>
+            <li>FFC validates and certifies your hours (commit history + mentor certification).</li>
+            <li>Request your FFC documentation and self-report it to {body.name}.</li>
+          </ol>
+          <div className="mt-5 flex flex-col sm:flex-row gap-3">
+            <Link
+              href="/volunteer"
+              className="inline-flex items-center justify-center px-6 py-3 bg-emerald-600 text-white rounded-lg font-semibold hover:bg-emerald-700 transition-colors text-sm"
+            >
+              Find your volunteer track
+            </Link>
+            <Link
+              href="/continuing-education"
+              className="inline-flex items-center justify-center px-6 py-3 border border-gray-300 text-gray-700 rounded-lg font-semibold hover:bg-gray-50 transition-colors text-sm"
+            >
+              All supported certifications
+            </Link>
+          </div>
+          <p className="mt-4 text-xs text-gray-500">{CE_DISCLAIMER}</p>
+        </section>
+
+        {/* MOVSM cross-link */}
+        <section className="bg-slate-50 border border-slate-200 rounded-xl p-6">
+          <h2 className="text-base font-bold text-gray-900 mb-1">
+            Military? You may also qualify for the MOVSM
+          </h2>
+          <p className="text-sm text-gray-700">
+            Many {body.name} holders serve in the military. The same volunteer hours can count
+            toward the{' '}
+            <Link href="/movsm" className="text-blue-600 underline hover:text-blue-800">
+              Military Outstanding Volunteer Service Medal
+            </Link>
+            .
+          </p>
+        </section>
+      </main>
+    </div>
+  )
+}

--- a/src/app/continuing-education/page.tsx
+++ b/src/app/continuing-education/page.tsx
@@ -1,0 +1,294 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import Breadcrumbs from '@/components/Breadcrumbs'
+import {
+  SUPPORTED_CE_BODIES,
+  UNSUPPORTED_CE_BODIES,
+  CE_LANDING_BODIES,
+  CHANNEL_LABELS,
+  CE_DISCLAIMER,
+  type CreditChannel,
+  type ChannelSupport,
+} from '@/data/ce-bodies'
+
+export const metadata: Metadata = {
+  title: 'Continuing Education (CE) by Volunteering',
+  description:
+    'Free For Charity certifies the hours you spend volunteering and training so you can self-report continuing-education credit toward CompTIA, PMI, ISC2, ISACA, CFRE, GIAC, and EC-Council — for free.',
+  keywords:
+    'continuing education volunteering, free CE credits, CPE PDU CEU volunteering, renew certification without paying, nonprofit continuing education, FFC continuing education',
+  alternates: {
+    canonical: 'https://ffcadmin.org/continuing-education/',
+  },
+}
+
+const channels: { id: CreditChannel; icon: string; blurb: string }[] = [
+  {
+    id: 'education',
+    icon: '📚',
+    blurb:
+      'Complete FFC training modules. Education is uncapped (or nearly so) at almost every body — the cleanest, highest-yield channel.',
+  },
+  {
+    id: 'teaching',
+    icon: '🧑‍🏫',
+    blurb:
+      'Teach or mentor others, or author a training module. Widely credited and often bonus-weighted (ISACA 5×, CFRE 3 pts/hr for new material).',
+  },
+  {
+    id: 'work',
+    icon: '🛠️',
+    blurb:
+      'Domain-relevant volunteer work — building, securing, or administering charity systems — counted against each body’s relevance test and caps.',
+  },
+]
+
+const SUPPORT_STYLE: Record<ChannelSupport, { label: string; chip: string }> = {
+  yes: { label: 'Yes', chip: 'bg-green-100 text-green-800' },
+  limited: { label: 'Limited', chip: 'bg-yellow-100 text-yellow-800' },
+  no: { label: 'No', chip: 'bg-gray-100 text-gray-500' },
+}
+
+export default function ContinuingEducationPage() {
+  const channelOrder: CreditChannel[] = ['education', 'teaching', 'work']
+
+  const faqJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: [
+      {
+        '@type': 'Question',
+        name: 'Can I earn continuing-education credit by volunteering with FFC?',
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text: 'Yes. FFC certifies the hours you spend training and doing domain-relevant volunteer work so you can self-report them to your certifying body. Acceptance is governed by that body’s rules.',
+        },
+      },
+      {
+        '@type': 'Question',
+        name: 'Which certifications are supported?',
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text: 'CompTIA (CEUs), PMI (PDUs), ISC2 (CPEs), ISACA (CPEs), CFRE (points), GIAC (CPEs), and EC-Council (ECE). Microsoft, Google Cloud, and AWS do not use a CE-hours model and are not supported.',
+        },
+      },
+      {
+        '@type': 'Question',
+        name: 'Does generic charity volunteering count?',
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text: 'Usually not. Most IT/security bodies only credit volunteering that is relevant to the credential’s profession. CompTIA credits no volunteering. Only CFRE credits general volunteer service, and caps it.',
+        },
+      },
+    ],
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
+      />
+      <Breadcrumbs items={[{ label: 'Home', href: '/' }, { label: 'Continuing Education' }]} />
+
+      {/* Hero */}
+      <div className="bg-gradient-to-r from-emerald-600 via-teal-600 to-cyan-700 text-white py-16 px-4 sm:px-6 lg:px-8">
+        <div className="max-w-5xl mx-auto">
+          <div className="flex items-center mb-4">
+            <span className="text-5xl mr-4" aria-hidden="true">
+              🎓
+            </span>
+            <div>
+              <h1 className="text-3xl md:text-4xl font-bold">
+                Continuing Education by Volunteering
+              </h1>
+              <p className="text-teal-50 text-sm mt-1">
+                Turn the hours you give into credit toward your certification — for free
+              </p>
+            </div>
+          </div>
+          <p className="text-teal-50 text-lg max-w-3xl">
+            Free For Charity certifies the hours you spend training and doing domain-relevant
+            volunteer work, so you can self-report continuing-education credit toward your
+            professional certification. It&apos;s a designation layered on the volunteer tracks —
+            like the{' '}
+            <Link href="/movsm" className="underline">
+              MOVSM
+            </Link>{' '}
+            for military volunteers.
+          </p>
+        </div>
+      </div>
+
+      <main className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        {/* Three channels */}
+        <section className="mb-12">
+          <h2 className="text-2xl font-bold text-gray-900 mb-2">Three ways your hours count</h2>
+          <p className="text-gray-600 text-sm mb-6">
+            CE value flows through three channels, in priority order. The right mix depends on your
+            certifying body&apos;s rules below.
+          </p>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            {channels.map((c) => (
+              <div key={c.id} className="bg-white rounded-xl border border-gray-200 p-5 shadow-sm">
+                <div className="text-3xl mb-2" aria-hidden="true">
+                  {c.icon}
+                </div>
+                <h3 className="font-bold text-gray-900 mb-1">{CHANNEL_LABELS[c.id]}</h3>
+                <p className="text-sm text-gray-600">{c.blurb}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* Per-body support matrix */}
+        <section className="mb-12">
+          <h2 className="text-2xl font-bold text-gray-900 mb-2">
+            Which certifications are supported
+          </h2>
+          <p className="text-gray-600 text-sm mb-6">
+            Per-body support and caps, from each body&apos;s published rules. Figures change —
+            always confirm against the official source linked in each row.
+          </p>
+          <div className="overflow-x-auto bg-white rounded-xl border border-gray-200 shadow-sm">
+            <table className="w-full text-sm">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="text-left p-3 font-semibold text-gray-900">Body</th>
+                  <th className="text-left p-3 font-semibold text-gray-900">Unit</th>
+                  {channelOrder.map((ch) => (
+                    <th key={ch} className="text-center p-3 font-semibold text-gray-900">
+                      {CHANNEL_LABELS[ch]}
+                    </th>
+                  ))}
+                  <th className="text-left p-3 font-semibold text-gray-900">Source</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100">
+                {SUPPORTED_CE_BODIES.map((b) => (
+                  <tr key={b.slug}>
+                    <td className="p-3">
+                      {b.landing ? (
+                        <Link
+                          href={`/continuing-education/${b.landing.slug}`}
+                          className="font-semibold text-blue-700 hover:text-blue-900"
+                        >
+                          {b.name}
+                        </Link>
+                      ) : (
+                        <span className="font-semibold text-gray-900">{b.name}</span>
+                      )}
+                      <span className="block text-xs text-gray-500">{b.certs.join(', ')}</span>
+                    </td>
+                    <td className="p-3 text-gray-700">{b.unit}</td>
+                    {channelOrder.map((ch) => {
+                      const s = SUPPORT_STYLE[b.channels[ch].support]
+                      return (
+                        <td key={ch} className="p-3 text-center">
+                          <span
+                            className={`inline-block px-2 py-0.5 rounded-full text-xs font-semibold ${s.chip}`}
+                            title={b.channels[ch].note}
+                          >
+                            {s.label}
+                          </span>
+                        </td>
+                      )
+                    })}
+                    <td className="p-3">
+                      <a
+                        href={b.sourceUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-blue-600 underline hover:text-blue-800 text-xs"
+                      >
+                        Official
+                      </a>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        {/* Not supported */}
+        <section className="mb-12 bg-amber-50 border-l-4 border-amber-500 rounded p-5">
+          <h2 className="text-lg font-bold text-amber-900 mb-2">
+            Not supported (no CE-hours model)
+          </h2>
+          <ul className="space-y-1 text-sm text-amber-900/90">
+            {UNSUPPORTED_CE_BODIES.map((b) => (
+              <li key={b.slug}>
+                <strong>{b.name}:</strong> {b.unsupportedReason}{' '}
+                <a
+                  href={b.sourceUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline"
+                >
+                  (source)
+                </a>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        {/* How to claim */}
+        <section className="mb-12 bg-white rounded-xl shadow-lg p-6 md:p-8 border border-gray-200">
+          <h2 className="text-2xl font-bold text-gray-900 mb-4">How to claim your credit</h2>
+          <ol className="space-y-3 text-sm text-gray-700 list-decimal pl-5">
+            <li>
+              Volunteer and train through the{' '}
+              <Link href="/volunteer" className="text-blue-600 underline hover:text-blue-800">
+                FFC volunteer tracks
+              </Link>{' '}
+              — your work and completed modules build hours.
+            </li>
+            <li>
+              Your hours are validated (GitHub commit history + mentor/board certification — the
+              same model as{' '}
+              <Link href="/recognition" className="text-blue-600 underline hover:text-blue-800">
+                recognition badges
+              </Link>
+              ).
+            </li>
+            <li>Request your FFC documentation — a certified record of hours and activities.</li>
+            <li>Self-report those hours to your certifying body under its current rules.</li>
+          </ol>
+          <p className="mt-4 text-xs text-gray-500">{CE_DISCLAIMER}</p>
+        </section>
+
+        {/* Per-cert landing links */}
+        <section className="mb-12">
+          <h2 className="text-xl font-bold text-gray-900 mb-4">Per-certification guides</h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+            {CE_LANDING_BODIES.map((b) => (
+              <Link
+                key={b.slug}
+                href={`/continuing-education/${b.landing!.slug}`}
+                className="flex items-center justify-between p-3 rounded-lg border border-gray-200 bg-white hover:shadow-md transition-shadow"
+              >
+                <span className="text-sm font-semibold text-gray-900">{b.name}</span>
+                <span className="text-xs text-gray-500">{b.certs.join(', ')}</span>
+              </Link>
+            ))}
+          </div>
+        </section>
+
+        {/* MOVSM cross-link */}
+        <section className="bg-slate-50 border border-slate-200 rounded-xl p-6">
+          <h2 className="text-lg font-bold text-gray-900 mb-2">
+            Military volunteer? You may also qualify for the MOVSM
+          </h2>
+          <p className="text-sm text-gray-700">
+            The same hours that earn CE credit can count toward the{' '}
+            <Link href="/movsm" className="text-blue-600 underline hover:text-blue-800">
+              Military Outstanding Volunteer Service Medal
+            </Link>{' '}
+            — another designation you earn by giving your time to a nonprofit.
+          </p>
+        </section>
+      </main>
+    </div>
+  )
+}

--- a/src/app/continuing-education/page.tsx
+++ b/src/app/continuing-education/page.tsx
@@ -191,6 +191,10 @@ export default function ContinuingEducationPage() {
                           >
                             {s.label}
                           </span>
+                          {/* Caps/rules text for screen readers (the title tooltip is mouse-only). */}
+                          <span className="sr-only">
+                            . {CHANNEL_LABELS[ch]} for {b.name}: {b.channels[ch].note}
+                          </span>
                         </td>
                       )
                     })}

--- a/src/app/movsm/page.tsx
+++ b/src/app/movsm/page.tsx
@@ -176,6 +176,16 @@ export default function MovsmPage() {
             the tiers, you build both community standing and a documented service record for your
             MOVSM application.
           </p>
+          <p className="text-sm text-gray-700 mt-3">
+            You can also earn{' '}
+            <Link
+              href="/continuing-education"
+              className="text-blue-600 underline hover:text-blue-800"
+            >
+              continuing-education (CE) credit
+            </Link>{' '}
+            for these same hours toward certifications like CompTIA, PMI, and ISC2.
+          </p>
         </section>
 
         {/* Get started */}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -3,6 +3,7 @@ import { blogPosts } from '@/data/blog'
 import { guides } from '@/data/guides'
 import { LEGACY_WP_ADMIN_BASE, LEGACY_WP_ADMIN_PAGES } from '@/data/legacy-wordpress-administration'
 import { VOLUNTEER_ROLES } from '@/data/volunteer-roles'
+import { CE_LANDING_BODIES } from '@/data/ce-bodies'
 
 export const dynamic = 'force-static'
 
@@ -37,6 +38,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
       lastModified: now,
       changeFrequency: 'monthly',
       priority: 0.7,
+    },
+    {
+      url: `${SITE_URL}/continuing-education/`,
+      lastModified: now,
+      changeFrequency: 'monthly',
+      priority: 0.8,
     },
     {
       url: `${SITE_URL}/training/`,
@@ -212,5 +219,20 @@ export default function sitemap(): MetadataRoute.Sitemap {
     priority: 0.6,
   }))
 
-  return [...corePages, ...guidePages, ...blogPages, ...legacyWpAdminPages, ...volunteerRolePages]
+  // Continuing-education per-body landing pages (#363)
+  const ceLandingPages: MetadataRoute.Sitemap = CE_LANDING_BODIES.map((b) => ({
+    url: `${SITE_URL}/continuing-education/${b.landing!.slug}/`,
+    lastModified: now,
+    changeFrequency: 'monthly' as const,
+    priority: 0.7,
+  }))
+
+  return [
+    ...corePages,
+    ...guidePages,
+    ...blogPages,
+    ...legacyWpAdminPages,
+    ...volunteerRolePages,
+    ...ceLandingPages,
+  ]
 }

--- a/src/data/ce-bodies.ts
+++ b/src/data/ce-bodies.ts
@@ -1,0 +1,414 @@
+/**
+ * Continuing-Education (CE) compliance matrix — single source of truth (#356).
+ *
+ * Maps "hours of activity → credit at a certifying body", encoding each body's
+ * **published** caps and relevance rules so FFC never certifies hours a body
+ * would reject. Drives the /continuing-education pillar (#357) and the per-body
+ * landing pages (#363). Figures verified against official sources in 2026 —
+ * re-verify at build time (rules change; ISACA changes Jan 2027).
+ *
+ * FFC's CE value flows through three channels, in priority order:
+ *   1. Training RECEIVED (Education) — cleanest, near-uncapped almost everywhere.
+ *   2. Training DELIVERED (Teaching/Mentoring) — widely credited, often weighted.
+ *   3. Domain-relevant volunteer WORK — only where it passes the relevance test.
+ *
+ * Headline reality: generic charity volunteering does NOT convert for most
+ * IT/security bodies. CompTIA credits no volunteering. Microsoft/Google/AWS have
+ * no hours model at all. Only CFRE credits general volunteer service (capped).
+ */
+
+export type CreditChannel = 'education' | 'teaching' | 'work'
+
+export type ChannelSupport = 'yes' | 'limited' | 'no'
+
+export interface CeChannel {
+  support: ChannelSupport
+  /** Plain-language cap / rule for this channel at this body. */
+  note: string
+}
+
+export interface CeBody {
+  /** Stable id, e.g. 'isc2'. */
+  slug: string
+  name: string
+  fullName: string
+  /** Certs this body issues that the program targets. */
+  certs: string[]
+  /** Unit of credit, e.g. 'CPE'. */
+  unit: string
+  unitPlural: string
+  /** Recertification cycle in years. */
+  cycleYears: number
+  /** Total units required per cycle (may vary by cert — kept as prose). */
+  total: string
+  /** Annual minimum, if the body imposes one. */
+  annualMin?: string
+  /** Per-channel support + caps. */
+  channels: Record<CreditChannel, CeChannel>
+  /** Does volunteering have to be profession/domain-relevant? */
+  relevance: 'domain-relevant-only' | 'general-ok' | 'not-applicable'
+  /** De-dup / once-per-content rules to carry into tracking. */
+  dedupRules: string[]
+  sourceUrl: string
+  /** Whether FFC's hours can convert to this body at all. */
+  supported: boolean
+  /** Why a body is unsupported (no CE-hours model). */
+  unsupportedReason?: string
+  /** SEO landing page (#363); omitted for unsupported bodies. */
+  landing?: {
+    slug: string
+    title: string
+    description: string
+    keywords: string
+    /** Honest cost contrast to lead with. */
+    costContrast: string
+  }
+}
+
+export const CE_BODIES: CeBody[] = [
+  {
+    slug: 'isc2',
+    name: 'ISC2',
+    fullName: 'ISC2 (CISSP, SSCP, CC)',
+    certs: ['CISSP', 'SSCP', 'CC'],
+    unit: 'CPE',
+    unitPlural: 'CPEs',
+    cycleYears: 3,
+    total: 'CISSP 120 / 3 yr (Group A min 90, Group B max 30); SSCP 60 / 3 yr; CC 45 / 1 yr',
+    annualMin: 'CC requires 15 CPE/yr',
+    channels: {
+      education: {
+        support: 'yes',
+        note: 'Training received counts as Group A; the cleanest channel.',
+      },
+      teaching: {
+        support: 'yes',
+        note: 'Prep + teaching = Group A, first delivery only. Instructors of ISC2 Official Training Courses get no CPE.',
+      },
+      work: {
+        support: 'limited',
+        note: 'Security-related volunteering = Group A; generic non-security volunteering = Group B only (CC cannot use Group B).',
+      },
+    },
+    relevance: 'domain-relevant-only',
+    dedupRules: ['Teaching credited for first delivery only'],
+    sourceUrl: 'https://www.isc2.org/-/media/ISC2/Certifications/CPE/ISC2-CPE-Handbook.pdf',
+    supported: true,
+    landing: {
+      slug: 'free-cpe-credits-isc2',
+      title: 'Free CPE Credits for ISC2 (CISSP, SSCP, CC) by Volunteering',
+      description:
+        'Earn free CPE credits toward your CISSP, SSCP, or CC by volunteering with Free For Charity — a real 501(c)(3) that certifies your security work and training hours. No training-vendor fee.',
+      keywords:
+        'free CPE credits CISSP, free CPE ISC2, renew CISSP without paying, CPE credits for volunteering, cybersecurity volunteer opportunities CPE, SSCP CPE, ISC2 CC CPE',
+      costContrast:
+        'Free volunteering and training vs. ~$2,000 for a 2-day conference to gather the same CPEs.',
+    },
+  },
+  {
+    slug: 'pmi',
+    name: 'PMI',
+    fullName: 'PMI (PMP, CAPM)',
+    certs: ['PMP', 'CAPM'],
+    unit: 'PDU',
+    unitPlural: 'PDUs',
+    cycleYears: 3,
+    total: 'PMP 60 / 3 yr (Education min 35); CAPM 15 / 3 yr (Education min 9)',
+    channels: {
+      education: {
+        support: 'yes',
+        note: '1 PDU = 1 hour of project-management training received.',
+      },
+      teaching: {
+        support: 'yes',
+        note: '“Share/Create Knowledge” (teaching/authoring) counts under Giving Back.',
+      },
+      work: {
+        support: 'limited',
+        note: 'Giving Back max 25 PDU (PMP) / 6 (CAPM); “Working as a Practitioner” max 8 (PMP) / 2 (CAPM). Must relate to project management.',
+      },
+    },
+    relevance: 'domain-relevant-only',
+    dedupRules: ['Generic charity volunteering does not qualify — work must be PM-relevant'],
+    sourceUrl:
+      'https://www.pmi.org/-/media/pmi/documents/public/pdf/certifications/ccr-certification-requirements-handbook.pdf',
+    supported: true,
+    landing: {
+      slug: 'free-pdus-pmi',
+      title: 'Free PDUs for PMP & CAPM by Volunteering',
+      description:
+        'Earn free PDUs toward your PMP or CAPM by leading project-management work for Free For Charity — a 501(c)(3) that certifies your Giving Back and Education hours. No paid course required.',
+      keywords:
+        'free PDUs PMP, giving back PDUs, renew PMP without paying, volunteer project manager nonprofit, nonprofit project management PDUs, CAPM PDUs',
+      costContrast:
+        'Giving Back and Education PDUs at $0 vs. paid PDU bundles from training vendors.',
+    },
+  },
+  {
+    slug: 'comptia',
+    name: 'CompTIA',
+    fullName: 'CompTIA (A+, Network+, Security+, CySA+, …)',
+    certs: ['A+', 'Network+', 'Security+', 'CySA+', 'PenTest+'],
+    unit: 'CEU',
+    unitPlural: 'CEUs',
+    cycleYears: 3,
+    total: 'Per cert: A+ 20, Network+ 30, Security+ 50, CySA+ 60, PenTest+ 60',
+    channels: {
+      education: {
+        support: 'yes',
+        note: 'Training/education received has no max — can fill the whole requirement.',
+      },
+      teaching: {
+        support: 'yes',
+        note: 'Teaching/Mentoring 1 CEU/hr; creating instructional materials 2 CEU/hr; SME workshop 1 CEU/hr (Security+ teaching capped at 20).',
+      },
+      work: {
+        support: 'no',
+        note: 'Generic volunteering does NOT count. Work experience credited separately at 3 CEU/yr.',
+      },
+    },
+    relevance: 'domain-relevant-only',
+    dedupRules: ['Same content credited once per cycle'],
+    sourceUrl:
+      'https://www.comptia.org/en-us/resources/ce/learn/earn-continuing-education-units-ceus/',
+    supported: true,
+    landing: {
+      slug: 'free-ceus-comptia',
+      title: 'Free CEUs for CompTIA (A+, Network+, Security+) by Volunteering',
+      description:
+        'Earn free CompTIA CEUs by teaching, mentoring, and completing training with Free For Charity. Note: CompTIA does not credit generic volunteering — we focus you on the channels that do count.',
+      keywords:
+        'free CEUs Security+, free CEUs A+, renew CompTIA without retaking exam, CompTIA CEUs volunteering, teach mentor CompTIA CEUs',
+      costContrast:
+        '$50/yr CE fee vs. $129–179 for CertMaster CE — earn the units with us for free.',
+    },
+  },
+  {
+    slug: 'isaca',
+    name: 'ISACA',
+    fullName: 'ISACA (CISA, CISM, CRISC, CGEIT)',
+    certs: ['CISA', 'CISM', 'CRISC', 'CGEIT'],
+    unit: 'CPE',
+    unitPlural: 'CPEs',
+    cycleYears: 3,
+    total: '120 / 3 yr',
+    annualMin: '20 CPE/yr minimum',
+    channels: {
+      education: { support: 'yes', note: 'Self-study and training received: no cap.' },
+      teaching: {
+        support: 'yes',
+        note: 'Teaching/presenting: no cap; 5× presentation time credited for first delivery.',
+      },
+      work: {
+        support: 'limited',
+        note: 'Volunteering on ISACA boards/committees 1 CPE/hr (max 20/yr); mentoring max 10/yr.',
+      },
+    },
+    relevance: 'domain-relevant-only',
+    dedupRules: [
+      'First delivery only for the 5× teaching multiplier',
+      '2027 change: ≥90/120 must be domain-aligned; domain volunteering 60 max/cycle, non-domain 30 max/cycle',
+    ],
+    sourceUrl: 'https://www.isaca.org/credentialing/how-to-earn-cpe',
+    supported: true,
+    landing: {
+      slug: 'free-cpe-credits-isaca',
+      title: 'Free CPE Credits for ISACA (CISA, CISM, CRISC) by Volunteering',
+      description:
+        'Earn free ISACA CPEs toward CISA, CISM, CRISC, or CGEIT by teaching and doing domain-relevant work with Free For Charity. Teaching is uncapped and bonus-weighted.',
+      keywords:
+        'free CPE ISACA, free CPE CISA, CISM CPE volunteering, renew ISACA without paying, ISACA teaching CPE',
+      costContrast: 'Uncapped teaching CPEs at $0 vs. paid ISACA training and conferences.',
+    },
+  },
+  {
+    slug: 'cfre',
+    name: 'CFRE',
+    fullName: 'CFRE (Certified Fund Raising Executive)',
+    certs: ['CFRE'],
+    unit: 'point',
+    unitPlural: 'points',
+    cycleYears: 3,
+    total:
+      '115 / 3 yr (Education category 45 pts; Professional Practice 30; Professional Performance 40)',
+    channels: {
+      education: { support: 'yes', note: 'Education 1 pt/hr (category max 45 pts).' },
+      teaching: {
+        support: 'yes',
+        note: 'Teaching 2 pts/hr existing material, 3 pts/hr new material; non-fundraising education capped at 5 pts.',
+      },
+      work: {
+        support: 'limited',
+        note: 'The only body that credits general volunteer service: “service learning” max 10 pts; volunteer leadership 2 pts/yr each.',
+      },
+    },
+    relevance: 'general-ok',
+    dedupRules: ['Service-learning capped at 10 pts/cycle'],
+    sourceUrl: 'https://www.cfre.org/certification/recertification/recertification-points',
+    supported: true,
+    landing: {
+      slug: 'free-cfre-points',
+      title: 'Free CFRE Points by Volunteering Your Fundraising Skills',
+      description:
+        'Earn free CFRE recertification points by doing pro bono fundraising and teaching with Free For Charity — the one certification that also credits general volunteer service (capped).',
+      keywords:
+        'free CFRE points, CFRE recertification volunteering, pro bono fundraising CFRE, renew CFRE without paying',
+      costContrast:
+        'Earn Education and service-learning points at $0 vs. paid CFRE webinars and courses.',
+    },
+  },
+  {
+    slug: 'giac',
+    name: 'GIAC',
+    fullName: 'GIAC (GSEC, GCIH, …)',
+    certs: ['GSEC', 'GCIH', 'GCIA'],
+    unit: 'CPE',
+    unitPlural: 'CPEs',
+    cycleYears: 4,
+    total: '36 CPE / 4 yr',
+    channels: {
+      education: { support: 'yes', note: '“Other InfoSec training” received: max 18 CPE/renewal.' },
+      teaching: {
+        support: 'limited',
+        note: 'Volunteering/Community Participation (incl. conducting training): max 12 CPE/renewal.',
+      },
+      work: { support: 'limited', note: 'Work experience: max 12 CPE/renewal.' },
+    },
+    relevance: 'domain-relevant-only',
+    dedupRules: ['Community-participation channel capped at 12 CPE/renewal'],
+    sourceUrl: 'https://www.giac.org/renewal/cpe-information',
+    supported: true,
+    landing: {
+      slug: 'free-cpe-credits-giac',
+      title: 'Free CPE Credits for GIAC by Volunteering',
+      description:
+        'Earn free GIAC CPEs by completing InfoSec training and contributing security work with Free For Charity. We map your hours to GIAC’s renewal channels and caps.',
+      keywords:
+        'free CPE GIAC, GIAC renewal CPE, GSEC CPE volunteering, cybersecurity volunteer CPE',
+      costContrast: 'InfoSec training and community CPEs at $0 vs. paid GIAC training events.',
+    },
+  },
+  {
+    slug: 'ec-council',
+    name: 'EC-Council',
+    fullName: 'EC-Council (CEH / ECE)',
+    certs: ['CEH'],
+    unit: 'ECE credit',
+    unitPlural: 'ECE credits',
+    cycleYears: 3,
+    total: '120 / 3 yr (40/yr)',
+    channels: {
+      education: {
+        support: 'yes',
+        note: 'Webinars/seminars 1 credit each; training received counts.',
+      },
+      teaching: { support: 'yes', note: 'Teaching a new course = 21 credits.' },
+      work: {
+        support: 'no',
+        note: 'No clear generic-volunteering category — likely not eligible; verify in the ASPEN portal.',
+      },
+    },
+    relevance: 'domain-relevant-only',
+    dedupRules: ['Verify category eligibility in the ASPEN portal'],
+    sourceUrl: 'https://cert.eccouncil.org/ece-policy.html',
+    supported: true,
+    landing: {
+      slug: 'free-ece-credits-ec-council',
+      title: 'Free ECE Credits for EC-Council (CEH) by Volunteering',
+      description:
+        'Earn free EC-Council ECE credits toward your CEH by teaching and completing training with Free For Charity. Teaching a new course is worth 21 credits.',
+      keywords:
+        'free ECE credits CEH, EC-Council ECE volunteering, renew CEH without paying, CEH continuing education',
+      costContrast: 'Teaching and training credits at $0 vs. paid EC-Council courseware.',
+    },
+  },
+  // --- Explicitly NOT supported: no CE-hours model (documented so volunteers aren't misled) ---
+  {
+    slug: 'microsoft',
+    name: 'Microsoft',
+    fullName: 'Microsoft Certifications',
+    certs: ['MS-900', 'AZ-900', 'and role-based certs'],
+    unit: 'n/a',
+    unitPlural: 'n/a',
+    cycleYears: 1,
+    total: 'Renewed by a free annual online assessment — no CE hours',
+    channels: {
+      education: { support: 'no', note: 'No CE-hours model.' },
+      teaching: { support: 'no', note: 'No CE-hours model.' },
+      work: { support: 'no', note: 'No CE-hours model.' },
+    },
+    relevance: 'not-applicable',
+    dedupRules: [],
+    sourceUrl:
+      'https://learn.microsoft.com/en-us/credentials/certifications/renew-your-microsoft-certification',
+    supported: false,
+    unsupportedReason:
+      'Microsoft renews certifications via a free annual assessment, not CE hours.',
+  },
+  {
+    slug: 'google-cloud',
+    name: 'Google Cloud',
+    fullName: 'Google Cloud Certifications',
+    certs: ['Associate', 'Professional'],
+    unit: 'n/a',
+    unitPlural: 'n/a',
+    cycleYears: 2,
+    total: 'Renewed by retaking the exam — no CE hours',
+    channels: {
+      education: { support: 'no', note: 'No CE-hours model.' },
+      teaching: { support: 'no', note: 'No CE-hours model.' },
+      work: { support: 'no', note: 'No CE-hours model.' },
+    },
+    relevance: 'not-applicable',
+    dedupRules: [],
+    sourceUrl: 'https://support.google.com/cloud-certification/answer/9907853',
+    supported: false,
+    unsupportedReason:
+      'Google Cloud recertification is by re-exam (Pro 2 yr, Assoc 3 yr), not CE hours.',
+  },
+  {
+    slug: 'aws',
+    name: 'AWS',
+    fullName: 'AWS Certifications',
+    certs: ['Foundational', 'Associate', 'Professional', 'Specialty'],
+    unit: 'n/a',
+    unitPlural: 'n/a',
+    cycleYears: 3,
+    total: 'Renewed by retaking the exam — explicitly does not accept CE credits',
+    channels: {
+      education: { support: 'no', note: 'No CE-hours model.' },
+      teaching: { support: 'no', note: 'No CE-hours model.' },
+      work: { support: 'no', note: 'No CE-hours model.' },
+    },
+    relevance: 'not-applicable',
+    dedupRules: [],
+    sourceUrl: 'https://aws.amazon.com/certification/recertification/',
+    supported: false,
+    unsupportedReason:
+      'AWS recertification is by re-exam and explicitly does not accept CE credits.',
+  },
+]
+
+/** The compliance disclaimer shipped on every CE page (verbatim from the epic). */
+export const CE_DISCLAIMER =
+  'FFC certifies the hours and activities a volunteer completed. Acceptance of those hours toward any certification is governed solely by the issuing body’s current rules, which the volunteer is responsible for following. FFC is not an accredited/approved CE provider for these bodies.'
+
+export const CHANNEL_LABELS: Record<CreditChannel, string> = {
+  education: 'Training received',
+  teaching: 'Training delivered',
+  work: 'Domain-relevant work',
+}
+
+export const SUPPORTED_CE_BODIES = CE_BODIES.filter((b) => b.supported)
+export const UNSUPPORTED_CE_BODIES = CE_BODIES.filter((b) => !b.supported)
+
+/** Bodies that have a per-body SEO landing page (#363). */
+export const CE_LANDING_BODIES = CE_BODIES.filter((b) => b.landing)
+
+export function getCeBody(slug: string): CeBody | undefined {
+  return CE_BODIES.find((b) => b.slug === slug)
+}
+
+export function getCeBodyByLandingSlug(slug: string): CeBody | undefined {
+  return CE_BODIES.find((b) => b.landing?.slug === slug)
+}

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -64,6 +64,11 @@ export const trainingDropdown: NavDropdown = {
       href: '/recognition',
       description: 'Volunteer badges that map 1:1 to GitHub access roles.',
     },
+    {
+      label: 'Continuing Education',
+      href: '/continuing-education',
+      description: 'Earn free CE credit (CPE/PDU/CEU) toward your certification by volunteering.',
+    },
   ],
 }
 


### PR DESCRIPTION
## Summary

Builds the public-facing surface of the **Continuing Education (CE) credentialing pathway** epic (#355): the compliance-matrix data, the designation pillar page, and the data-driven per-body SEO landing-page cluster — all unified with the existing MOVSM funnel.

This is the **buildable core** of the epic. The remaining sub-issues (#358 documentation artifact, #359 CE badge tiers, #360 hours evidence model, #361/#362 hours backend) depend on the separate hours-tracking backend and owner decisions, so they follow separately.

## Changes

### #356 — Compliance matrix (`src/data/ce-bodies.ts`)
Single source of truth so the pages never hardcode numbers that can drift. Per body: cycle, total, annual minimum, unit, and per-channel caps for the three credit channels (**training received / training delivered / domain-relevant work**), plus a relevance flag, de-dup rules, and the official source URL. Encodes the headline reality honestly:
- **Supported:** ISC2, PMI, CompTIA, ISACA, CFRE, GIAC, EC-Council.
- **Explicitly unsupported (no CE-hours model):** Microsoft, Google Cloud, AWS — documented with reasons so volunteers aren't misled.
- **CompTIA credits no volunteer work**; only **CFRE** credits general volunteering (capped) — both encoded.
- Ships the verbatim compliance disclaimer.

### #357 — `/continuing-education` pillar page
Three-channel explainer, a **data-driven support matrix** (per body × channel, with official-source links), the unsupported-vendor note, a "how to claim" flow tied to recognition validation, per-cert guide links, the disclaimer, and `FAQPage` JSON-LD. Framed as a designation layered on the volunteer tracks, cross-linked to `/movsm`.

### #363 — `/continuing-education/[body]` landing cluster
Seven data-driven, keyword-front-loaded landing pages (`free-cpe-credits-isc2`, `free-pdus-pmi`, `free-ceus-comptia`, `free-cpe-credits-isaca`, `free-cfre-points`, `free-cpe-credits-giac`, `free-ece-credits-ec-council`) via `generateStaticParams`, each with the honest cost contrast, per-body channel rules, how-to-claim, `FAQPage` JSON-LD, self-canonical, and **MOVSM cross-links in both directions** (unified SEO cluster).

### Wiring
- Nav: "Continuing Education" added to the Training dropdown.
- Sitemap: pillar + 7 landing pages.
- `/movsm`: additive "you can also earn CE credit" callback (no regression to the shipped MOVSM page).
- Tests: `ce-bodies` data test (supported/unsupported sets, channel shape, CompTIA-no-work rule, disclaimer) + route-generation tests for the pillar and landing pages.

## Verification
- `pnpm run lint` — clean (pre-existing warnings only)
- `pnpm run build` — pillar + 7 SSG landing pages prerender
- `pnpm test` — 372 passed

Refs #355, #356, #357, #363, #335.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X4omPQW2ErDyZsMtxypuMe)_