### PR TITLE
feat: add FFC CE documentation artifact generator (#358)

### DIFF
--- a/__tests__/ce-documentation.test.ts
+++ b/__tests__/ce-documentation.test.ts
@@ -1,0 +1,113 @@
+import { buildCeDocument, renderCeDocumentMarkdown, FFC_ISSUER } from '../src/lib/ceDocumentation'
+import { getCeBody } from '../src/data/ce-bodies'
+import type { HoursEntry } from '../src/data/hours-model'
+
+const entries: HoursEntry[] = [
+  {
+    id: '1',
+    volunteer: 'Jane Doe',
+    githubHandle: 'jane',
+    date: '2026-05-02',
+    activityType: 'training-received',
+    activity: 'Completed Security & Trust module',
+    channel: 'education',
+    rawHours: 3,
+    source: 'self-log',
+    domainRelevant: true,
+    dedupKey: 'jane|2026-05-02|training-received|',
+    approver: 'Program Lead',
+    status: 'approved',
+  },
+  {
+    id: '2',
+    volunteer: 'Jane Doe',
+    githubHandle: 'jane',
+    date: '2026-05-05',
+    activityType: 'pull_request',
+    activity: 'Secured a charity site',
+    channel: 'work',
+    rawHours: 4,
+    source: 'github',
+    domainRelevant: true,
+    dedupKey: 'jane|2026-05-05|pull_request|x',
+    approver: 'Program Lead',
+    status: 'approved',
+  },
+  {
+    id: '3',
+    volunteer: 'Jane Doe',
+    githubHandle: 'jane',
+    date: '2026-05-06',
+    activityType: 'design',
+    activity: 'Pending entry should be excluded',
+    channel: 'work',
+    rawHours: 9,
+    source: 'self-log',
+    domainRelevant: true,
+    dedupKey: 'jane|2026-05-06|design|',
+    approver: 'Program Lead',
+    status: 'pending',
+  },
+]
+
+describe('CE documentation artifact (#358)', () => {
+  it('includes only approved entries for the named volunteer', () => {
+    const doc = buildCeDocument({
+      volunteer: 'Jane Doe',
+      githubHandle: 'jane',
+      entries,
+      body: getCeBody('isc2')!,
+      now: new Date('2026-06-06T00:00:00Z'),
+    })
+    expect(doc.rows).toHaveLength(2) // pending excluded
+    expect(doc.issueDate).toBe('2026-06-06')
+  })
+
+  it('applies per-body eligibility (ISC2 credits domain work; CompTIA does not)', () => {
+    const isc2Doc = buildCeDocument({
+      volunteer: 'Jane Doe',
+      githubHandle: 'jane',
+      entries,
+      body: getCeBody('isc2')!,
+    })
+    // education 3 + work 4 both eligible for ISC2
+    expect(isc2Doc.totalEligibleHours).toBe(7)
+
+    const comptiaDoc = buildCeDocument({
+      volunteer: 'Jane Doe',
+      githubHandle: 'jane',
+      entries,
+      body: getCeBody('comptia')!,
+    })
+    // CompTIA: education eligible (3), work not (0)
+    expect(comptiaDoc.eligibleByChannel.work).toBe(0)
+    expect(comptiaDoc.eligibleByChannel.education).toBe(3)
+  })
+
+  it('renders an audit-friendly letter with issuer, disclaimer, and verification', () => {
+    const doc = buildCeDocument({
+      volunteer: 'Jane Doe',
+      githubHandle: 'jane',
+      entries,
+      body: getCeBody('isc2')!,
+    })
+    const md = renderCeDocumentMarkdown(doc)
+    expect(md).toContain('Certification of Volunteer & Training Hours')
+    expect(md).toContain(FFC_ISSUER.org)
+    expect(md).toContain('501(c)(3)')
+    expect(md).toContain('not an accredited/approved CE provider')
+    expect(md).toContain('Verification')
+    expect(md).toContain('Completed Security & Trust module')
+  })
+
+  it('allows the EIN to be supplied at generation time', () => {
+    const doc = buildCeDocument({
+      volunteer: 'Jane Doe',
+      githubHandle: 'jane',
+      entries,
+      body: getCeBody('isc2')!,
+      issuer: { ...FFC_ISSUER, ein: '12-3456789' },
+    })
+    expect(renderCeDocumentMarkdown(doc)).toContain('12-3456789')
+  })
+})

--- a/docs/ce-documentation-artifact.md
+++ b/docs/ce-documentation-artifact.md
@@ -1,0 +1,45 @@
+# FFC CE documentation artifact (#358)
+
+The verified record a volunteer self-reports to their certifying body: a signed
+letter + an hours table, formatted to satisfy a body's CE audit (date, activity,
+hours, category, provider contact). Fully data-driven — generated from the
+approved-hours log, no manual per-volunteer editing.
+
+- **Builder/template:** [`src/lib/ceDocumentation.ts`](../src/lib/ceDocumentation.ts)
+  (`buildCeDocument` + `renderCeDocumentMarkdown`).
+- **Generator CLI:** [`scripts/generate-ce-documentation.ts`](../scripts/generate-ce-documentation.ts).
+- **Data source:** `public/data/volunteer-hours.json` (approved hours, #361/#362).
+- **Categorization:** `src/data/ce-bodies.ts` (#356) via `creditability()`.
+
+## What it contains
+
+- Issuer block: FFC org name, 501(c)(3) tax status, EIN (supplied at generation
+  time), signer name/role, verification email + phone, issue date.
+- Per-activity rows: date, activity, channel, hours, **eligibility for the
+  target body**, category/cap note, and the verifying approver.
+- Eligible totals by channel (raw — the body applies its own numeric caps).
+- The compliance disclaimer (verbatim from the epic).
+
+## Generating one
+
+```bash
+pnpm tsx scripts/generate-ce-documentation.ts --body isc2 --handle janedoe
+pnpm tsx scripts/generate-ce-documentation.ts --body pmi --volunteer "Jane Doe" --ein 12-3456789
+```
+
+The Markdown is printed to stdout (printable / attachable / convertible to PDF).
+
+## Format
+
+The MVP is an **audit-friendly Markdown letter** (model + renderer). The same
+`CeDocument` model can drive future formats without rework:
+
+- **PDF** — render the Markdown/HTML to PDF for a signed attachment.
+- **Per-body CSV** — emit rows in a body's self-report import format.
+- **Digital badge** (Open Badges) — complements, not replaces, the audit letter
+  (ties to the recognition badges #359/#336).
+
+## Relationship to MOVSM
+
+This shares machinery with the MOVSM documentation-provider letter (#335) — same
+hours engine, different template. A future shared generator can emit both.

--- a/scripts/generate-ce-documentation.ts
+++ b/scripts/generate-ce-documentation.ts
@@ -1,0 +1,59 @@
+#!/usr/bin/env tsx
+/**
+ * Generate an FFC CE documentation artifact for one volunteer + body (#358).
+ *
+ * Reads the committed approved-hours log (public/data/volunteer-hours.json,
+ * produced by the hours backend #361/#362) and prints an audit-friendly Markdown
+ * certification letter to stdout. Data-driven; no manual per-volunteer editing.
+ *
+ * Usage:
+ *   pnpm tsx scripts/generate-ce-documentation.ts --handle <gh> --body <slug>
+ *   pnpm tsx scripts/generate-ce-documentation.ts --volunteer "Jane Doe" --body isc2
+ *
+ * Optionally pass --ein <value> to fill the issuer EIN.
+ */
+import { readFileSync } from 'fs'
+import { join } from 'path'
+import { getCeBody } from '../src/data/ce-bodies'
+import type { HoursEntry } from '../src/data/hours-model'
+import { buildCeDocument, renderCeDocumentMarkdown, FFC_ISSUER } from '../src/lib/ceDocumentation'
+
+function arg(name: string): string | undefined {
+  const i = process.argv.indexOf(`--${name}`)
+  return i !== -1 ? process.argv[i + 1] : undefined
+}
+
+function main() {
+  const handle = arg('handle')
+  const volunteer = arg('volunteer')
+  const bodySlug = arg('body')
+  const ein = arg('ein')
+
+  if (!bodySlug || (!handle && !volunteer)) {
+    console.error(
+      'Usage: pnpm tsx scripts/generate-ce-documentation.ts --body <slug> (--handle <gh> | --volunteer "Name") [--ein <value>]'
+    )
+    process.exit(1)
+  }
+
+  const body = getCeBody(bodySlug)
+  if (!body) {
+    console.error(`Unknown body slug: ${bodySlug}`)
+    process.exit(1)
+  }
+
+  const file = join(process.cwd(), 'public', 'data', 'volunteer-hours.json')
+  const data = JSON.parse(readFileSync(file, 'utf8')) as { entries: HoursEntry[] }
+
+  const doc = buildCeDocument({
+    volunteer: volunteer || handle || 'Unknown',
+    githubHandle: handle,
+    entries: data.entries || [],
+    body,
+    issuer: ein ? { ...FFC_ISSUER, ein } : FFC_ISSUER,
+  })
+
+  process.stdout.write(renderCeDocumentMarkdown(doc) + '\n')
+}
+
+main()

--- a/scripts/generate-ce-documentation.ts
+++ b/scripts/generate-ce-documentation.ts
@@ -24,7 +24,7 @@ function arg(name: string): string | undefined {
 }
 
 function main() {
-  const handle = arg('handle')
+  const handle = arg('handle')?.replace(/^@/, '')
   const volunteer = arg('volunteer')
   const bodySlug = arg('body')
   const ein = arg('ein')
@@ -44,11 +44,16 @@ function main() {
 
   const file = join(process.cwd(), 'public', 'data', 'volunteer-hours.json')
   const data = JSON.parse(readFileSync(file, 'utf8')) as { entries: HoursEntry[] }
+  const entries = data.entries || []
+
+  // Resolve the volunteer's real name from the hours log when only a handle is given.
+  const resolvedName =
+    volunteer || entries.find((e) => e.githubHandle === handle)?.volunteer || handle || 'Unknown'
 
   const doc = buildCeDocument({
-    volunteer: volunteer || handle || 'Unknown',
+    volunteer: resolvedName,
     githubHandle: handle,
-    entries: data.entries || [],
+    entries,
     body,
     issuer: ein ? { ...FFC_ISSUER, ein } : FFC_ISSUER,
   })

--- a/src/lib/ceDocumentation.ts
+++ b/src/lib/ceDocumentation.ts
@@ -13,7 +13,7 @@
  */
 import type { CeBody } from '../data/ce-bodies'
 import { CE_DISCLAIMER } from '../data/ce-bodies'
-import { creditability, type HoursEntry } from '../data/hours-model'
+import { approvedEntries, creditability, type HoursEntry } from '../data/hours-model'
 import { FFC_FOUNDER_CONTACT } from '../data/legacy-wordpress-administration'
 import type { CreditChannel } from '../data/ce-bodies'
 
@@ -85,10 +85,10 @@ export function buildCeDocument(opts: {
   const issuer = opts.issuer ?? FFC_ISSUER
   const now = opts.now ?? new Date()
 
-  const mine = opts.entries.filter(
-    (e) =>
-      e.status === 'approved' &&
-      (opts.githubHandle ? e.githubHandle === opts.githubHandle : e.volunteer === opts.volunteer)
+  // approvedEntries() filters to approved status AND de-dups by key, so the
+  // document never double-counts hours or lists duplicate rows.
+  const mine = approvedEntries(opts.entries).filter((e) =>
+    opts.githubHandle ? e.githubHandle === opts.githubHandle : e.volunteer === opts.volunteer
   )
 
   const rows: CeDocumentRow[] = mine
@@ -137,8 +137,9 @@ export function renderCeDocumentMarkdown(doc: CeDocument): string {
     `This letter certifies that **${doc.volunteer}**${
       doc.githubHandle ? ` (GitHub: @${doc.githubHandle})` : ''
     } completed the volunteer and training activities below with ${doc.issuer.org}. ` +
-      `Of these, **${doc.totalEligibleHours} hour(s)** are eligible for ${doc.body.name} ` +
-      `${doc.body.unitPlural} under that body's published rules.`
+      `Of these, **${doc.totalEligibleHours} hour(s)** are eligible to be submitted toward ` +
+      `${doc.body.name} recertification under that body's published rules — ${doc.body.name} ` +
+      `determines how these hours convert to ${doc.body.unitPlural} and applies its own caps.`
   )
   lines.push('')
   lines.push('## Activities')
@@ -181,5 +182,5 @@ export function renderCeDocumentMarkdown(doc: CeDocument): string {
 }
 
 function escapePipes(s: string): string {
-  return s.replace(/\|/g, '\\|').replace(/\n/g, ' ')
+  return s.replace(/\|/g, '\\|').replace(/[\r\n]+/g, ' ')
 }

--- a/src/lib/ceDocumentation.ts
+++ b/src/lib/ceDocumentation.ts
@@ -1,0 +1,185 @@
+/**
+ * FFC-issued CE documentation artifact (#358).
+ *
+ * Turns a volunteer's approved hours (#360/#361) into the verified record they
+ * self-report to a certifying body (#356): a signed letter + an hours table,
+ * formatted to satisfy what bodies ask for in an audit (date, activity, hours,
+ * category, provider contact). Fully data-driven — no manual per-volunteer
+ * editing.
+ *
+ * Format: this builds the document *model* and an audit-friendly Markdown
+ * rendering (the MVP, printable/attachable). Per-body CSV export and a digital
+ * badge are future formats that can reuse this same model.
+ */
+import type { CeBody } from '../data/ce-bodies'
+import { CE_DISCLAIMER } from '../data/ce-bodies'
+import { creditability, type HoursEntry } from '../data/hours-model'
+import { FFC_FOUNDER_CONTACT } from '../data/legacy-wordpress-administration'
+import type { CreditChannel } from '../data/ce-bodies'
+
+export interface CeIssuer {
+  org: string
+  taxStatus: string
+  /** EIN is kept out of source; supply at generation time or leave the note. */
+  ein: string
+  signerName: string
+  signerRole: string
+  verificationEmail: string
+  verificationPhone: string
+}
+
+/** Default issuer block. EIN intentionally a placeholder — supply at runtime. */
+export const FFC_ISSUER: CeIssuer = {
+  org: 'Free For Charity',
+  taxStatus: '501(c)(3) nonprofit organization',
+  ein: '[EIN on file — contact FFC to verify]',
+  signerName: FFC_FOUNDER_CONTACT.name,
+  signerRole: FFC_FOUNDER_CONTACT.role,
+  verificationEmail: FFC_FOUNDER_CONTACT.email,
+  verificationPhone: FFC_FOUNDER_CONTACT.phone,
+}
+
+export interface CeDocumentRow {
+  date: string
+  activity: string
+  channel: CreditChannel
+  hours: number
+  /** Eligible toward this body per the compliance matrix (#356). */
+  eligible: boolean
+  /** The category/cap note or the reason it's ineligible. */
+  note: string
+  approver: string
+}
+
+export interface CeDocument {
+  issuer: CeIssuer
+  volunteer: string
+  githubHandle?: string
+  body: { name: string; unitPlural: string }
+  issueDate: string
+  rows: CeDocumentRow[]
+  /** Eligible hours per channel (raw; per-body numeric caps applied by the reader). */
+  eligibleByChannel: Record<CreditChannel, number>
+  totalEligibleHours: number
+  disclaimer: string
+}
+
+const CHANNEL_TITLE: Record<CreditChannel, string> = {
+  education: 'Training received',
+  teaching: 'Training delivered',
+  work: 'Domain-relevant work',
+}
+
+/**
+ * Build the document model for one volunteer + one certifying body from approved
+ * hours entries. Only `status: 'approved'` entries are included.
+ */
+export function buildCeDocument(opts: {
+  volunteer: string
+  githubHandle?: string
+  entries: HoursEntry[]
+  body: CeBody
+  issuer?: CeIssuer
+  now?: Date
+}): CeDocument {
+  const issuer = opts.issuer ?? FFC_ISSUER
+  const now = opts.now ?? new Date()
+
+  const mine = opts.entries.filter(
+    (e) =>
+      e.status === 'approved' &&
+      (opts.githubHandle ? e.githubHandle === opts.githubHandle : e.volunteer === opts.volunteer)
+  )
+
+  const rows: CeDocumentRow[] = mine
+    .slice()
+    .sort((a, b) => a.date.localeCompare(b.date))
+    .map((e) => {
+      const c = creditability(e, opts.body)
+      return {
+        date: e.date,
+        activity: e.activity,
+        channel: e.channel,
+        hours: e.rawHours,
+        eligible: c.creditable,
+        note: c.reason,
+        approver: e.approver ?? 'FFC Program Lead',
+      }
+    })
+
+  const eligibleByChannel: Record<CreditChannel, number> = { education: 0, teaching: 0, work: 0 }
+  for (const r of rows) if (r.eligible) eligibleByChannel[r.channel] += r.hours
+  const totalEligibleHours = Object.values(eligibleByChannel).reduce((s, n) => s + n, 0)
+
+  return {
+    issuer,
+    volunteer: opts.volunteer,
+    githubHandle: opts.githubHandle,
+    body: { name: opts.body.name, unitPlural: opts.body.unitPlural },
+    issueDate: now.toISOString().slice(0, 10),
+    rows,
+    eligibleByChannel,
+    totalEligibleHours,
+    disclaimer: CE_DISCLAIMER,
+  }
+}
+
+/** Render the document as an audit-friendly Markdown letter + hours table. */
+export function renderCeDocumentMarkdown(doc: CeDocument): string {
+  const lines: string[] = []
+  lines.push(`# Certification of Volunteer & Training Hours`)
+  lines.push('')
+  lines.push(`**Issued by:** ${doc.issuer.org} — ${doc.issuer.taxStatus}`)
+  lines.push(`**EIN:** ${doc.issuer.ein}`)
+  lines.push(`**Issue date:** ${doc.issueDate}`)
+  lines.push('')
+  lines.push(
+    `This letter certifies that **${doc.volunteer}**${
+      doc.githubHandle ? ` (GitHub: @${doc.githubHandle})` : ''
+    } completed the volunteer and training activities below with ${doc.issuer.org}. ` +
+      `Of these, **${doc.totalEligibleHours} hour(s)** are eligible for ${doc.body.name} ` +
+      `${doc.body.unitPlural} under that body's published rules.`
+  )
+  lines.push('')
+  lines.push('## Activities')
+  lines.push('')
+  lines.push('| Date | Activity | Channel | Hours | Eligible | Category / note | Verified by |')
+  lines.push('| --- | --- | --- | --- | --- | --- | --- |')
+  for (const r of doc.rows) {
+    lines.push(
+      `| ${r.date} | ${escapePipes(r.activity)} | ${CHANNEL_TITLE[r.channel]} | ${r.hours} | ${
+        r.eligible ? 'Yes' : 'No'
+      } | ${escapePipes(r.note)} | ${escapePipes(r.approver)} |`
+    )
+  }
+  if (doc.rows.length === 0) {
+    lines.push('| — | No approved activities yet | — | 0 | — | — | — |')
+  }
+  lines.push('')
+  lines.push('## Eligible totals by channel')
+  lines.push('')
+  for (const ch of ['education', 'teaching', 'work'] as CreditChannel[]) {
+    lines.push(`- **${CHANNEL_TITLE[ch]}:** ${doc.eligibleByChannel[ch]} hour(s)`)
+  }
+  lines.push('')
+  lines.push(
+    `> Note: ${doc.body.name} applies per-channel caps to these totals — see the body's official ` +
+      `rules. ${doc.issuer.org} certifies the hours; it does not pre-apply the caps.`
+  )
+  lines.push('')
+  lines.push('## Compliance disclaimer')
+  lines.push('')
+  lines.push(`> ${doc.disclaimer}`)
+  lines.push('')
+  lines.push('## Verification')
+  lines.push('')
+  lines.push(`${doc.issuer.signerName}, ${doc.issuer.signerRole}`)
+  lines.push(`${doc.issuer.org}`)
+  lines.push(`Email: ${doc.issuer.verificationEmail} · Phone: ${doc.issuer.verificationPhone}`)
+  lines.push('')
+  return lines.join('\n')
+}
+
+function escapePipes(s: string): string {
+  return s.replace(/\|/g, '\\|').replace(/\n/g, ' ')
+}


### PR DESCRIPTION
## Summary

Implements **#358 — the FFC-issued CE documentation/certificate artifact**, the **last sub-issue of the CE epic (#355)**. It turns a volunteer's approved hours into the verified record they self-report to a certifying body: a signed letter + an hours table, audit-formatted, fully data-driven (no manual per-volunteer editing).

## Changes

- **`src/lib/ceDocumentation.ts`** — `buildCeDocument()` assembles the document model from approved `HoursEntry` records (#360/#361): issuer block (FFC, 501(c)(3), EIN supplied at generation, signer, verification contact), per-activity rows with **per-body eligibility** computed via the #356 `creditability()` rules, eligible totals by channel, and the compliance disclaimer. `renderCeDocumentMarkdown()` renders an audit-friendly letter + table.
- **`scripts/generate-ce-documentation.ts`** — `pnpm tsx` CLI (same convention as the existing `generate-legacy-wp-admin-stubs.ts`) reading `public/data/volunteer-hours.json` → Markdown letter for a given `--handle`/`--volunteer` + `--body` (+ optional `--ein`).
- **`docs/ce-documentation-artifact.md`** — contents, usage, the format roadmap (Markdown MVP; PDF/CSV/Open-Badge reuse the same model), and the MOVSM shared-machinery tie-in.
- **Tests** — approved-only filtering, per-body eligibility (ISC2 credits domain work; CompTIA doesn't), letter rendering (issuer/disclaimer/verification), and runtime EIN.

## Acceptance criteria (#358)
- [x] Given approved tracked hours, FFC can produce a per-volunteer document with correct per-body categorization and caps noted.
- [x] Contains all fields bodies request (issuer + EIN + signer + verification contact + dated activity rows + category + disclaimer).
- [x] Disclaimer + verification contact present.
- [x] Templating is data-driven (no manual per-volunteer editing).

## Verification
- `pnpm run type-check` / `lint` — clean
- `pnpm run build` — green
- `pnpm test` — 390 passed

Closes #358. With this, the CE epic (#355) sub-issues #356/#357/#358/#359/#360/#363 and the hours backend (#361/#362) are all complete.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X4omPQW2ErDyZsMtxypuMe)_