### PR TITLE
docs: link Cloudflare bulk-redirect CSV from cutover plan (#244)

### DIFF
--- a/docs/dns-cutover-site-plan.md
+++ b/docs/dns-cutover-site-plan.md
@@ -330,6 +330,11 @@ Only the WordPress-only drops and the slug-shortening redirects remain:
 
 All redirects use **301 Permanent** and **preserve query strings**.
 
+The ready-to-import Cloudflare Bulk Redirect List is committed at
+[`docs/cloudflare-bulk-redirects-cutover.csv`](./cloudflare-bulk-redirects-cutover.csv)
+(#244) — load it against the freeforcharity.org zone, then verify each row with
+`curl -I` before and after the DNS cutover.
+
 > Note: `/ffcadmin/` on freeforcharity.org stays as a thin signpost page
 > linking to `https://ffcadmin.org/` — it is not a redirect.
 


### PR DESCRIPTION
## Summary

Completes the **in-repo** deliverable for #244: the committed Cloudflare bulk-redirect list (`docs/cloudflare-bulk-redirects-cutover.csv`) is now linked from `docs/dns-cutover-site-plan.md` with load + `curl`-verify guidance — the last unmet in-repo acceptance checkbox.

The remaining #244 acceptance items (loading the list into Cloudflare and `curl -I` verification before/after DNS cutover) are **cutover-day ops** against the freeforcharity.org zone — tracked in the #240 checklist, not actionable from this static-site repo.

## Verification
- `pnpm test` — 393 passed (docs-only change)

Refs #240. Advances #244 (in-repo portion complete).

---
_Generated by [Claude Code](https://claude.ai/code/session_01X4omPQW2ErDyZsMtxypuMe)_