### PR TITLE
feat: define CE hours evidence model (#360)

### DIFF
--- a/__tests__/hours-model.test.ts
+++ b/__tests__/hours-model.test.ts
@@ -1,0 +1,83 @@
+import {
+  GITHUB_AUTO_ACTIVITIES,
+  SAMPLE_HOURS_ENTRIES,
+  makeDedupKey,
+  requiresSelfLog,
+  approvedEntries,
+  creditability,
+  hoursByChannel,
+  type HoursEntry,
+} from '../src/data/hours-model'
+import { getCeBody } from '../src/data/ce-bodies'
+
+describe('CE hours evidence model (#360)', () => {
+  it('classifies GitHub-auto vs self-log activity types', () => {
+    expect(requiresSelfLog('pull_request')).toBe(false)
+    expect(requiresSelfLog('commit')).toBe(false)
+    expect(requiresSelfLog('design')).toBe(true)
+    expect(requiresSelfLog('mentoring')).toBe(true)
+    expect(GITHUB_AUTO_ACTIVITIES).toContain('review')
+  })
+
+  it('builds a stable, case-insensitive de-dup key', () => {
+    const a = makeDedupKey({
+      volunteer: 'X',
+      githubHandle: 'gh',
+      date: '2026-05-01',
+      activityType: 'pull_request',
+      evidenceUrl: 'https://github.com/o/r/pull/1',
+    })
+    const b = makeDedupKey({
+      volunteer: 'X',
+      githubHandle: 'GH',
+      date: '2026-05-01',
+      activityType: 'pull_request',
+      evidenceUrl: 'HTTPS://GITHUB.COM/o/r/pull/1',
+    })
+    expect(a).toBe(b)
+  })
+
+  it('only counts approved, de-duplicated entries', () => {
+    const dupe: HoursEntry = { ...SAMPLE_HOURS_ENTRIES[0], id: 'dupe' }
+    const result = approvedEntries([...SAMPLE_HOURS_ENTRIES, dupe])
+    // sample-1 is approved; sample-2 is pending; the duplicate is dropped
+    expect(result).toHaveLength(1)
+    expect(result[0].status).toBe('approved')
+  })
+
+  it('totals approved hours by channel', () => {
+    const totals = hoursByChannel(SAMPLE_HOURS_ENTRIES)
+    expect(totals.work).toBe(4) // the approved PR entry
+    expect(totals.education).toBe(0) // sample-2 is still pending
+  })
+
+  it('applies #356 channel + relevance rules via creditability', () => {
+    const comptia = getCeBody('comptia')!
+    const isc2 = getCeBody('isc2')!
+    const workEntry = SAMPLE_HOURS_ENTRIES[0]
+
+    // CompTIA credits no volunteer work
+    expect(creditability(workEntry, comptia).creditable).toBe(false)
+    // ISC2 credits domain-relevant security work
+    expect(creditability(workEntry, isc2).creditable).toBe(true)
+
+    // Non-domain-relevant work fails the relevance gate
+    const generic = { ...workEntry, domainRelevant: false }
+    expect(creditability(generic, isc2).creditable).toBe(false)
+  })
+
+  it('rejects credit for unsupported bodies', () => {
+    const microsoft = getCeBody('microsoft')!
+    expect(creditability(SAMPLE_HOURS_ENTRIES[0], microsoft).creditable).toBe(false)
+  })
+
+  it('teaching credit is first-delivery only', () => {
+    const isc2 = getCeBody('isc2')!
+    const repeat: HoursEntry = {
+      ...SAMPLE_HOURS_ENTRIES[0],
+      channel: 'teaching',
+      firstDelivery: false,
+    }
+    expect(creditability(repeat, isc2).creditable).toBe(false)
+  })
+})

--- a/docs/hours-evidence-model.md
+++ b/docs/hours-evidence-model.md
@@ -1,0 +1,78 @@
+# CE hours evidence model (#360)
+
+The shared "system of record" schema for volunteer + training hours that FFC
+certifies toward continuing-education credit (#356), the FFC documentation
+artifact (#358), the MOVSM funnel (#335), and recognition badges (#359/#336).
+
+This is the **model** — the TypeScript source of truth is
+[`src/data/hours-model.ts`](../src/data/hours-model.ts). **Where/how** entries are
+stored and automated is the separate backend epic (#361/#362); whichever backend
+is chosen must emit records matching `HoursEntry` (ideally as committed JSON, per
+the #337 scheduled-Actions pattern) so everything downstream consumes one shape.
+
+## Principles
+
+- **Hybrid evidence.** GitHub activity is auto-evidenced; non-code work is
+  self-logged.
+- **No self-claim for credit.** Every entry is certified by a mentor / program
+  lead before it counts. The certifying authority is the named `approver`.
+- **One engine, three consumers.** The same approved hours feed CE conversion,
+  MOVSM documentation, and recognition badges — reusing the validation approach
+  already used by #335 and #336.
+
+## `HoursEntry` schema
+
+| Field                        | Meaning                                                     |
+| ---------------------------- | ----------------------------------------------------------- |
+| `id`                         | Stable unique id.                                           |
+| `volunteer` / `githubHandle` | Who.                                                        |
+| `date` / `endDate`           | When (single day or range).                                 |
+| `activityType`               | One of the GitHub-auto or self-log activity types below.    |
+| `activity`                   | Human description.                                          |
+| `channel`                    | CE credit channel: `education` / `teaching` / `work`.       |
+| `rawHours`                   | Hours logged, **before** per-body caps.                     |
+| `source`                     | `github` or `self-log`.                                     |
+| `evidenceUrl`                | PR/commit/issue URL, or a doc/notes reference.              |
+| `moduleId`                   | For `training-received`: the #320 module completed.         |
+| `domainRelevant`             | Whether it passes a body's profession-relevance test.       |
+| `firstDelivery`              | Teaching de-dup: `true` only for first delivery of content. |
+| `dedupKey`                   | Stable key so the same activity is never counted twice.     |
+| `approver` / `status`        | Certifier + `pending` / `approved` / `rejected`.            |
+
+## What auto-counts vs needs a self-log
+
+- **GitHub auto-evidence** (`source: github`): `pull_request`, `commit`,
+  `issue`, `review`. These can be derived automatically from repo activity (cf.
+  recognition's commit-history validation #336 and the #337 pipeline).
+- **Self-logged** (`source: self-log`): `design`, `admin`, `meeting`,
+  `mentoring`, `training-received`, `training-delivered`, `other` — things GitHub
+  can't see. The volunteer logs date, activity, channel, and hours.
+
+`requiresSelfLog(activityType)` encodes this split.
+
+## Approval workflow
+
+1. **Intake** — GitHub activity is ingested automatically; non-code work is
+   self-logged.
+2. **Certify** — an entry routes to a mentor / program lead who sets
+   `status: approved` and records themselves as `approver`. Nothing counts while
+   `pending`.
+3. **De-dup** — `approvedEntries()` drops duplicates by `dedupKey`.
+4. **Total** — `hoursByChannel()` sums approved raw hours per channel.
+
+## Mapping to credit
+
+`creditability(entry, body)` applies the compliance-matrix (#356) channel
+support + relevance rules to decide whether an approved entry is _eligible_ for a
+given body (e.g. CompTIA credits no `work`; ISC2 needs domain-relevant work;
+teaching is first-delivery only). Precise **numeric caps** stay as prose in
+`ce-bodies.ts` — they vary by cert and change over time — and are applied by the
+documentation step (#358), not machine-parsed, so figures never silently drift.
+
+## Channel sources of hours
+
+- `training-received` → hours from the completed #320 module's published
+  CE-eligible hours (`moduleId`).
+- `training-delivered` / `work` → hours from approved self-log or GitHub
+  evidence, carrying `firstDelivery` / `domainRelevant` flags through to
+  conversion.

--- a/src/data/hours-model.ts
+++ b/src/data/hours-model.ts
@@ -100,8 +100,10 @@ export function approvedEntries(entries: HoursEntry[]): HoursEntry[] {
   const out: HoursEntry[] = []
   for (const e of entries) {
     if (e.status !== 'approved') continue
-    if (seen.has(e.dedupKey)) continue
-    seen.add(e.dedupKey)
+    // Normalize the key so de-dup is robust even if a backend emits inconsistent casing.
+    const key = e.dedupKey.toLowerCase()
+    if (seen.has(key)) continue
+    seen.add(key)
     out.push(e)
   }
   return out
@@ -118,8 +120,15 @@ export function creditability(
   entry: HoursEntry,
   body: CeBody
 ): { creditable: boolean; reason: string } {
+  // Only approved entries count; pending/rejected are never creditable.
+  if (entry.status !== 'approved') {
+    return { creditable: false, reason: `Entry is ${entry.status}, not approved.` }
+  }
   if (!body.supported) {
-    return { creditable: false, reason: `${body.name} has no CE-hours model.` }
+    return {
+      creditable: false,
+      reason: body.unsupportedReason ?? `${body.name} has no CE-hours model.`,
+    }
   }
   const channel = body.channels[entry.channel]
   if (channel.support === 'no') {
@@ -170,7 +179,13 @@ export const SAMPLE_HOURS_ENTRIES: HoursEntry[] = [
     source: 'github',
     evidenceUrl: 'https://github.com/FreeForCharity/example/pull/1',
     domainRelevant: true,
-    dedupKey: 'sample|2026-05-01|pull_request|https://github.com/freeforcharity/example/pull/1',
+    dedupKey: makeDedupKey({
+      volunteer: 'Sample Volunteer',
+      githubHandle: 'sample',
+      date: '2026-05-01',
+      activityType: 'pull_request',
+      evidenceUrl: 'https://github.com/FreeForCharity/example/pull/1',
+    }),
     approver: 'Program Lead',
     status: 'approved',
   },
@@ -186,7 +201,12 @@ export const SAMPLE_HOURS_ENTRIES: HoursEntry[] = [
     source: 'self-log',
     moduleId: 'security-trust',
     domainRelevant: true,
-    dedupKey: 'sample|2026-05-03|training-received|',
+    dedupKey: makeDedupKey({
+      volunteer: 'Sample Volunteer',
+      githubHandle: 'sample',
+      date: '2026-05-03',
+      activityType: 'training-received',
+    }),
     approver: 'Program Lead',
     status: 'pending',
   },

--- a/src/data/hours-model.ts
+++ b/src/data/hours-model.ts
@@ -1,0 +1,193 @@
+/**
+ * CE hours evidence model (#360) — the data *model* for logging, approving, and
+ * totalling volunteer + training hours so FFC can certify them toward CE credit
+ * (#356), the documentation artifact (#358), MOVSM (#335), and recognition
+ * badges (#359/#336).
+ *
+ * This file defines *what* is tracked and the rules for it. *Where/how* it is
+ * stored and automated is the separate backend epic (#361/#362) — whichever
+ * backend is chosen must emit records matching `HoursEntry` (e.g. committed
+ * JSON, per the #337 scheduled-Actions pattern) so everything downstream can
+ * consume one shape.
+ *
+ * Evidence is hybrid and never self-claimed for credit:
+ *   - GitHub activity (PRs/commits/issues/reviews) auto-counts as evidence.
+ *   - Non-code work (design/admin/meetings/mentoring/training) is self-logged.
+ *   - Every entry is certified by a mentor / program lead before it counts.
+ */
+import type { CeBody, CreditChannel } from './ce-bodies'
+
+export type HoursSource = 'github' | 'self-log'
+
+export type ApprovalStatus = 'pending' | 'approved' | 'rejected'
+
+/** Activity types GitHub can evidence automatically (no self-log needed). */
+export const GITHUB_AUTO_ACTIVITIES = ['pull_request', 'commit', 'issue', 'review'] as const
+export type GitHubActivity = (typeof GITHUB_AUTO_ACTIVITIES)[number]
+
+/** Activity types GitHub can't see — these require a self-logged entry. */
+export const SELF_LOG_ACTIVITIES = [
+  'design',
+  'admin',
+  'meeting',
+  'mentoring',
+  'training-received',
+  'training-delivered',
+  'other',
+] as const
+export type SelfLogActivity = (typeof SELF_LOG_ACTIVITIES)[number]
+
+export type ActivityType = GitHubActivity | SelfLogActivity
+
+export interface HoursEntry {
+  /** Stable unique id. */
+  id: string
+  volunteer: string
+  githubHandle?: string
+  /** ISO date (range start) of the activity. */
+  date: string
+  /** Optional range end for multi-day activities. */
+  endDate?: string
+  activityType: ActivityType
+  /** Human description of what was done. */
+  activity: string
+  /** Which CE credit channel this maps to. */
+  channel: CreditChannel
+  /** Raw hours logged, before any per-body caps are applied. */
+  rawHours: number
+  source: HoursSource
+  /** Evidence: a PR/commit/issue URL (github) or a doc/notes reference (self-log). */
+  evidenceUrl?: string
+  /** For `training-received`: the #320 module completed (its published CE hours). */
+  moduleId?: string
+  /** Whether the activity is relevant to the volunteer's certification domain. */
+  domainRelevant: boolean
+  /** Teaching de-dup: true only for the first delivery of this content. */
+  firstDelivery?: boolean
+  /** Stable key so the same activity is never counted twice. */
+  dedupKey: string
+  /** The mentor / program lead who certifies the entry. */
+  approver?: string
+  status: ApprovalStatus
+}
+
+/** Build a stable de-dup key from the identifying parts of an entry. */
+export function makeDedupKey(parts: {
+  githubHandle?: string
+  volunteer: string
+  date: string
+  activityType: ActivityType
+  evidenceUrl?: string
+}): string {
+  return [
+    parts.githubHandle || parts.volunteer,
+    parts.date,
+    parts.activityType,
+    parts.evidenceUrl || '',
+  ]
+    .join('|')
+    .toLowerCase()
+}
+
+/** Does this activity type auto-count from GitHub, or need a self-log? */
+export function requiresSelfLog(activityType: ActivityType): boolean {
+  return !GITHUB_AUTO_ACTIVITIES.includes(activityType as GitHubActivity)
+}
+
+/** Approved, de-duplicated entries (the only ones that count toward credit). */
+export function approvedEntries(entries: HoursEntry[]): HoursEntry[] {
+  const seen = new Set<string>()
+  const out: HoursEntry[] = []
+  for (const e of entries) {
+    if (e.status !== 'approved') continue
+    if (seen.has(e.dedupKey)) continue
+    seen.add(e.dedupKey)
+    out.push(e)
+  }
+  return out
+}
+
+/**
+ * Whether an approved entry is creditable toward a given body, applying the
+ * channel support + relevance rules from the compliance matrix (#356). This is
+ * the MVP "is it eligible" gate; precise numeric caps stay as prose in
+ * `ce-bodies.ts` and are applied by a human/documentation step (caps there are
+ * intentionally not machine-parsed because they vary by cert and change).
+ */
+export function creditability(
+  entry: HoursEntry,
+  body: CeBody
+): { creditable: boolean; reason: string } {
+  if (!body.supported) {
+    return { creditable: false, reason: `${body.name} has no CE-hours model.` }
+  }
+  const channel = body.channels[entry.channel]
+  if (channel.support === 'no') {
+    return { creditable: false, reason: `${body.name} does not credit this channel.` }
+  }
+  if (
+    entry.channel === 'work' &&
+    body.relevance === 'domain-relevant-only' &&
+    !entry.domainRelevant
+  ) {
+    return {
+      creditable: false,
+      reason: `${body.name} only credits domain-relevant work; this entry is not flagged relevant.`,
+    }
+  }
+  if (entry.channel === 'teaching' && entry.firstDelivery === false) {
+    return {
+      creditable: false,
+      reason: 'Teaching credit applies to first delivery only (de-dup).',
+    }
+  }
+  return { creditable: true, reason: channel.note }
+}
+
+/** Total approved raw hours per channel (before per-body caps). */
+export function hoursByChannel(entries: HoursEntry[]): Record<CreditChannel, number> {
+  const totals: Record<CreditChannel, number> = { education: 0, teaching: 0, work: 0 }
+  for (const e of approvedEntries(entries)) {
+    totals[e.channel] += e.rawHours
+  }
+  return totals
+}
+
+/**
+ * Sample entries — illustrative only (not real logged hours). They show the
+ * shape each backend (#361/#362) must emit. Replace with the live export.
+ */
+export const SAMPLE_HOURS_ENTRIES: HoursEntry[] = [
+  {
+    id: 'sample-1',
+    volunteer: 'Sample Volunteer',
+    githubHandle: 'sample',
+    date: '2026-05-01',
+    activityType: 'pull_request',
+    activity: 'Built a charity site section and opened a reviewed PR.',
+    channel: 'work',
+    rawHours: 4,
+    source: 'github',
+    evidenceUrl: 'https://github.com/FreeForCharity/example/pull/1',
+    domainRelevant: true,
+    dedupKey: 'sample|2026-05-01|pull_request|https://github.com/freeforcharity/example/pull/1',
+    approver: 'Program Lead',
+    status: 'approved',
+  },
+  {
+    id: 'sample-2',
+    volunteer: 'Sample Volunteer',
+    githubHandle: 'sample',
+    date: '2026-05-03',
+    activityType: 'training-received',
+    activity: 'Completed the Security & Trust module.',
+    channel: 'education',
+    rawHours: 3,
+    source: 'self-log',
+    moduleId: 'security-trust',
+    domainRelevant: true,
+    dedupKey: 'sample|2026-05-03|training-received|',
+    approver: 'Program Lead',
+    status: 'pending',
+  },
+]


### PR DESCRIPTION
## Summary

Implements #360 — the **hours evidence model**: the shared schema for logging, approving, and totalling volunteer + training hours that CE conversion (#356), the FFC documentation artifact (#358), MOVSM (#335), and recognition badges (#359/#336) all consume. One engine, not three.

This defines **what** is tracked and the rules for it. **Where/how** it's stored and automated is the separate backend epic (#361/#362) — whichever backend is chosen must emit records matching `HoursEntry` (ideally committed JSON per the #337 pattern).

## Changes

- **`src/data/hours-model.ts`**:
  - `HoursEntry` schema — who, date(s), activity type, channel, raw hours, source (`github`/`self-log`), evidence URL, `moduleId`, `domainRelevant`, `firstDelivery`, `dedupKey`, `approver`, `status`.
  - GitHub-auto activities (`pull_request`/`commit`/`issue`/`review`) vs self-log activities (design/admin/meeting/mentoring/training) + `requiresSelfLog()`.
  - `approvedEntries()` (approval gate + de-dup), `hoursByChannel()` (totals), `makeDedupKey()`.
  - `creditability(entry, body)` — applies the #356 channel-support + relevance rules (CompTIA credits no work; ISC2 needs domain-relevant work; teaching first-delivery only; unsupported bodies rejected). Numeric caps intentionally stay as prose in `ce-bodies.ts` so figures never silently drift.
  - Clearly-labelled sample entries showing the shape a backend must emit.
- **`docs/hours-evidence-model.md`** — documents the model, the GitHub-auto-vs-self-log split, the approval workflow, and credit mapping.
- **Tests** — `hours-model.test.ts` covers classification, de-dup, approval gating, channel totals, and the creditability rules.

## Verification
- `pnpm run type-check` — clean
- `pnpm run lint` — clean (pre-existing warnings only)
- `pnpm run build` — green
- `pnpm test` — 382 passed

Refs #355.

Closes #360

---
_Generated by [Claude Code](https://claude.ai/code/session_01X4omPQW2ErDyZsMtxypuMe)_