### PR TITLE
feat: add per-page OpenGraph images (#255)

### DIFF
--- a/__tests__/route-generation.test.js
+++ b/__tests__/route-generation.test.js
@@ -225,20 +225,26 @@ describe('Route Generation Tests', () => {
   })
 
   describe('Test Case 4.1c: OpenGraph Images (#255)', () => {
+    // The metadata image route is emitted as a static file; tolerate any
+    // extension (e.g. `opengraph-image` or `opengraph-image.png`).
+    const hasOgFile = (dir) =>
+      fs.existsSync(dir) && fs.readdirSync(dir).some((f) => /^opengraph-image/.test(f))
+
     it('generates a branded site-wide OG image and sets og:image on the home page', () => {
       const home = path.join(outDir, 'index.html')
       if (fs.existsSync(home)) {
         const content = fs.readFileSync(home, 'utf-8')
         expect(content).toMatch(/property="og:image"[^>]*opengraph-image/)
       }
-      // The metadata image route is emitted as a static file under out/.
-      expect(fs.existsSync(path.join(outDir, 'opengraph-image'))).toBe(true)
+      expect(hasOgFile(outDir)).toBe(true)
     })
 
-    it('gives each legacy WP admin leaf its own per-page OG image', () => {
-      const leaves = ['wordpress-domains', 'wordpress-web-hosting', 'wordpress-escalation-runbook']
-      for (const slug of leaves) {
-        const leaf = path.join(outDir, 'legacy-wordpress-administration', slug, 'index.html')
+    it('gives every legacy WP admin leaf its own per-page OG image', () => {
+      // Derive from the data so coverage never drifts as leaves are added.
+      const { LEGACY_WP_ADMIN_PAGES } = require('../src/data/legacy-wordpress-administration')
+      for (const { slug } of LEGACY_WP_ADMIN_PAGES) {
+        const dir = path.join(outDir, 'legacy-wordpress-administration', slug)
+        const leaf = path.join(dir, 'index.html')
         if (fs.existsSync(leaf)) {
           const content = fs.readFileSync(leaf, 'utf-8')
           // Each leaf points at its own opengraph-image, not the root one.
@@ -247,6 +253,7 @@ describe('Route Generation Tests', () => {
               `property="og:image"[^>]*legacy-wordpress-administration/${slug}/opengraph-image`
             )
           )
+          expect(hasOgFile(dir)).toBe(true)
         }
       }
     })

--- a/__tests__/route-generation.test.js
+++ b/__tests__/route-generation.test.js
@@ -224,6 +224,34 @@ describe('Route Generation Tests', () => {
     })
   })
 
+  describe('Test Case 4.1c: OpenGraph Images (#255)', () => {
+    it('generates a branded site-wide OG image and sets og:image on the home page', () => {
+      const home = path.join(outDir, 'index.html')
+      if (fs.existsSync(home)) {
+        const content = fs.readFileSync(home, 'utf-8')
+        expect(content).toMatch(/property="og:image"[^>]*opengraph-image/)
+      }
+      // The metadata image route is emitted as a static file under out/.
+      expect(fs.existsSync(path.join(outDir, 'opengraph-image'))).toBe(true)
+    })
+
+    it('gives each legacy WP admin leaf its own per-page OG image', () => {
+      const leaves = ['wordpress-domains', 'wordpress-web-hosting', 'wordpress-escalation-runbook']
+      for (const slug of leaves) {
+        const leaf = path.join(outDir, 'legacy-wordpress-administration', slug, 'index.html')
+        if (fs.existsSync(leaf)) {
+          const content = fs.readFileSync(leaf, 'utf-8')
+          // Each leaf points at its own opengraph-image, not the root one.
+          expect(content).toMatch(
+            new RegExp(
+              `property="og:image"[^>]*legacy-wordpress-administration/${slug}/opengraph-image`
+            )
+          )
+        }
+      }
+    })
+  })
+
   describe('Test Case 4.4: Legacy WordPress Administration Section', () => {
     const sectionRoot = path.join(outDir, 'legacy-wordpress-administration')
     const hubPath = path.join(sectionRoot, 'index.html')

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -41,7 +41,7 @@ export const metadata: Metadata = {
       'Training hub for Free For Charity volunteers. Explore Global Administrator and Canva Designer certification paths while helping nonprofits.',
   },
   twitter: {
-    card: 'summary',
+    card: 'summary_large_image',
     title: 'Free For Charity Admin | Volunteer & Admin Training Hub',
     description:
       'Training hub for Free For Charity volunteers. Explore Global Administrator and Canva Designer certification paths while helping nonprofits.',

--- a/src/app/legacy-wordpress-administration/wordpress-charity-offboarding/opengraph-image.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-charity-offboarding/opengraph-image.tsx
@@ -1,0 +1,10 @@
+import { renderLegacyLeafOg, OG_SIZE, OG_CONTENT_TYPE } from '@/lib/og'
+
+export const dynamic = 'force-static'
+export const size = OG_SIZE
+export const contentType = OG_CONTENT_TYPE
+export const alt = 'Free For Charity — Legacy WordPress Administration'
+
+export default function Image() {
+  return renderLegacyLeafOg('wordpress-charity-offboarding')
+}

--- a/src/app/legacy-wordpress-administration/wordpress-charity-validation/opengraph-image.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-charity-validation/opengraph-image.tsx
@@ -1,0 +1,10 @@
+import { renderLegacyLeafOg, OG_SIZE, OG_CONTENT_TYPE } from '@/lib/og'
+
+export const dynamic = 'force-static'
+export const size = OG_SIZE
+export const contentType = OG_CONTENT_TYPE
+export const alt = 'Free For Charity — Legacy WordPress Administration'
+
+export default function Image() {
+  return renderLegacyLeafOg('wordpress-charity-validation')
+}

--- a/src/app/legacy-wordpress-administration/wordpress-cpanel-backup-sop/opengraph-image.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-cpanel-backup-sop/opengraph-image.tsx
@@ -1,0 +1,10 @@
+import { renderLegacyLeafOg, OG_SIZE, OG_CONTENT_TYPE } from '@/lib/og'
+
+export const dynamic = 'force-static'
+export const size = OG_SIZE
+export const contentType = OG_CONTENT_TYPE
+export const alt = 'Free For Charity — Legacy WordPress Administration'
+
+export default function Image() {
+  return renderLegacyLeafOg('wordpress-cpanel-backup-sop')
+}

--- a/src/app/legacy-wordpress-administration/wordpress-domains/opengraph-image.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-domains/opengraph-image.tsx
@@ -1,0 +1,10 @@
+import { renderLegacyLeafOg, OG_SIZE, OG_CONTENT_TYPE } from '@/lib/og'
+
+export const dynamic = 'force-static'
+export const size = OG_SIZE
+export const contentType = OG_CONTENT_TYPE
+export const alt = 'Free For Charity — Legacy WordPress Administration'
+
+export default function Image() {
+  return renderLegacyLeafOg('wordpress-domains')
+}

--- a/src/app/legacy-wordpress-administration/wordpress-escalation-runbook/opengraph-image.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-escalation-runbook/opengraph-image.tsx
@@ -1,0 +1,10 @@
+import { renderLegacyLeafOg, OG_SIZE, OG_CONTENT_TYPE } from '@/lib/og'
+
+export const dynamic = 'force-static'
+export const size = OG_SIZE
+export const contentType = OG_CONTENT_TYPE
+export const alt = 'Free For Charity — Legacy WordPress Administration'
+
+export default function Image() {
+  return renderLegacyLeafOg('wordpress-escalation-runbook')
+}

--- a/src/app/legacy-wordpress-administration/wordpress-guidestar-guide/opengraph-image.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-guidestar-guide/opengraph-image.tsx
@@ -1,0 +1,10 @@
+import { renderLegacyLeafOg, OG_SIZE, OG_CONTENT_TYPE } from '@/lib/og'
+
+export const dynamic = 'force-static'
+export const size = OG_SIZE
+export const contentType = OG_CONTENT_TYPE
+export const alt = 'Free For Charity — Legacy WordPress Administration'
+
+export default function Image() {
+  return renderLegacyLeafOg('wordpress-guidestar-guide')
+}

--- a/src/app/legacy-wordpress-administration/wordpress-hosting-techstack/opengraph-image.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-hosting-techstack/opengraph-image.tsx
@@ -1,0 +1,10 @@
+import { renderLegacyLeafOg, OG_SIZE, OG_CONTENT_TYPE } from '@/lib/og'
+
+export const dynamic = 'force-static'
+export const size = OG_SIZE
+export const contentType = OG_CONTENT_TYPE
+export const alt = 'Free For Charity — Legacy WordPress Administration'
+
+export default function Image() {
+  return renderLegacyLeafOg('wordpress-hosting-techstack')
+}

--- a/src/app/legacy-wordpress-administration/wordpress-online-impacts-onboarding/opengraph-image.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-online-impacts-onboarding/opengraph-image.tsx
@@ -1,0 +1,10 @@
+import { renderLegacyLeafOg, OG_SIZE, OG_CONTENT_TYPE } from '@/lib/og'
+
+export const dynamic = 'force-static'
+export const size = OG_SIZE
+export const contentType = OG_CONTENT_TYPE
+export const alt = 'Free For Charity — Legacy WordPress Administration'
+
+export default function Image() {
+  return renderLegacyLeafOg('wordpress-online-impacts-onboarding')
+}

--- a/src/app/legacy-wordpress-administration/wordpress-service-delivery-stages/opengraph-image.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-service-delivery-stages/opengraph-image.tsx
@@ -1,0 +1,10 @@
+import { renderLegacyLeafOg, OG_SIZE, OG_CONTENT_TYPE } from '@/lib/og'
+
+export const dynamic = 'force-static'
+export const size = OG_SIZE
+export const contentType = OG_CONTENT_TYPE
+export const alt = 'Free For Charity — Legacy WordPress Administration'
+
+export default function Image() {
+  return renderLegacyLeafOg('wordpress-service-delivery-stages')
+}

--- a/src/app/legacy-wordpress-administration/wordpress-tools-for-success/opengraph-image.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-tools-for-success/opengraph-image.tsx
@@ -1,0 +1,10 @@
+import { renderLegacyLeafOg, OG_SIZE, OG_CONTENT_TYPE } from '@/lib/og'
+
+export const dynamic = 'force-static'
+export const size = OG_SIZE
+export const contentType = OG_CONTENT_TYPE
+export const alt = 'Free For Charity — Legacy WordPress Administration'
+
+export default function Image() {
+  return renderLegacyLeafOg('wordpress-tools-for-success')
+}

--- a/src/app/legacy-wordpress-administration/wordpress-training-programs/opengraph-image.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-training-programs/opengraph-image.tsx
@@ -1,0 +1,10 @@
+import { renderLegacyLeafOg, OG_SIZE, OG_CONTENT_TYPE } from '@/lib/og'
+
+export const dynamic = 'force-static'
+export const size = OG_SIZE
+export const contentType = OG_CONTENT_TYPE
+export const alt = 'Free For Charity — Legacy WordPress Administration'
+
+export default function Image() {
+  return renderLegacyLeafOg('wordpress-training-programs')
+}

--- a/src/app/legacy-wordpress-administration/wordpress-volunteer-core-competencies/opengraph-image.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-volunteer-core-competencies/opengraph-image.tsx
@@ -1,0 +1,10 @@
+import { renderLegacyLeafOg, OG_SIZE, OG_CONTENT_TYPE } from '@/lib/og'
+
+export const dynamic = 'force-static'
+export const size = OG_SIZE
+export const contentType = OG_CONTENT_TYPE
+export const alt = 'Free For Charity — Legacy WordPress Administration'
+
+export default function Image() {
+  return renderLegacyLeafOg('wordpress-volunteer-core-competencies')
+}

--- a/src/app/legacy-wordpress-administration/wordpress-web-developer-training/opengraph-image.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-web-developer-training/opengraph-image.tsx
@@ -1,0 +1,10 @@
+import { renderLegacyLeafOg, OG_SIZE, OG_CONTENT_TYPE } from '@/lib/og'
+
+export const dynamic = 'force-static'
+export const size = OG_SIZE
+export const contentType = OG_CONTENT_TYPE
+export const alt = 'Free For Charity — Legacy WordPress Administration'
+
+export default function Image() {
+  return renderLegacyLeafOg('wordpress-web-developer-training')
+}

--- a/src/app/legacy-wordpress-administration/wordpress-web-hosting/opengraph-image.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-web-hosting/opengraph-image.tsx
@@ -1,0 +1,10 @@
+import { renderLegacyLeafOg, OG_SIZE, OG_CONTENT_TYPE } from '@/lib/og'
+
+export const dynamic = 'force-static'
+export const size = OG_SIZE
+export const contentType = OG_CONTENT_TYPE
+export const alt = 'Free For Charity — Legacy WordPress Administration'
+
+export default function Image() {
+  return renderLegacyLeafOg('wordpress-web-hosting')
+}

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,0 +1,13 @@
+import { renderOgImage, OG_SIZE, OG_CONTENT_TYPE } from '@/lib/og'
+
+export const dynamic = 'force-static'
+export const size = OG_SIZE
+export const contentType = OG_CONTENT_TYPE
+export const alt = 'Free For Charity Admin — volunteer & admin training hub'
+
+export default function Image() {
+  return renderOgImage({
+    eyebrow: 'Free For Charity Admin',
+    title: 'Volunteer & Admin Training Hub',
+  })
+}

--- a/src/lib/og.tsx
+++ b/src/lib/og.tsx
@@ -68,9 +68,16 @@ export function renderOgImage({
 /** Per-leaf OG image for a Legacy WordPress Administration page (#255). */
 export function renderLegacyLeafOg(slug: string): ImageResponse {
   const page = LEGACY_WP_ADMIN_PAGES.find((p) => p.slug === slug)
+  // Fail the build loudly on a slug/data mismatch rather than shipping a
+  // generic image with the wrong title.
+  if (!page) {
+    throw new Error(
+      `renderLegacyLeafOg: no LEGACY_WP_ADMIN_PAGES entry for slug "${slug}" — directory/data mismatch.`
+    )
+  }
   return renderOgImage({
     eyebrow: 'Legacy WordPress Administration',
-    title: page?.title ?? 'Legacy WordPress Administration',
+    title: page.title,
     accent: '#38bdf8',
   })
 }

--- a/src/lib/og.tsx
+++ b/src/lib/og.tsx
@@ -1,0 +1,76 @@
+import { ImageResponse } from 'next/og'
+import { LEGACY_WP_ADMIN_PAGES } from '@/data/legacy-wordpress-administration'
+
+/**
+ * Shared OpenGraph image rendering (#255).
+ *
+ * Build-time branded 1200×630 PNGs via Next's built-in `next/og` (satori) — no
+ * extra dependencies. Used by the root `opengraph-image.tsx` and the per-section
+ * leaf images so social shares are visually differentiated by title.
+ *
+ * Satori requires every element with multiple children to set `display: flex`.
+ */
+export const OG_SIZE = { width: 1200, height: 630 } as const
+export const OG_CONTENT_TYPE = 'image/png'
+
+export function renderOgImage({
+  title,
+  eyebrow,
+  accent = '#2dd4bf',
+}: {
+  title: string
+  eyebrow: string
+  accent?: string
+}): ImageResponse {
+  return new ImageResponse(
+    <div
+      style={{
+        height: '100%',
+        width: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'space-between',
+        background: 'linear-gradient(135deg, #0f172a 0%, #134e4a 100%)',
+        color: 'white',
+        padding: '80px',
+        fontFamily: 'sans-serif',
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          fontSize: 32,
+          letterSpacing: 2,
+          textTransform: 'uppercase',
+          color: accent,
+          fontWeight: 700,
+        }}
+      >
+        {eyebrow}
+      </div>
+      <div style={{ display: 'flex', fontSize: 70, fontWeight: 800, lineHeight: 1.1 }}>{title}</div>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          fontSize: 30,
+        }}
+      >
+        <span style={{ display: 'flex', fontWeight: 700 }}>Free For Charity</span>
+        <span style={{ display: 'flex', color: '#94a3b8' }}>ffcadmin.org</span>
+      </div>
+    </div>,
+    { ...OG_SIZE }
+  )
+}
+
+/** Per-leaf OG image for a Legacy WordPress Administration page (#255). */
+export function renderLegacyLeafOg(slug: string): ImageResponse {
+  const page = LEGACY_WP_ADMIN_PAGES.find((p) => p.slug === slug)
+  return renderOgImage({
+    eyebrow: 'Legacy WordPress Administration',
+    title: page?.title ?? 'Legacy WordPress Administration',
+    accent: '#38bdf8',
+  })
+}


### PR DESCRIPTION
## Summary

Implements #255 — per-page OpenGraph images. Uses Next's built-in `next/og` (satori) to generate **branded 1200×630 PNGs at build time** as static files in the export — no extra dependencies, no manual image design, regenerates automatically when the data file changes.

## Changes

- **`src/lib/og.tsx`** — shared `renderOgImage({ title, eyebrow, accent })` and `renderLegacyLeafOg(slug)` (pulls the leaf title from `legacy-wordpress-administration.ts`).
- **`src/app/opengraph-image.tsx`** — a branded site-wide default OG image (covers every page that doesn't override it — home, volunteer, CE, recognition, etc.).
- **Per-leaf `opengraph-image.tsx` for all 14 Legacy WP Admin leaves** — each renders its own page title, so social shares are visually differentiated instead of all showing the homepage image.
- **`layout.tsx`** — Twitter card bumped to `summary_large_image` now that we ship 1200×630 art.
- **Tests** — assert the OG files are emitted and each leaf's `og:image` points at its own `opengraph-image`.

Each metadata image route sets `dynamic = 'force-static'` so it's emitted as a static file under `output: export`.

## Acceptance criteria (#255)
- [x] Each leaf sets a unique `og:image`.
- [x] Image is 1200×630.
- [x] Image references the page title + FFC branding.
- [x] Build step regenerates images from the data file (no manual assets).

## Verification
- `pnpm run build` — generates 15 OG PNGs (1 site-wide + 14 leaves); verified each leaf's `og:image` meta points at its own image
- `pnpm run type-check` / `lint` — clean
- `pnpm test` — 393 passed

Refs #248. Closes #255.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X4omPQW2ErDyZsMtxypuMe)_