### PR TITLE
feat: documentation search + runbooks/playbooks section (#187)

### DIFF
--- a/src/app/documentation/DocSearch.tsx
+++ b/src/app/documentation/DocSearch.tsx
@@ -1,0 +1,130 @@
+'use client'
+
+import Link from 'next/link'
+import { useMemo, useState } from 'react'
+import { documentationSections, type DocSection } from './docs-data'
+
+const GitHubIcon = () => (
+  <svg className="w-4 h-4 mr-1" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+    <path
+      fillRule="evenodd"
+      d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"
+      clipRule="evenodd"
+    />
+  </svg>
+)
+
+function matches(section: DocSection, q: string): DocSection | null {
+  if (!q) return section
+  const needle = q.toLowerCase()
+  if (section.title.toLowerCase().includes(needle)) return section
+  const docs = section.docs.filter((d) =>
+    [d.name, d.description, d.audience, d.file].some((f) => f.toLowerCase().includes(needle))
+  )
+  return docs.length > 0 ? { ...section, docs } : null
+}
+
+export default function DocSearch() {
+  const [query, setQuery] = useState('')
+
+  const filtered = useMemo(
+    () => documentationSections.map((s) => matches(s, query)).filter((s): s is DocSection => !!s),
+    [query]
+  )
+  const resultCount = filtered.reduce((n, s) => n + s.docs.length, 0)
+
+  return (
+    <>
+      {/* Search */}
+      <div className="bg-white rounded-xl shadow-lg p-4 md:p-5 mb-8">
+        <label htmlFor="doc-search" className="sr-only">
+          Search documentation
+        </label>
+        <div className="relative">
+          <svg
+            className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+            />
+          </svg>
+          <input
+            id="doc-search"
+            type="search"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search docs by name, topic, or audience…"
+            className="w-full pl-10 pr-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none"
+          />
+        </div>
+        {query && (
+          <p className="text-sm text-gray-500 mt-2" role="status">
+            {resultCount} result{resultCount === 1 ? '' : 's'} for “{query}”
+          </p>
+        )}
+      </div>
+
+      {filtered.length === 0 ? (
+        <div className="bg-white rounded-xl shadow-lg p-8 text-center text-gray-600">
+          No documents match “{query}”. Try a different term.
+        </div>
+      ) : (
+        filtered.map((section) => (
+          <div key={section.title} className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
+            <div className="flex items-center mb-6">
+              <span className="text-4xl mr-4" aria-hidden="true">
+                {section.icon}
+              </span>
+              <div>
+                <h2 className="text-2xl font-bold text-gray-900">{section.title}</h2>
+                <p className="text-gray-600">{section.description}</p>
+              </div>
+            </div>
+
+            <div className="space-y-6">
+              {section.docs.map((doc) => (
+                <div key={doc.name} className="border-l-4 border-blue-600 pl-4 py-2">
+                  <div className="flex items-start justify-between mb-2 gap-4">
+                    <h3 className="text-xl font-semibold text-gray-900">{doc.name}</h3>
+                    <div className="flex-shrink-0 flex items-center gap-2">
+                      {doc.liveUrl && (
+                        <Link
+                          href={doc.liveUrl}
+                          className="inline-flex items-center px-3 py-1 bg-blue-600 text-white text-sm rounded-lg hover:bg-blue-700 transition-colors"
+                        >
+                          Open page
+                        </Link>
+                      )}
+                      <a
+                        href={doc.githubUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center px-3 py-1 bg-gray-900 text-white text-sm rounded-lg hover:bg-gray-800 transition-colors"
+                        aria-label={`View ${doc.name} on GitHub`}
+                      >
+                        <GitHubIcon />
+                        GitHub
+                      </a>
+                    </div>
+                  </div>
+                  <p className="text-sm text-gray-600 mb-2 font-mono">{doc.file}</p>
+                  <p className="text-gray-700 mb-3">{doc.description}</p>
+                  <p className="text-sm text-gray-600">
+                    <strong>Audience:</strong> {doc.audience}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </div>
+        ))
+      )}
+    </>
+  )
+}

--- a/src/app/documentation/docs-data.ts
+++ b/src/app/documentation/docs-data.ts
@@ -1,0 +1,249 @@
+const GH_BLOB = 'https://github.com/FreeForCharity/FFC-IN-ffcadmin.org/blob/main'
+
+export interface DocLink {
+  name: string
+  file: string
+  description: string
+  audience: string
+  githubUrl: string
+  /** Optional on-site page (e.g. a runbook leaf) shown as an "Open page" link. */
+  liveUrl?: string
+}
+
+export interface DocSection {
+  title: string
+  description: string
+  icon: string
+  docs: DocLink[]
+}
+
+export const documentationSections: DocSection[] = [
+  {
+    title: 'Getting Started',
+    description: 'Essential guides to get up and running quickly',
+    icon: '🚀',
+    docs: [
+      {
+        name: 'Main README',
+        file: 'README.md',
+        description:
+          'The primary documentation for this repository. Covers deployment status, responsive design, analytics setup, testing, code quality standards, and commit signing requirements. This is your starting point for understanding the entire project.',
+        audience: 'Everyone - Developers, Administrators, New Contributors',
+        githubUrl: `${GH_BLOB}/README.md`,
+      },
+      {
+        name: 'Quick Start Guide',
+        file: 'QUICK_START.md',
+        description:
+          'A 5-minute setup guide for enabling automatic commit signing using the Free For Charity GPG key. Includes step-by-step instructions for adding the public key to GitHub and configuring repository secrets.',
+        audience: 'Repository Administrators, New Developers',
+        githubUrl: `${GH_BLOB}/QUICK_START.md`,
+      },
+    ],
+  },
+  {
+    title: 'Runbooks & Playbooks',
+    description: 'Step-by-step operational procedures for common scenarios',
+    icon: '📑',
+    docs: [
+      {
+        name: 'Onboard a new charity',
+        file: '/legacy-wordpress-administration/wordpress-online-impacts-onboarding',
+        description:
+          'End-to-end workflow for bringing a new charity online: validation, accounts, hosting, and the service-delivery stages. Start here when a new charity is approved.',
+        audience: 'Global Admins, Onboarding volunteers',
+        githubUrl: `${GH_BLOB}/src/app/legacy-wordpress-administration/wordpress-online-impacts-onboarding/page.tsx`,
+        liveUrl: '/legacy-wordpress-administration/wordpress-online-impacts-onboarding',
+      },
+      {
+        name: 'Handle a DNS / hosting issue (escalation)',
+        file: '/legacy-wordpress-administration/wordpress-escalation-runbook',
+        description:
+          'Consolidated escalation paths for when a site won’t load, email breaks, or a domain may have lapsed — who to contact and in what order.',
+        audience: 'Global Admins, Maintainers',
+        githubUrl: `${GH_BLOB}/src/app/legacy-wordpress-administration/wordpress-escalation-runbook/page.tsx`,
+        liveUrl: '/legacy-wordpress-administration/wordpress-escalation-runbook',
+      },
+      {
+        name: 'DNS cutover runbook',
+        file: 'docs/dns-cutover-runbook.md',
+        description:
+          'The step-by-step procedure and redirect-verification script for cutting a domain over to the static stack. Use alongside the cutover site plan.',
+        audience: 'Global Admins, DevOps',
+        githubUrl: `${GH_BLOB}/docs/dns-cutover-runbook.md`,
+      },
+      {
+        name: 'Respond to a security alert',
+        file: 'SECURITY.md',
+        description:
+          'How FFC handles security reports and Dependabot/CodeQL alerts, the disclosure policy, and who to contact. Read before acting on any security finding.',
+        audience: 'Global Admins, Security Team',
+        githubUrl: `${GH_BLOB}/SECURITY.md`,
+      },
+      {
+        name: 'Charity site-owner repo configuration',
+        file: 'docs/site-owner-repo-config.md',
+        description:
+          'The required repository settings (auto-merge + branch protection + write access) so a charity owner’s "approve → it publishes" flow works.',
+        audience: 'Global Admins',
+        githubUrl: `${GH_BLOB}/docs/site-owner-repo-config.md`,
+      },
+    ],
+  },
+  {
+    title: 'Deployment & Operations',
+    description: 'Guides for deploying and operating the site',
+    icon: '🌐',
+    docs: [
+      {
+        name: 'Deployment Guide',
+        file: 'DEPLOYMENT.md',
+        description:
+          'Comprehensive guide for deploying this Next.js site to GitHub Pages. Covers Next.js configuration for static export, custom domain setup, GitHub Actions workflow, build output structure, and troubleshooting common deployment issues.',
+        audience: 'DevOps Engineers, Repository Administrators',
+        githubUrl: `${GH_BLOB}/DEPLOYMENT.md`,
+      },
+      {
+        name: 'GitHub Actions Workflows',
+        file: '.github/workflows/README.md',
+        description:
+          'Documentation for the GitHub Actions workflows: CI (continuous integration with testing and linting), CodeQL Analysis (automated security scanning), Deploy (production deployment), and the scheduled data feeds (sites list, CI status, domain expiry, volunteer hours).',
+        audience: 'DevOps Engineers, Developers',
+        githubUrl: `${GH_BLOB}/.github/workflows/README.md`,
+      },
+      {
+        name: 'Dashboard data contracts',
+        file: 'docs/data-contracts.md',
+        description:
+          'The committed-JSON contracts behind the live dashboards (CI status, domain expiry, volunteer hours): what each feed contains, how it refreshes, and how the UI degrades gracefully when data is stale.',
+        audience: 'Developers, Global Admins',
+        githubUrl: `${GH_BLOB}/docs/data-contracts.md`,
+      },
+    ],
+  },
+  {
+    title: 'Development & Code Quality',
+    description: 'Standards, guidelines, and best practices for code',
+    icon: '💻',
+    docs: [
+      {
+        name: 'Code Quality Standards',
+        file: 'CODE_QUALITY.md',
+        description:
+          'Comprehensive overview of code quality standards including ESLint configuration, TypeScript type safety, testing framework (Jest + React Testing Library), security scanning, and recommendations for enhancements. Essential reading for maintaining high code quality.',
+        audience: 'Developers, Code Reviewers, Quality Assurance',
+        githubUrl: `${GH_BLOB}/CODE_QUALITY.md`,
+      },
+      {
+        name: 'Test Cases Documentation',
+        file: 'TEST_CASES.md',
+        description:
+          'Detailed documentation of all test cases including build output validation, GitHub Pages configuration, SEO metadata, route generation, and configuration validation. Explains the test framework, coverage goals, and maintenance procedures.',
+        audience: 'Developers, Quality Assurance, Testers',
+        githubUrl: `${GH_BLOB}/TEST_CASES.md`,
+      },
+      {
+        name: 'Test Documentation (Public Page)',
+        file: '/testing',
+        description:
+          'Comprehensive public-facing test documentation covering every test suite, their purposes, what they test, why they are important, and how to verify them manually. Includes a live CI status badge.',
+        audience: 'All Users - Developers, QA Testers, Administrators, Auditors',
+        githubUrl: `${GH_BLOB}/src/app/testing/page.tsx`,
+        liveUrl: '/testing',
+      },
+    ],
+  },
+  {
+    title: 'Security & Authentication',
+    description: 'Security practices and GPG commit signing',
+    icon: '🔒',
+    docs: [
+      {
+        name: 'Security Policy',
+        file: 'SECURITY.md',
+        description:
+          'How to report a vulnerability, the disclosure policy, and how FFC triages Dependabot and CodeQL alerts.',
+        audience: 'Everyone, Security Team',
+        githubUrl: `${GH_BLOB}/SECURITY.md`,
+      },
+      {
+        name: 'GPG Signing Configuration',
+        file: 'GPG_SIGNING.md',
+        description:
+          'Technical documentation explaining why GPG signatures are required, how GitHub verifies signatures, and solutions for enabling commit signing including repository settings, GitHub Apps, bot configuration, and workflow automation.',
+        audience: 'Repository Administrators, Security Team, Developers',
+        githubUrl: `${GH_BLOB}/GPG_SIGNING.md`,
+      },
+      {
+        name: 'Security Controls',
+        file: 'docs/security-controls.md',
+        description:
+          'The enforced security controls (MFA, Conditional Access) and the documented gaps, with SSO status. Reference when answering a security questionnaire.',
+        audience: 'Global Admins, Security Team, Auditors',
+        githubUrl: `${GH_BLOB}/docs/security-controls.md`,
+      },
+    ],
+  },
+  {
+    title: 'Design & User Experience',
+    description: 'Responsive design and accessibility documentation',
+    icon: '🎨',
+    docs: [
+      {
+        name: 'Responsive Design',
+        file: 'RESPONSIVE_DESIGN.md',
+        description:
+          'Complete responsive design documentation covering Tailwind CSS breakpoints, navigation behavior across devices, expected behavior at different screen sizes, a troubleshooting guide for cache and CSS loading issues, and testing/verification results.',
+        audience: 'Frontend Developers, Designers, QA Testers',
+        githubUrl: `${GH_BLOB}/RESPONSIVE_DESIGN.md`,
+      },
+    ],
+  },
+  {
+    title: 'Sites Management & Monitoring',
+    description: 'Domain and site management tools',
+    icon: '🌍',
+    docs: [
+      {
+        name: 'Sites List (Public Page)',
+        file: '/sites-list',
+        description:
+          'Master list of all managed domains with health checks, the domain-expiration tracker, and per-row quick links. Integrates WHMCS, Cloudflare, and WPMUDEV data, refreshed by scheduled workflows.',
+        audience: 'All Users - Administrators, Site Managers, Auditors',
+        githubUrl: `${GH_BLOB}/src/app/sites-list/page.tsx`,
+        liveUrl: '/sites-list',
+      },
+      {
+        name: 'Sites List Documentation',
+        file: 'docs/SITES_LIST.md',
+        description:
+          'Comprehensive documentation for the Sites List system: categorized tables, automated health checks, data integration, the weekly automation workflow, data structure, and troubleshooting.',
+        audience: 'Administrators, Site Managers, Developers, Auditors',
+        githubUrl: `${GH_BLOB}/docs/SITES_LIST.md`,
+      },
+      {
+        name: 'Sites List Update Workflow',
+        file: '.github/workflows/update-sites-data.yml',
+        description:
+          'Automated weekly workflow that exports data from WHMCS, Cloudflare, and WPMUDEV, runs site health checks, merges into a single CSV, and opens a pull request with the updates.',
+        audience: 'Repository Administrators, DevOps Engineers, Site Managers',
+        githubUrl: `${GH_BLOB}/.github/workflows/update-sites-data.yml`,
+      },
+    ],
+  },
+  {
+    title: 'Archived Documentation',
+    description: 'Previously active documentation that has been consolidated or completed',
+    icon: '📦',
+    docs: [
+      {
+        name: 'Archived Files',
+        file: 'docs/archived/README.md',
+        description:
+          'Documentation that has been archived (consolidated GPG/auto-signing guides, responsive testing results, and completed implementation issues). Preserved for historical reference and audit purposes.',
+        audience: 'Repository Administrators, Auditors, Historical Reference',
+        githubUrl: `${GH_BLOB}/docs/archived/README.md`,
+      },
+    ],
+  },
+]

--- a/src/app/documentation/page.tsx
+++ b/src/app/documentation/page.tsx
@@ -1,231 +1,14 @@
 import type { Metadata } from 'next'
 import NonprofitCallout from '@/components/NonprofitCallout'
+import DocSearch from './DocSearch'
 
 export const metadata: Metadata = {
   title: 'Documentation',
   description:
-    'Guides for FFC volunteers: deployment, security, responsive design, code quality, Lighthouse CI, and more. Everything you need to contribute.',
-  keywords: 'documentation, volunteer guides, deployment, security, nonprofit web development',
+    'Searchable index of FFC documentation and runbooks: onboarding, escalation, deployment, security, code quality, and more. Everything you need to contribute and operate.',
+  keywords:
+    'documentation, runbooks, playbooks, volunteer guides, deployment, security, nonprofit web development',
 }
-
-interface DocSection {
-  title: string
-  description: string
-  icon: string
-  docs: Array<{
-    name: string
-    file: string
-    description: string
-    audience: string
-    githubUrl: string
-  }>
-}
-
-const documentationSections: DocSection[] = [
-  {
-    title: 'Getting Started',
-    description: 'Essential guides to get up and running quickly',
-    icon: '🚀',
-    docs: [
-      {
-        name: 'Main README',
-        file: 'README.md',
-        description:
-          'The primary documentation for this repository. Covers deployment status, responsive design, analytics setup, testing, code quality standards, and commit signing requirements. This is your starting point for understanding the entire project.',
-        audience: 'Everyone - Developers, Administrators, New Contributors',
-        githubUrl: 'https://github.com/FreeForCharity/FFC-IN-ffcadmin.org/blob/main/README.md',
-      },
-      {
-        name: 'Quick Start Guide',
-        file: 'QUICK_START.md',
-        description:
-          'A 5-minute setup guide for enabling automatic commit signing using the Free For Charity GPG key. Includes step-by-step instructions for adding the public key to GitHub and configuring repository secrets.',
-        audience: 'Repository Administrators, New Developers',
-        githubUrl: 'https://github.com/FreeForCharity/FFC-IN-ffcadmin.org/blob/main/QUICK_START.md',
-      },
-    ],
-  },
-  {
-    title: 'Deployment & Operations',
-    description: 'Guides for deploying and operating the site',
-    icon: '🌐',
-    docs: [
-      {
-        name: 'Deployment Guide',
-        file: 'DEPLOYMENT.md',
-        description:
-          'Comprehensive guide for deploying this Next.js site to GitHub Pages. Covers Next.js configuration for static export, custom domain setup, GitHub Actions workflow, build output structure, and troubleshooting common deployment issues.',
-        audience: 'DevOps Engineers, Repository Administrators',
-        githubUrl: 'https://github.com/FreeForCharity/FFC-IN-ffcadmin.org/blob/main/DEPLOYMENT.md',
-      },
-      {
-        name: 'GitHub Actions Workflows',
-        file: '.github/workflows/README.md',
-        description:
-          'Documentation for the three GitHub Actions workflows: CI (continuous integration with testing and linting), CodeQL Analysis (automated security scanning), and Deploy (production deployment to GitHub Pages).',
-        audience: 'DevOps Engineers, Developers',
-        githubUrl:
-          'https://github.com/FreeForCharity/FFC-IN-ffcadmin.org/blob/main/.github/workflows/README.md',
-      },
-    ],
-  },
-  {
-    title: 'Development & Code Quality',
-    description: 'Standards, guidelines, and best practices for code',
-    icon: '💻',
-    docs: [
-      {
-        name: 'Code Quality Standards',
-        file: 'CODE_QUALITY.md',
-        description:
-          'Comprehensive overview of code quality standards including ESLint configuration, TypeScript type safety, testing framework (Jest + React Testing Library), security scanning, and recommendations for enhancements. Essential reading for maintaining high code quality.',
-        audience: 'Developers, Code Reviewers, Quality Assurance',
-        githubUrl:
-          'https://github.com/FreeForCharity/FFC-IN-ffcadmin.org/blob/main/CODE_QUALITY.md',
-      },
-      {
-        name: 'Test Cases Documentation',
-        file: 'TEST_CASES.md',
-        description:
-          'Detailed documentation of all test cases including build output validation, GitHub Pages configuration, SEO metadata, route generation, and configuration validation. Explains the test framework, coverage goals, and maintenance procedures.',
-        audience: 'Developers, Quality Assurance, Testers',
-        githubUrl: 'https://github.com/FreeForCharity/FFC-IN-ffcadmin.org/blob/main/TEST_CASES.md',
-      },
-      {
-        name: 'Test Documentation (Public Page)',
-        file: '/testing',
-        description:
-          'Comprehensive public-facing test documentation covering all 17 test suites, their purposes, what they test, why they are important, and how to verify them manually. Includes running instructions, CI/CD integration details, and test result interpretation. Essential for understanding the testing strategy and quality assurance processes.',
-        audience: 'All Users - Developers, QA Testers, Administrators, Auditors',
-        githubUrl:
-          'https://github.com/FreeForCharity/FFC-IN-ffcadmin.org/blob/main/src/app/testing/page.tsx',
-      },
-    ],
-  },
-  {
-    title: 'Security & Authentication',
-    description: 'Security practices and GPG commit signing',
-    icon: '🔒',
-    docs: [
-      {
-        name: 'Quick Start: GPG Signing Setup',
-        file: 'QUICK_START.md',
-        description:
-          'Comprehensive 5-minute setup guide for enabling automatic GPG commit signing. Includes step-by-step instructions, verification procedures, troubleshooting, how auto-signing works, and advanced topics. Consolidated from multiple GPG documentation files for easy access.',
-        audience: 'Repository Administrators, DevOps Engineers, Developers',
-        githubUrl: 'https://github.com/FreeForCharity/FFC-IN-ffcadmin.org/blob/main/QUICK_START.md',
-      },
-      {
-        name: 'GPG Signing Configuration',
-        file: 'GPG_SIGNING.md',
-        description:
-          'Technical documentation explaining why GPG signatures are required, how GitHub verifies signatures, and five different solutions for enabling commit signing including repository settings, GitHub Apps, bot configuration, and workflow automation.',
-        audience: 'Repository Administrators, Security Team, Developers',
-        githubUrl: 'https://github.com/FreeForCharity/FFC-IN-ffcadmin.org/blob/main/GPG_SIGNING.md',
-      },
-      {
-        name: 'GPG Keys Directory',
-        file: 'gpg-keys/README.md',
-        description:
-          'Documentation for the official Free For Charity GPG key including key information (ID, fingerprint, validity period), security warnings, setup instructions, and verification procedures. Explains how to safely manage public and private keys.',
-        audience: 'Repository Administrators, Security Team',
-        githubUrl:
-          'https://github.com/FreeForCharity/FFC-IN-ffcadmin.org/blob/main/gpg-keys/README.md',
-      },
-    ],
-  },
-  {
-    title: 'Design & User Experience',
-    description: 'Responsive design and accessibility documentation',
-    icon: '🎨',
-    docs: [
-      {
-        name: 'Responsive Design',
-        file: 'RESPONSIVE_DESIGN.md',
-        description:
-          'Complete responsive design documentation covering Tailwind CSS breakpoints, navigation behavior across devices (mobile hamburger menu vs desktop inline links), expected behavior at different screen sizes, comprehensive troubleshooting guide for cache and CSS loading issues, and detailed testing and verification results.',
-        audience: 'Frontend Developers, Designers, QA Testers',
-        githubUrl:
-          'https://github.com/FreeForCharity/FFC-IN-ffcadmin.org/blob/main/RESPONSIVE_DESIGN.md',
-      },
-    ],
-  },
-  {
-    title: 'Troubleshooting & Issue Resolution',
-    description: 'Problem-solving guides and issue analysis',
-    icon: '🔧',
-    docs: [
-      {
-        name: 'Issue Resolution',
-        file: 'ISSUE_RESOLUTION.md',
-        description:
-          'Comprehensive analysis and resolution of issues encountered during development. Documents problems, root causes, solutions implemented, and lessons learned. Valuable resource for troubleshooting similar issues in the future.',
-        audience: 'Developers, Support Team, Repository Administrators',
-        githubUrl:
-          'https://github.com/FreeForCharity/FFC-IN-ffcadmin.org/blob/main/ISSUE_RESOLUTION.md',
-      },
-    ],
-  },
-  {
-    title: 'Sites Management & Monitoring',
-    description: 'Domain and site management tools',
-    icon: '🌍',
-    docs: [
-      {
-        name: 'Sites List Documentation',
-        file: 'docs/SITES_LIST.md',
-        description:
-          'Comprehensive documentation for the Sites List system covering all features and capabilities. Topics include: categorized tables (Active, Transferred, Expired, Fraud), automated site health checks, WPMUDEV/WHMCS/Cloudflare data integration, weekly automation workflow, data structure, update script details, troubleshooting, and security. Essential reading for understanding the complete Sites List architecture.',
-        audience: 'All Users - Administrators, Site Managers, Developers, Auditors',
-        githubUrl:
-          'https://github.com/FreeForCharity/FFC-IN-ffcadmin.org/blob/main/docs/SITES_LIST.md',
-      },
-      {
-        name: 'Sites List (Public Page)',
-        file: '/sites-list',
-        description:
-          'Master list of all managed domains with automated health checks and data integration. Displays categorized tables for Active sites, Transferred domains, Expired/Cancelled sites, and Fraudulent/High Risk domains. Integrates data from WHMCS (domain registration), Cloudflare (DNS/CDN), and WPMUDEV (WordPress hosting). Includes latest site health status from weekly automated checks (Live, Redirect, Error, Unreachable) and GitHub repository links. Updated automatically via scheduled workflows.',
-        audience: 'All Users - Administrators, Site Managers, Auditors, Stakeholders',
-        githubUrl:
-          'https://github.com/FreeForCharity/FFC-IN-ffcadmin.org/blob/main/src/app/sites-list/page.tsx',
-      },
-      {
-        name: 'Sites List Update Workflow',
-        file: '.github/workflows/update-sites-data.yml',
-        description:
-          'Automated workflow that updates the Sites List weekly. Triggers remote workflows to export data from WHMCS, Cloudflare, and WPMUDEV systems, downloads the exported data, runs automated site health checks (HTTP status validation), merges all data sources into a single CSV file, and creates a pull request with the updates. Enables automated site monitoring and reduces manual data entry.',
-        audience: 'Repository Administrators, DevOps Engineers, Site Managers',
-        githubUrl:
-          'https://github.com/FreeForCharity/FFC-IN-ffcadmin.org/blob/main/.github/workflows/update-sites-data.yml',
-      },
-      {
-        name: 'Sites Data Update Script',
-        file: 'scripts/update-sites-data.mjs',
-        description:
-          'Node.js script that processes and merges data from WHMCS, Cloudflare, and WPMUDEV CSV exports. Performs automated site health checks with HTTP requests, categorizes sites by status (Active, Transferred, Expired, Fraud), applies sorting and pairing logic for .org/.com domain pairs, and generates the final sites_list.csv file. Processes sites in chunks to avoid network throttling.',
-        audience: 'Developers, DevOps Engineers, Site Managers',
-        githubUrl:
-          'https://github.com/FreeForCharity/FFC-IN-ffcadmin.org/blob/main/scripts/update-sites-data.mjs',
-      },
-    ],
-  },
-  {
-    title: 'Archived Documentation',
-    description: 'Previously active documentation that has been consolidated or completed',
-    icon: '📦',
-    docs: [
-      {
-        name: 'Archived Files',
-        file: 'docs/archived/README.md',
-        description:
-          'Documentation that has been archived includes: SETUP_AUTO_SIGNING.md and AUTO_SIGN_TEST.md (consolidated into QUICK_START.md), RESPONSIVE_TESTING_RESULTS.md (consolidated into RESPONSIVE_DESIGN.md), and IMPLEMENTATION_ISSUES.md (all 11 issues complete). Files are preserved for historical reference and audit purposes.',
-        audience: 'Repository Administrators, Auditors, Historical Reference',
-        githubUrl:
-          'https://github.com/FreeForCharity/FFC-IN-ffcadmin.org/blob/main/docs/archived/README.md',
-      },
-    ],
-  },
-]
 
 export default function Documentation() {
   return (
@@ -251,7 +34,8 @@ export default function Documentation() {
             <h1 className="text-3xl md:text-4xl font-bold">Documentation Center</h1>
           </div>
           <p className="text-blue-100 text-lg">
-            Comprehensive guides and technical documentation for Free For Charity Admin Portal
+            Searchable guides, references, and operational runbooks for the Free For Charity Admin
+            Portal
           </p>
         </div>
       </div>
@@ -261,186 +45,32 @@ export default function Documentation() {
         <div className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
           <h2 className="text-2xl font-bold text-gray-900 mb-4">About This Documentation</h2>
           <p className="text-gray-700 mb-4">
-            This page provides a comprehensive index of all documentation files in this repository.
-            Each README file serves a specific purpose and is designed to help different audiences
-            understand, use, and contribute to this project.
-          </p>
-          <p className="text-gray-700 mb-4">
-            Whether you're a <strong>new developer</strong> getting started, a{' '}
-            <strong>global administrator</strong> managing the infrastructure, a{' '}
-            <strong>nonprofit partner</strong> understanding our technology, or an{' '}
-            <strong>auditor</strong> reviewing our practices, you'll find the documentation you need
-            here.
+            A comprehensive, searchable index of every documentation file and runbook in this
+            repository. Search by name, topic, or audience, then open the live page or the source on
+            GitHub.
           </p>
           <div className="bg-blue-50 border-l-4 border-blue-600 p-4 rounded">
             <p className="text-blue-900 text-sm">
-              <strong>💡 Tip:</strong> Click the GitHub icon next to each document to view it
-              directly in the repository. This ensures you always have access to the latest version
-              with full context and history.
+              <strong>💡 Tip:</strong> Need a procedure? Search “onboard”, “escalation”, “security”,
+              or “deploy” to jump straight to the relevant runbook.
             </p>
           </div>
         </div>
 
-        {/* Documentation Sections */}
-        {documentationSections.map((section, idx) => (
-          <div key={idx} className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
-            <div className="flex items-center mb-6">
-              <span className="text-4xl mr-4" aria-hidden="true">
-                {section.icon}
-              </span>
-              <div>
-                <h2 className="text-2xl font-bold text-gray-900">{section.title}</h2>
-                <p className="text-gray-600">{section.description}</p>
-              </div>
-            </div>
-
-            <div className="space-y-6">
-              {section.docs.map((doc, docIdx) => (
-                <div key={docIdx} className="border-l-4 border-blue-600 pl-4 py-2">
-                  <div className="flex items-start justify-between mb-2">
-                    <h3 className="text-xl font-semibold text-gray-900">{doc.name}</h3>
-                    <a
-                      href={doc.githubUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="flex-shrink-0 ml-4 inline-flex items-center px-3 py-1 bg-gray-900 text-white text-sm rounded-lg hover:bg-gray-800 transition-colors"
-                      aria-label={`View ${doc.name} on GitHub`}
-                    >
-                      <svg
-                        className="w-4 h-4 mr-1"
-                        fill="currentColor"
-                        viewBox="0 0 24 24"
-                        aria-hidden="true"
-                      >
-                        <path
-                          fillRule="evenodd"
-                          d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"
-                          clipRule="evenodd"
-                        />
-                      </svg>
-                      View on GitHub
-                    </a>
-                  </div>
-                  <p className="text-sm text-gray-600 mb-2 font-mono">{doc.file}</p>
-                  <p className="text-gray-700 mb-3">{doc.description}</p>
-                  <div className="flex items-center text-sm">
-                    <svg
-                      className="w-4 h-4 mr-2 text-blue-600"
-                      fill="none"
-                      stroke="currentColor"
-                      viewBox="0 0 24 24"
-                      aria-hidden="true"
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2}
-                        d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
-                      />
-                    </svg>
-                    <span className="text-gray-600">
-                      <strong>Audience:</strong> {doc.audience}
-                    </span>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </div>
-        ))}
-
-        {/* How to Use This Documentation */}
-        <div className="bg-gradient-to-br from-indigo-50 to-purple-50 rounded-xl shadow-lg p-6 md:p-8 border border-indigo-200">
-          <h2 className="text-2xl font-bold text-gray-900 mb-4">How to Use This Documentation</h2>
-
-          <div className="space-y-4">
-            <div className="flex items-start">
-              <div className="flex-shrink-0 w-8 h-8 bg-indigo-600 text-white rounded-full flex items-center justify-center font-bold mr-3">
-                1
-              </div>
-              <div>
-                <h3 className="font-semibold text-gray-900 mb-1">Identify Your Role</h3>
-                <p className="text-gray-700">
-                  Start by identifying which audience category you fall into. Each document lists
-                  its target audience to help you find relevant information quickly.
-                </p>
-              </div>
-            </div>
-
-            <div className="flex items-start">
-              <div className="flex-shrink-0 w-8 h-8 bg-indigo-600 text-white rounded-full flex items-center justify-center font-bold mr-3">
-                2
-              </div>
-              <div>
-                <h3 className="font-semibold text-gray-900 mb-1">Choose Your Starting Point</h3>
-                <p className="text-gray-700">
-                  <strong>New to the project?</strong> Start with the Main README and Quick Start
-                  Guide.
-                  <br />
-                  <strong>Need to deploy?</strong> Check the Deployment Guide and GitHub Actions
-                  Workflows.
-                  <br />
-                  <strong>Working on code?</strong> Review Code Quality Standards and Test Cases
-                  Documentation.
-                </p>
-              </div>
-            </div>
-
-            <div className="flex items-start">
-              <div className="flex-shrink-0 w-8 h-8 bg-indigo-600 text-white rounded-full flex items-center justify-center font-bold mr-3">
-                3
-              </div>
-              <div>
-                <h3 className="font-semibold text-gray-900 mb-1">View on GitHub</h3>
-                <p className="text-gray-700">
-                  Click the "View on GitHub" button to read the full documentation in the
-                  repository. This ensures you see the latest version and can navigate related files
-                  easily.
-                </p>
-              </div>
-            </div>
-
-            <div className="flex items-start">
-              <div className="flex-shrink-0 w-8 h-8 bg-indigo-600 text-white rounded-full flex items-center justify-center font-bold mr-3">
-                4
-              </div>
-              <div>
-                <h3 className="font-semibold text-gray-900 mb-1">Follow Cross-References</h3>
-                <p className="text-gray-700">
-                  Many documents reference each other. Following these links will give you a
-                  complete understanding of interconnected topics.
-                </p>
-              </div>
-            </div>
-          </div>
-        </div>
+        {/* Searchable documentation index + runbooks */}
+        <DocSearch />
 
         {/* Need Help Section */}
         <div className="bg-white rounded-xl shadow-lg p-6 md:p-8 mt-8">
           <h2 className="text-2xl font-bold text-gray-900 mb-4">Need Additional Help?</h2>
           <p className="text-gray-700 mb-6">
-            If you can't find what you're looking for in the documentation, here's how to get
-            support:
+            If you can&apos;t find what you&apos;re looking for in the documentation, here&apos;s
+            how to get support:
           </p>
 
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
             <div className="border border-gray-200 rounded-lg p-4">
-              <h3 className="font-semibold text-gray-900 mb-2 flex items-center">
-                <svg
-                  className="w-5 h-5 mr-2 text-blue-600"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                  aria-hidden="true"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z"
-                  />
-                </svg>
-                General Support
-              </h3>
+              <h3 className="font-semibold text-gray-900 mb-2">General Support</h3>
               <p className="text-gray-600 text-sm">
                 Open a support ticket with Free For Charity for general questions, feature requests,
                 or non-urgent issues.
@@ -448,23 +78,7 @@ export default function Documentation() {
             </div>
 
             <div className="border border-yellow-200 bg-yellow-50 rounded-lg p-4">
-              <h3 className="font-semibold text-gray-900 mb-2 flex items-center">
-                <svg
-                  className="w-5 h-5 mr-2 text-yellow-600"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                  aria-hidden="true"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-                  />
-                </svg>
-                Emergency Escalation
-              </h3>
+              <h3 className="font-semibold text-gray-900 mb-2">Emergency Escalation</h3>
               <p className="text-gray-600 text-sm mb-2">
                 For urgent issues that require immediate attention:
               </p>
@@ -481,7 +95,7 @@ export default function Documentation() {
           <div className="mt-6 pt-6 border-t border-gray-200">
             <p className="text-gray-600 text-sm">
               <strong>Contributing to Documentation:</strong> Found an error or want to improve the
-              documentation? Visit our{' '}
+              docs? Visit our{' '}
               <a
                 href="https://github.com/FreeForCharity/FFC-IN-ffcadmin.org"
                 target="_blank"


### PR DESCRIPTION
## Summary

Global-Admin quality-of-life from #187: make the **Documentation hub searchable** and add the **runbooks/playbooks section** the issue asks for.

## Changes
- **`docs-data.ts`** — the documentation index as data, plus a new **Runbooks & Playbooks** section: *onboard a new charity*, *handle a DNS/hosting issue (escalation)*, *DNS cutover runbook*, *respond to a security alert*, *site-owner repo config*. Refreshed entries to point at current docs (data contracts, security controls) and the live dashboards.
- **`DocSearch.tsx`** (client) — search across name / topic / audience / filename with a live result count and empty state; each entry shows an **Open page** link for on-site runbooks and a **GitHub** link for the source.
- **`documentation/page.tsx`** — slimmed to header + intro + `<DocSearch />` + help.

## #187 status
This closes the **Documentation** group of #187:
- [x] Add search to Documentation hub
- [x] Add runbook/playbook section
- [x] Collapsible/scannability — search replaces the need to scroll the full list

Already shipped earlier in #337: live CI status badge, Sites List summary stats / filter-sort / last-updated, health dashboard, domain-expiration tracker. Remaining #187 item — per-row **quick-action deep links** to Cloudflare/WHMCS — needs account/zone IDs not available to the static site; tracked as a follow-up (the GitHub repo link is already shown on migrated-site rows).

## Verification
- `pnpm run type-check` / `lint` — clean
- `pnpm run build` — `/documentation` prerenders
- `pnpm test` — 393 passed

Refs #187.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X4omPQW2ErDyZsMtxypuMe)_