### PR TITLE
refactor: simplify top-level navigation (audience-first)

### DIFF
--- a/__tests__/components/Navigation.test.tsx
+++ b/__tests__/components/Navigation.test.tsx
@@ -33,9 +33,10 @@ describe('Navigation Component', () => {
     it('should render desktop navigation links and dropdown buttons', async () => {
       await renderNavigation()
       expect(screen.getByRole('link', { name: /home/i })).toBeInTheDocument()
-      expect(screen.getByRole('link', { name: /get involved/i })).toBeInTheDocument()
-      expect(screen.getByRole('link', { name: /sites list/i })).toBeInTheDocument()
+      expect(screen.getByRole('link', { name: /edit my site/i })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /volunteer/i })).toBeInTheDocument()
       expect(screen.getByRole('button', { name: /training/i })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /operate/i })).toBeInTheDocument()
       expect(screen.getByRole('button', { name: /resources/i })).toBeInTheDocument()
     })
 
@@ -82,16 +83,31 @@ describe('Navigation Component', () => {
       expect(homeLink).toHaveAttribute('href', '/')
     })
 
-    it('should have correct href for get involved link', async () => {
+    it('should have correct href for edit my site link', async () => {
       await renderNavigation()
-      const link = screen.getByRole('link', { name: /get involved/i })
-      expect(link).toHaveAttribute('href', '/get-involved')
+      const link = screen.getByRole('link', { name: /edit my site/i })
+      expect(link).toHaveAttribute('href', '/site-owner')
     })
 
-    it('should have correct href for sites list link', async () => {
+    it('should render volunteer dropdown items when opened', async () => {
       await renderNavigation()
-      const link = screen.getByRole('link', { name: /sites list/i })
-      expect(link).toHaveAttribute('href', '/sites-list')
+      fireEvent.click(screen.getByRole('button', { name: /volunteer/i }))
+      expect(screen.getByRole('menuitem', { name: /get involved/i })).toHaveAttribute(
+        'href',
+        '/get-involved'
+      )
+      expect(screen.getByRole('menuitem', { name: /recognition/i })).toHaveAttribute(
+        'href',
+        '/recognition'
+      )
+      expect(screen.getByRole('menuitem', { name: /continuing education/i })).toHaveAttribute(
+        'href',
+        '/continuing-education'
+      )
+      expect(screen.getByRole('menuitem', { name: /contributor ladder/i })).toHaveAttribute(
+        'href',
+        '/contributor-ladder'
+      )
     })
 
     it('should render training dropdown items when opened', async () => {
@@ -107,27 +123,36 @@ describe('Navigation Component', () => {
         'href',
         '/canva-designer-path'
       )
-      expect(screen.getByRole('menuitem', { name: /contributor ladder/i })).toHaveAttribute(
+      expect(screen.getByRole('menuitem', { name: /data & analytics/i })).toHaveAttribute(
         'href',
-        '/contributor-ladder'
+        '/training/data-analytics'
       )
     })
 
-    it('should render resources dropdown items when opened', async () => {
+    it('should render operate dropdown items when opened', async () => {
       await renderNavigation()
-      const resourcesBtn = screen.getByRole('button', { name: /resources/i })
-      fireEvent.click(resourcesBtn)
-      expect(screen.getByRole('menuitem', { name: /tech stack/i })).toHaveAttribute(
+      fireEvent.click(screen.getByRole('button', { name: /operate/i }))
+      expect(screen.getByRole('menuitem', { name: /sites list/i })).toHaveAttribute(
         'href',
-        '/tech-stack'
+        '/sites-list'
       )
       expect(screen.getByRole('menuitem', { name: /documentation/i })).toHaveAttribute(
         'href',
         '/documentation'
       )
       expect(screen.getByRole('menuitem', { name: /testing/i })).toHaveAttribute('href', '/testing')
+    })
+
+    it('should render resources dropdown items when opened', async () => {
+      await renderNavigation()
+      const resourcesBtn = screen.getByRole('button', { name: /resources/i })
+      fireEvent.click(resourcesBtn)
       expect(screen.getByRole('menuitem', { name: /guides/i })).toHaveAttribute('href', '/guides')
       expect(screen.getByRole('menuitem', { name: /blog/i })).toHaveAttribute('href', '/blog')
+      expect(screen.getByRole('menuitem', { name: /what ffc delivers/i })).toHaveAttribute(
+        'href',
+        '/what-ffc-delivers'
+      )
     })
   })
 

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -11,7 +11,7 @@ test.describe('Smoke Tests', () => {
     await page.goto('/')
     const nav = page.locator('nav')
     await expect(nav.locator('a[href="/"]').first()).toBeVisible()
-    await expect(nav.locator('a[href="/site-owner"]').first()).toBeVisible()
+    await expect(nav.locator('a[href*="/site-owner"]').first()).toBeVisible()
     await expect(nav.locator('button:has-text("Volunteer")')).toBeVisible()
     await expect(nav.locator('button:has-text("Training")')).toBeVisible()
     await expect(nav.locator('button:has-text("Operate")')).toBeVisible()

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -11,10 +11,20 @@ test.describe('Smoke Tests', () => {
     await page.goto('/')
     const nav = page.locator('nav')
     await expect(nav.locator('a[href="/"]').first()).toBeVisible()
-    await expect(nav.locator('a[href*="/get-involved"]').first()).toBeVisible()
-    await expect(nav.locator('a[href*="/sites-list"]').first()).toBeVisible()
+    await expect(nav.locator('a[href="/site-owner"]').first()).toBeVisible()
+    await expect(nav.locator('button:has-text("Volunteer")')).toBeVisible()
     await expect(nav.locator('button:has-text("Training")')).toBeVisible()
+    await expect(nav.locator('button:has-text("Operate")')).toBeVisible()
     await expect(nav.locator('button:has-text("Resources")')).toBeVisible()
+  })
+
+  test('volunteer dropdown links are accessible', async ({ page }) => {
+    await page.goto('/')
+    await page.locator('nav button:has-text("Volunteer")').hover()
+    await expect(page.locator('nav a[href*="/get-involved"]').first()).toBeVisible()
+    await expect(page.locator('nav a[href*="/recognition"]').first()).toBeVisible()
+    await expect(page.locator('nav a[href*="/continuing-education"]').first()).toBeVisible()
+    await expect(page.locator('nav a[href*="/contributor-ladder"]').first()).toBeVisible()
   })
 
   test('training dropdown links are accessible', async ({ page }) => {
@@ -22,17 +32,25 @@ test.describe('Smoke Tests', () => {
     await page.locator('nav button:has-text("Training")').hover()
     await expect(page.locator('nav a[href*="/training-plan"]').first()).toBeVisible()
     await expect(page.locator('nav a[href*="/canva-designer-path"]').first()).toBeVisible()
-    await expect(page.locator('nav a[href*="/contributor-ladder"]').first()).toBeVisible()
+    await expect(page.locator('nav a[href*="/training/web-developer"]').first()).toBeVisible()
+  })
+
+  test('operate dropdown links are accessible', async ({ page }) => {
+    await page.goto('/')
+    await page.locator('nav button:has-text("Operate")').hover()
+    await expect(page.locator('nav a[href*="/sites-list"]').first()).toBeVisible()
+    await expect(page.locator('nav a[href*="/tech-stack"]').first()).toBeVisible()
+    await expect(page.locator('nav a[href*="/documentation"]').first()).toBeVisible()
+    await expect(page.locator('nav a[href*="/testing"]').first()).toBeVisible()
   })
 
   test('resources dropdown links are accessible', async ({ page }) => {
     await page.goto('/')
     await page.locator('nav button:has-text("Resources")').hover()
-    await expect(page.locator('nav a[href*="/tech-stack"]').first()).toBeVisible()
-    await expect(page.locator('nav a[href*="/documentation"]').first()).toBeVisible()
-    await expect(page.locator('nav a[href*="/testing"]').first()).toBeVisible()
     await expect(page.locator('nav a[href*="/guides"]').first()).toBeVisible()
+    await expect(page.locator('nav a[href*="/developer-environment-setup"]').first()).toBeVisible()
     await expect(page.locator('nav a[href*="/blog"]').first()).toBeVisible()
+    await expect(page.locator('nav a[href*="/what-ffc-delivers"]').first()).toBeVisible()
   })
 
   test('footer is visible on home page', async ({ page }) => {

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -122,6 +122,7 @@ export default function Navigation() {
     >
       <button
         type="button"
+        id={`${dropdown.id}-dropdown-button`}
         className={`${isDropdownActive(dropdown) ? 'text-blue-600 font-bold' : 'font-medium'} hover:text-blue-600 transition-colors inline-flex items-center whitespace-nowrap`}
         aria-expanded={openDropdown === dropdown.id}
         aria-haspopup="true"
@@ -135,6 +136,7 @@ export default function Navigation() {
         <div
           id={`${dropdown.id}-dropdown-menu`}
           role="menu"
+          aria-labelledby={`${dropdown.id}-dropdown-button`}
           className="absolute left-1/2 -translate-x-1/2 mt-2 w-80 bg-white rounded-lg shadow-xl border border-gray-200 py-2 z-50"
         >
           {dropdown.items.map((item) => (

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -4,14 +4,19 @@ import Link from 'next/link'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { usePathname } from 'next/navigation'
 import { assetPath } from '@/lib/assetPath'
-import { trainingDropdown, resourcesDropdown, type NavDropdown } from '@/data/navigation'
+import {
+  volunteerDropdown,
+  trainingDropdown,
+  operateDropdown,
+  resourcesDropdown,
+  type NavDropdown,
+} from '@/data/navigation'
 
 export default function Navigation() {
   const [isMenuOpen, setIsMenuOpen] = useState(false)
   const [openDropdown, setOpenDropdown] = useState<string | null>(null)
   const [mobileAccordions, setMobileAccordions] = useState<Set<string>>(new Set())
-  const trainingRef = useRef<HTMLDivElement>(null)
-  const resourcesRef = useRef<HTMLDivElement>(null)
+  const desktopNavRef = useRef<HTMLDivElement>(null)
   const hoverTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const pathname = usePathname() ?? ''
 
@@ -88,8 +93,7 @@ export default function Navigation() {
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent) => {
       if (!openDropdown) return
-      const target = e.target as Node
-      if (!trainingRef.current?.contains(target) && !resourcesRef.current?.contains(target)) {
+      if (!desktopNavRef.current?.contains(e.target as Node)) {
         setOpenDropdown(null)
       }
     }
@@ -107,6 +111,79 @@ export default function Navigation() {
     >
       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
     </svg>
+  )
+
+  const desktopDropdown = (dropdown: NavDropdown) => (
+    <div
+      key={dropdown.id}
+      className="relative"
+      onMouseEnter={() => handleDropdownMouseEnter(dropdown.id)}
+      onMouseLeave={handleDropdownMouseLeave}
+    >
+      <button
+        type="button"
+        className={`${isDropdownActive(dropdown) ? 'text-blue-600 font-bold' : 'font-medium'} hover:text-blue-600 transition-colors inline-flex items-center whitespace-nowrap`}
+        aria-expanded={openDropdown === dropdown.id}
+        aria-haspopup="true"
+        aria-controls={`${dropdown.id}-dropdown-menu`}
+        onClick={() => setOpenDropdown(openDropdown === dropdown.id ? null : dropdown.id)}
+      >
+        {dropdown.label}
+        {chevronSvg(openDropdown === dropdown.id)}
+      </button>
+      {openDropdown === dropdown.id && (
+        <div
+          id={`${dropdown.id}-dropdown-menu`}
+          role="menu"
+          className="absolute left-1/2 -translate-x-1/2 mt-2 w-80 bg-white rounded-lg shadow-xl border border-gray-200 py-2 z-50"
+        >
+          {dropdown.items.map((item) => (
+            <Link
+              key={item.href}
+              href={item.href}
+              role="menuitem"
+              className="block px-4 py-3 hover:bg-blue-50 transition-colors"
+              onClick={() => setOpenDropdown(null)}
+            >
+              <p className="text-sm font-semibold text-gray-900">{item.label}</p>
+              <p className="text-xs text-gray-500 mt-0.5">{item.description}</p>
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+
+  const mobileDropdown = (dropdown: NavDropdown) => (
+    <div key={dropdown.id}>
+      <button
+        type="button"
+        className={`${isDropdownActive(dropdown) ? 'text-blue-600 font-bold bg-blue-50' : 'hover:bg-gray-50 hover:text-blue-600'} w-full text-left px-3 py-2 rounded-md transition-colors inline-flex items-center justify-between`}
+        onClick={() => toggleMobileAccordion(dropdown.id)}
+        aria-expanded={mobileAccordions.has(dropdown.id)}
+        aria-controls={`mobile-${dropdown.id}-panel`}
+      >
+        {dropdown.label}
+        {chevronSvg(mobileAccordions.has(dropdown.id))}
+      </button>
+      {mobileAccordions.has(dropdown.id) && (
+        <div
+          id={`mobile-${dropdown.id}-panel`}
+          className="ml-4 mt-1 space-y-1 border-l-2 border-blue-100 pl-2"
+        >
+          {dropdown.items.map((item) => (
+            <Link
+              key={item.href}
+              href={item.href}
+              className="block px-3 py-2 rounded-md text-sm hover:bg-gray-50 hover:text-blue-600 transition-colors"
+              onClick={() => setIsMenuOpen(false)}
+            >
+              {item.label}
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
   )
 
   return (
@@ -131,103 +208,20 @@ export default function Navigation() {
           </Link>
 
           {/* Desktop Navigation */}
-          <div className="hidden xl:flex items-center space-x-6">
+          <div ref={desktopNavRef} className="hidden xl:flex items-center space-x-6">
             <Link href="/" className={linkClass('/')}>
               Home
             </Link>
-            <Link
-              href="/get-involved"
-              className={`${linkClass('/get-involved')} whitespace-nowrap`}
-            >
-              Get Involved
-            </Link>
+
+            {desktopDropdown(volunteerDropdown)}
+
             <Link href="/site-owner" className={`${linkClass('/site-owner')} whitespace-nowrap`}>
               Edit My Site
             </Link>
 
-            {/* Training Dropdown */}
-            <div
-              ref={trainingRef}
-              className="relative"
-              onMouseEnter={() => handleDropdownMouseEnter('training')}
-              onMouseLeave={handleDropdownMouseLeave}
-            >
-              <button
-                type="button"
-                className={`${isDropdownActive(trainingDropdown) ? 'text-blue-600 font-bold' : 'font-medium'} hover:text-blue-600 transition-colors inline-flex items-center whitespace-nowrap`}
-                aria-expanded={openDropdown === 'training'}
-                aria-haspopup="true"
-                aria-controls="training-dropdown-menu"
-                onClick={() => setOpenDropdown(openDropdown === 'training' ? null : 'training')}
-              >
-                Training
-                {chevronSvg(openDropdown === 'training')}
-              </button>
-              {openDropdown === 'training' && (
-                <div
-                  id="training-dropdown-menu"
-                  role="menu"
-                  className="absolute left-1/2 -translate-x-1/2 mt-2 w-80 bg-white rounded-lg shadow-xl border border-gray-200 py-2 z-50"
-                >
-                  {trainingDropdown.items.map((item) => (
-                    <Link
-                      key={item.href}
-                      href={item.href}
-                      role="menuitem"
-                      className="block px-4 py-3 hover:bg-blue-50 transition-colors"
-                      onClick={() => setOpenDropdown(null)}
-                    >
-                      <p className="text-sm font-semibold text-gray-900">{item.label}</p>
-                      <p className="text-xs text-gray-500 mt-0.5">{item.description}</p>
-                    </Link>
-                  ))}
-                </div>
-              )}
-            </div>
-
-            {/* Resources Dropdown */}
-            <div
-              ref={resourcesRef}
-              className="relative"
-              onMouseEnter={() => handleDropdownMouseEnter('resources')}
-              onMouseLeave={handleDropdownMouseLeave}
-            >
-              <button
-                type="button"
-                className={`${isDropdownActive(resourcesDropdown) ? 'text-blue-600 font-bold' : 'font-medium'} hover:text-blue-600 transition-colors inline-flex items-center whitespace-nowrap`}
-                aria-expanded={openDropdown === 'resources'}
-                aria-haspopup="true"
-                aria-controls="resources-dropdown-menu"
-                onClick={() => setOpenDropdown(openDropdown === 'resources' ? null : 'resources')}
-              >
-                Resources
-                {chevronSvg(openDropdown === 'resources')}
-              </button>
-              {openDropdown === 'resources' && (
-                <div
-                  id="resources-dropdown-menu"
-                  role="menu"
-                  className="absolute left-1/2 -translate-x-1/2 mt-2 w-80 bg-white rounded-lg shadow-xl border border-gray-200 py-2 z-50"
-                >
-                  {resourcesDropdown.items.map((item) => (
-                    <Link
-                      key={item.href}
-                      href={item.href}
-                      role="menuitem"
-                      className="block px-4 py-3 hover:bg-blue-50 transition-colors"
-                      onClick={() => setOpenDropdown(null)}
-                    >
-                      <p className="text-sm font-semibold text-gray-900">{item.label}</p>
-                      <p className="text-xs text-gray-500 mt-0.5">{item.description}</p>
-                    </Link>
-                  ))}
-                </div>
-              )}
-            </div>
-
-            <Link href="/sites-list" className={`${linkClass('/sites-list')} whitespace-nowrap`}>
-              Sites List
-            </Link>
+            {desktopDropdown(trainingDropdown)}
+            {desktopDropdown(operateDropdown)}
+            {desktopDropdown(resourcesDropdown)}
 
             <a
               href="https://freeforcharity.org/"
@@ -293,13 +287,9 @@ export default function Navigation() {
             <Link href="/" className={mobileLinkClass('/')} onClick={() => setIsMenuOpen(false)}>
               Home
             </Link>
-            <Link
-              href="/get-involved"
-              className={mobileLinkClass('/get-involved')}
-              onClick={() => setIsMenuOpen(false)}
-            >
-              Get Involved
-            </Link>
+
+            {mobileDropdown(volunteerDropdown)}
+
             <Link
               href="/site-owner"
               className={mobileLinkClass('/site-owner')}
@@ -308,75 +298,9 @@ export default function Navigation() {
               Edit My Site
             </Link>
 
-            {/* Mobile Training Accordion */}
-            <div>
-              <button
-                type="button"
-                className={`${isDropdownActive(trainingDropdown) ? 'text-blue-600 font-bold bg-blue-50' : 'hover:bg-gray-50 hover:text-blue-600'} w-full text-left px-3 py-2 rounded-md transition-colors inline-flex items-center justify-between`}
-                onClick={() => toggleMobileAccordion('training')}
-                aria-expanded={mobileAccordions.has('training')}
-                aria-controls="mobile-training-panel"
-              >
-                Training
-                {chevronSvg(mobileAccordions.has('training'))}
-              </button>
-              {mobileAccordions.has('training') && (
-                <div
-                  id="mobile-training-panel"
-                  className="ml-4 mt-1 space-y-1 border-l-2 border-blue-100 pl-2"
-                >
-                  {trainingDropdown.items.map((item) => (
-                    <Link
-                      key={item.href}
-                      href={item.href}
-                      className="block px-3 py-2 rounded-md text-sm hover:bg-gray-50 hover:text-blue-600 transition-colors"
-                      onClick={() => setIsMenuOpen(false)}
-                    >
-                      {item.label}
-                    </Link>
-                  ))}
-                </div>
-              )}
-            </div>
-
-            {/* Mobile Resources Accordion */}
-            <div>
-              <button
-                type="button"
-                className={`${isDropdownActive(resourcesDropdown) ? 'text-blue-600 font-bold bg-blue-50' : 'hover:bg-gray-50 hover:text-blue-600'} w-full text-left px-3 py-2 rounded-md transition-colors inline-flex items-center justify-between`}
-                onClick={() => toggleMobileAccordion('resources')}
-                aria-expanded={mobileAccordions.has('resources')}
-                aria-controls="mobile-resources-panel"
-              >
-                Resources
-                {chevronSvg(mobileAccordions.has('resources'))}
-              </button>
-              {mobileAccordions.has('resources') && (
-                <div
-                  id="mobile-resources-panel"
-                  className="ml-4 mt-1 space-y-1 border-l-2 border-blue-100 pl-2"
-                >
-                  {resourcesDropdown.items.map((item) => (
-                    <Link
-                      key={item.href}
-                      href={item.href}
-                      className="block px-3 py-2 rounded-md text-sm hover:bg-gray-50 hover:text-blue-600 transition-colors"
-                      onClick={() => setIsMenuOpen(false)}
-                    >
-                      {item.label}
-                    </Link>
-                  ))}
-                </div>
-              )}
-            </div>
-
-            <Link
-              href="/sites-list"
-              className={mobileLinkClass('/sites-list')}
-              onClick={() => setIsMenuOpen(false)}
-            >
-              Sites List
-            </Link>
+            {mobileDropdown(trainingDropdown)}
+            {mobileDropdown(operateDropdown)}
+            {mobileDropdown(resourcesDropdown)}
 
             <a
               href="https://freeforcharity.org/"

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -2,8 +2,8 @@
  * Shared navigation data used by the Navigation component.
  *
  * Top level (audience-first): Home · Volunteer ▾ · Edit My Site · Training ▾ ·
- * Operate ▾ · Resources ▾ · For Charities ↗. Add new items here so desktop and
- * mobile menus stay in sync.
+ * Operate ▾ · Resources ▾ · For Charities & Donors ↗. Add new items here so
+ * desktop and mobile menus stay in sync.
  */
 
 export interface NavDropdownItem {

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -1,6 +1,9 @@
 /**
- * Shared navigation dropdown data used by the Navigation component.
- * Add new items here so desktop and mobile menus stay in sync.
+ * Shared navigation data used by the Navigation component.
+ *
+ * Top level (audience-first): Home · Volunteer ▾ · Edit My Site · Training ▾ ·
+ * Operate ▾ · Resources ▾ · For Charities ↗. Add new items here so desktop and
+ * mobile menus stay in sync.
  */
 
 export interface NavDropdownItem {
@@ -15,6 +18,45 @@ export interface NavDropdown {
   items: NavDropdownItem[]
 }
 
+/** Join & grow: the volunteer funnel and the designations you earn. */
+export const volunteerDropdown: NavDropdown = {
+  label: 'Volunteer',
+  id: 'volunteer',
+  items: [
+    {
+      label: 'Get Involved',
+      href: '/get-involved',
+      description: 'Ways to volunteer with FFC and how to start.',
+    },
+    {
+      label: 'Volunteer Roles',
+      href: '/volunteer',
+      description: 'Web dev, Microsoft 365 / Google Workspace admin, data, design, military.',
+    },
+    {
+      label: 'Contributor Ladder',
+      href: '/contributor-ladder',
+      description: 'Progress from Contributor to Maintainer to Mentor.',
+    },
+    {
+      label: 'Recognition',
+      href: '/recognition',
+      description: 'Volunteer badges that map 1:1 to GitHub access roles.',
+    },
+    {
+      label: 'Continuing Education',
+      href: '/continuing-education',
+      description: 'Earn free CE credit (CPE/PDU/CEU) toward your certification.',
+    },
+    {
+      label: 'MOVSM',
+      href: '/movsm',
+      description: 'Military Outstanding Volunteer Service Medal pathway.',
+    },
+  ],
+}
+
+/** Role-based training tracks (modules × tiers). */
 export const trainingDropdown: NavDropdown = {
   label: 'Training',
   id: 'training',
@@ -54,37 +96,18 @@ export const trainingDropdown: NavDropdown = {
       href: '/canva-designer-path',
       description: 'Canva Designer certification path for nonprofits.',
     },
-    {
-      label: 'Contributor Ladder',
-      href: '/contributor-ladder',
-      description: 'Progress from Contributor to Maintainer to Mentor.',
-    },
-    {
-      label: 'Recognition',
-      href: '/recognition',
-      description: 'Volunteer badges that map 1:1 to GitHub access roles.',
-    },
-    {
-      label: 'Continuing Education',
-      href: '/continuing-education',
-      description: 'Earn free CE credit (CPE/PDU/CEU) toward your certification by volunteering.',
-    },
   ],
 }
 
-export const resourcesDropdown: NavDropdown = {
-  label: 'Resources',
-  id: 'resources',
+/** Day-to-day operational tools for the FFC technical team. */
+export const operateDropdown: NavDropdown = {
+  label: 'Operate',
+  id: 'operate',
   items: [
     {
-      label: 'Dev Environment Setup',
-      href: '/developer-environment-setup',
-      description: 'Start with your AI of choice — Claude, Codex, Gemini, or Copilot.',
-    },
-    {
-      label: 'Tech Stack',
-      href: '/tech-stack',
-      description: 'Technologies and tools used across FFC projects.',
+      label: 'Sites List',
+      href: '/sites-list',
+      description: 'All FFC-managed domains with health and migration status.',
     },
     {
       label: 'Documentation',
@@ -92,24 +115,55 @@ export const resourcesDropdown: NavDropdown = {
       description: 'Project documentation and reference materials.',
     },
     {
-      label: 'Testing',
-      href: '/testing',
-      description: 'Testing strategy, tools, and best practices.',
+      label: 'Tech Stack',
+      href: '/tech-stack',
+      description: 'Technologies and tools used across FFC projects.',
     },
     {
-      label: 'Guides',
-      href: '/guides',
-      description: 'Step-by-step technical guides for common tasks.',
+      label: 'Testing',
+      href: '/testing',
+      description: 'Testing strategy, live CI status, and best practices.',
     },
     {
       label: 'Legacy WP Admin',
       href: '/legacy-wordpress-administration',
       description: 'WordPress-era operations, SOPs, and procedures for partner charities.',
     },
+  ],
+}
+
+/** Reference, how-to, and supporting content. */
+export const resourcesDropdown: NavDropdown = {
+  label: 'Resources',
+  id: 'resources',
+  items: [
+    {
+      label: 'Guides',
+      href: '/guides',
+      description: 'Step-by-step how-to guides for common tasks.',
+    },
+    {
+      label: 'Dev Environment Setup',
+      href: '/developer-environment-setup',
+      description: 'Start with your AI of choice — Claude, Codex, Gemini, or Copilot.',
+    },
     {
       label: 'Blog',
       href: '/blog',
       description: 'News, volunteer spotlights, and FFC stories.',
     },
+    {
+      label: 'What FFC Delivers',
+      href: '/what-ffc-delivers',
+      description: 'What’s included when FFC builds a charity’s website.',
+    },
   ],
 }
+
+/** The dropdown menus rendered in the top bar, in order. */
+export const NAV_DROPDOWNS: NavDropdown[] = [
+  volunteerDropdown,
+  trainingDropdown,
+  operateDropdown,
+  resourcesDropdown,
+]


### PR DESCRIPTION
## Summary

Simplifies the top-level navigation to the **audience-first (5 menus)** structure. The Training dropdown had grown to ~10 mixed items (tracks + ladder + recognition + CE) and operational/reference links were spread thin; this regroups everything by who's using it.

## New top bar

`Home · Volunteer ▾ · Edit My Site · Training ▾ · Operate ▾ · Resources ▾ · For Charities ↗`

| Menu | Items |
| --- | --- |
| **Volunteer** ▾ | Get Involved · Volunteer Roles · Contributor Ladder · Recognition · Continuing Education · MOVSM |
| **Edit My Site** | → `/site-owner` |
| **Training** ▾ | All Tracks · Site Owner · Web Developer · Global Admin · Google Workspace · Data & Analytics · Canva |
| **Operate** ▾ | Sites List · Documentation · Tech Stack · Testing · Legacy WP Admin |
| **Resources** ▾ | Guides · Dev Environment Setup · Blog · What FFC Delivers |

### What changed vs. before
- **Training** is now tracks-only (Contributor Ladder, Recognition, Continuing Education moved into **Volunteer**).
- **Sites List** moved off the top bar into **Operate** (with Docs/Tech Stack/Testing/Legacy WP).
- New **Resources** groups how-to/reference: Guides, Dev Environment Setup, Blog, What FFC Delivers.
- Newer pages that had no nav home (Recognition, Continuing Education, MOVSM, What FFC Delivers, the two new training tracks) are now all reachable.

## Implementation
- `src/data/navigation.ts` — four `NavDropdown`s (`volunteer`/`training`/`operate`/`resources`) + `NAV_DROPDOWNS`.
- `src/components/Navigation.tsx` — renders the dropdowns from data via shared desktop/mobile helpers (no more per-dropdown duplication); single container ref for click-outside; mobile accordions unchanged in behavior.
- Tests updated for the new groups; `navigation-coverage` still passes (every page reachable from nav or footer).

## Verification
- `pnpm run type-check` / `lint` — clean
- `pnpm run build` — green
- `pnpm test` — 391 passed

Note: this is nav-only. Fully folding Dev Environment Setup *into* the Guides page (vs. listing it alongside Guides in Resources) and collapsing the `/get-involved` ↔ `/volunteer` content overlap are optional content follow-ups.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X4omPQW2ErDyZsMtxypuMe)_