### PR TITLE
feat(sites-list): surface "Left FFC" domains + Cloudflare-aware transfers

### DIFF
--- a/docs/sites_list.csv
+++ b/docs/sites_list.csv
@@ -1,377 +1,377 @@
-Section,Domain,Status,In WHMCS,In Cloudflare,In WPMUDEV,Server In Use,Old Server Abandoned?,Notes,Cloudflare IP,Is In Cloudflare,Repo URL,Site Health,Priority,Repo Archived,Last PR Closed,Open PRs,Last Commit,Dev Status,Work Tier
-Unknown,bearupinternationalministries.org,Unknown,No,No,No,,,,185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153,No,https://github.com/FreeForCharity/FFC-EX-bearupinternationalministries.org,Live,Standard,No,2026-06-07,16,2026-06-07,Active,1 - Active Development
-Subdomain,ffcadmin.org,Active,Yes,Yes,No,GitHub Pages,Yes,Fully migrated,185.199.108.153;185.199.109.153;185.199.110.153;185.199.111.153,Yes,https://github.com/FreeForCharity/FFC-IN-ffcadmin.org,Live,Standard,No,2026-06-07,3,2026-06-07,Active,1 - Active Development
-Unknown,mitchellnchistory.org,Unknown,No,Yes,No,,,,35.212.109.210,Yes,https://github.com/FreeForCharity/FFC-EX-mitchellnchistory.org,Live,Standard,No,2026-06-07,3,2026-06-07,Active,1 - Active Development
-Unknown,thewayofyeshuaministries.org,Unknown,No,No,No,,,,185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153,No,https://github.com/FreeForCharity/FFC-EX-thewayofyeshuaministries.org,Live,Standard,No,2026-06-07,5,2026-06-07,Active,1 - Active Development
-Unknown,rebirthsdc.org,Unknown,No,No,No,,,,185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153,No,https://github.com/FreeForCharity/FFC-EX-rebirthsdc.org,Live,Standard,No,2026-06-04,4,2026-06-04,Active,1 - Active Development
-Cloudflare-Only,3dmc2.org,Active,Yes,Yes,No,Cloudflare Proxy,No,Proxy origin unknown,184.182.219.182,Yes,https://github.com/FreeForCharity/FFC-EX-3dmc2.org,Unreachable,Standard,No,2026-06-02,20,2026-06-02,Active,1 - Active Development
-Unknown,amargraves.org,Active,Yes,No,No,,,,185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153,No,https://github.com/FreeForCharity/FFC-EX-amargraves.org,Live,Standard,No,2026-06-02,21,2026-06-02,Active,1 - Active Development
-Unknown,americanlegionpost64.org,Active,Yes,No,Yes,,,,(no A record),No,https://github.com/FreeForCharity/FFC-EX-americanlegionpost64.org,Unreachable,Standard,No,2026-06-02,20,2026-06-02,Active,1 - Active Development
-For-Profit,aprilhansen.com,Transferred Away,Yes,Yes,Yes,HostPapa,No,Matches HostPapa server list,204.44.192.77,Yes,https://github.com/FreeForCharity/FFC-EX-aprilhansen.com,Unreachable,Standard,No,2026-06-02,19,2026-06-02,Active,1 - Active Development
-Unknown,browncanyonranch.org,Active,Yes,Yes,No,,,,204.44.192.77,Yes,https://github.com/FreeForCharity/FFC-EX-browncanyonranch.org,Live,Standard,No,2026-06-02,20,2026-06-02,Active,1 - Active Development
-Unknown,bucktownbullsbaseball.org,Active,Yes,Yes,No,,,,204.44.192.77,Yes,https://github.com/FreeForCharity/FFC-EX-bucktownbullsbaseball.org,Redirect,Standard,No,2026-06-02,20,2026-06-02,Active,1 - Active Development
-For-Profit,bulldogztowing.com,Active,Yes,Yes,Yes,HostPapa,No,Matches HostPapa server list,204.44.192.77,Yes,https://github.com/FreeForCharity/FFC-EX-bulldogztowing.com,Live,Standard,No,2026-06-02,20,2026-06-02,Active,1 - Active Development
-Org-WPAdmin,canadatokeywestcoastalrun.org,Active,Yes,Yes,Yes,Hostinger,No,.com has no A record,153.92.213.212,Yes,https://github.com/FreeForCharity/FFC-EX-canadatokeywestcoastalrun.org,Live,Standard,No,2026-06-02,20,2026-06-02,Active,1 - Active Development
-Cloudflare-Only,coronadonationalforestheritagesociety.org,Active,Yes,Yes,No,HostPapa,No,Appears only in Cloudflare,204.44.192.77,Yes,https://github.com/FreeForCharity/FFC-EX-coronadonationalforestheritagesociety.org,Live,Standard,No,2026-06-02,20,2026-06-02,Active,1 - Active Development
-Unknown,falloutshelterecovillage.org,Active,Yes,Yes,No,,,,204.44.192.77,Yes,https://github.com/FreeForCharity/FFC-EX-falloutshelterecovillage.org,Live,Standard,No,2026-06-02,20,2026-06-02,Active,1 - Active Development
-For-Profit,foxtrotenterprises.com,Unknown,No,No,Yes,HostPapa,No,Matches HostPapa,204.44.192.77,No,https://github.com/FreeForCharity/FFC-EX-foxtrotenterprises.com,Live,Standard,No,2026-06-02,20,2026-06-02,Active,1 - Active Development
-Cloudflare-Only,freedomrisingusa.org,Active,Yes,Yes,No,GitHub Pages,Yes,Fully migrated,185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153,Yes,https://github.com/FreeForCharity/freedomrisingusa.org,Live,Standard,No,2026-06-02,22,2026-06-02,Active,1 - Active Development
-Org-WPAdmin,freeforcharity.org,Transferred Away,Yes,Yes,Yes,InterServer cPanel,No,Duplicate on HostPapa + Hostinger,66.45.234.13,Yes,https://github.com/FreeForCharity/FreeForCharity.org,Live,Standard,No,2026-06-02,24,2026-06-02,Active,1 - Active Development
-Krystal-New,hclwellness.org,Unknown,No,No,Yes,Krystal.io,No,New Krystal Host,185.199.224.x,No,https://github.com/FreeForCharity/FFC-EX-hclwellness.org,Error,Standard,No,2026-06-02,5,2026-06-06,Active,1 - Active Development
-Unknown,instituteofforgiveness.org,Active,Yes,Yes,Yes,,,,204.44.192.77,Yes,https://github.com/FreeForCharity/FFC-EX-instituteofforgiveness.org,Live,Standard,No,2026-06-02,20,2026-06-02,Active,1 - Active Development
-Unknown,jwvpost619.org,Active,Yes,Yes,No,,,,67.211.214.117,Yes,https://github.com/FreeForCharity/FFC-EX-jwvpost619.org,Live,Standard,No,2026-06-02,18,2026-06-02,Active,1 - Active Development
-Cloudflare-Only,legioninthewoods.org,Unknown,No,Yes,No,GitHub Pages,Yes,Fully migrated (dashless variant),185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153,Yes,https://github.com/FreeForCharity/legioninthewoods.org,Live,Standard,No,2026-06-02,23,2026-06-02,Active,1 - Active Development
-Unknown,nj4israel.org,Active,Yes,No,Yes,,,,(no A record),No,https://github.com/FreeForCharity/FFC-EX-nj4israel.org,Live,Standard,No,2026-06-02,20,2026-06-02,Active,1 - Active Development
-Unknown,savewatersaveplanet.org,Active,Yes,No,Yes,,,,216.222.200.253,No,https://github.com/FreeForCharity/FFC-EX-savewatersaveplanet.org,Live,Standard,No,2026-06-02,20,2026-06-02,Active,1 - Active Development
-Org-WPAdmin,southamptonfriends.org,Active,Yes,Yes,Yes,InterServer DA,No,Duplicate on Hostinger,192.64.86.202,Yes,https://github.com/FreeForCharity/FFC-EX-southamptonfriends.org,Live,Standard,No,2026-06-02,20,2026-06-02,Active,1 - Active Development
-Unknown,sporting2impact.org,Active,Yes,No,No,,,,185.199.111.153;185.199.109.153;185.199.110.153;185.199.108.153,No,https://github.com/FreeForCharity/FFC-EX-sporting2Impact.org,Error,Standard,No,2026-06-02,22,2026-06-02,Active,1 - Active Development
-Unknown,technomonasteries.org,Unknown,No,No,No,,,,70.32.23.118,No,https://github.com/FreeForCharity/FFC-EX-technomonasteries.org,Live,Standard,No,2026-06-02,19,2026-06-02,Active,1 - Active Development
-Unknown,clarasbridge.org,Unknown,No,No,No,,,,185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153,No,https://github.com/FreeForCharity/FFC-EX-clarasbridge.org,Live,Standard,No,2026-05-28,27,2026-05-28,Active,1 - Active Development
-Unknown,aariasblueelephant.org,Pending,Yes,No,No,,,,185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153,No,https://github.com/FreeForCharity/FFC-EX-aariasblueelephant.org,Live,Standard,No,2026-05-27,23,2026-06-03,Active,1 - Active Development
-Unknown,friendsof362.org,Unknown,No,No,No,,,,(no A record),No,https://github.com/FreeForCharity/FFC-EX-friendsof362.org,Unreachable,Standard,No,2026-05-27,22,2026-06-02,Active,1 - Active Development
-Unknown,slopestohope.org,Active,Yes,No,No,,,,185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153,No,https://github.com/FreeForCharity/FFC-EX-slopestohope.org,Live,Standard,No,2026-05-27,0,2026-06-02,Active,1 - Active Development
-For-Profit,srrn.net,Unknown,No,Yes,Yes,Hostinger,No,.net not paired,153.92.213.212,Yes,https://github.com/FreeForCharity/FFC-EX-SRRN.net,Redirect,Standard,No,2026-05-27,0,2026-05-27,Active,1 - Active Development
-Cloudflare-Only,technologymonastery.org,Active,Yes,Yes,Yes,InterServer RS1,No,Matches InterServer RS1 IP,216.158.234.18,Yes,https://github.com/FreeForCharity/TechnologyMonastery.org,Live,Standard,No,2026-05-27,0,2026-05-28,Active,1 - Active Development
-Unknown,thecrookedhouse.net,Unknown,No,No,No,,,,185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153,No,https://github.com/FreeForCharity/FFC-EX-thecrookedhouse.net,Live,Standard,No,2026-05-27,0,2026-05-27,Active,1 - Active Development
-Cloudflare-Only,bintobetter.org,Active,Yes,Yes,No,GitHub Pages,Yes,Fully migrated,185.199.108.153;185.199.111.153;185.199.110.153;185.199.109.153,Yes,https://github.com/FreeForCharity/FFC-EX-bintobetter.org,Live,Standard,No,2026-05-12,0,2026-05-27,Active,1 - Active Development
-For-Profit,alltypetowing.com,Active,Yes,Yes,Yes,HostPapa,No,Matches HostPapa server list,204.44.192.77,Yes,https://github.com/FreeForCharity/FFC-EX-AllTypeTowing.com,Live,Standard,No,2026-01-27,0,2026-03-25,Stalled,"2 - Has Repo, Stalled"
-Org-WPAdmin,acharyaapp.org,Unknown,No,No,Yes,Hostinger,No,.com exists as subdomain,153.92.213.212,No,,Redirect,Standard,,,,,None,3 - Needs Migration
-Org-WPAdmin,ambofoundation.org,Active,Yes,No,Yes,Hostinger,No,Matches Hostinger,153.92.213.212,No,,Live,Standard,,,,,None,3 - Needs Migration
-Org-WPAdmin,apollonianfp.org,Active,Yes,Yes,No,Hostinger,No,Matches Hostinger,153.92.213.212,Yes,,Error,Standard,,,,,None,3 - Needs Migration
-Subdomain,az.acharyaapp.org,Unknown,No,No,No,Hostinger,No,Subdomain of acharyaapp.org,153.92.213.212,No,,Unreachable,Standard,,,,,None,3 - Needs Migration
-Cloudflare-Only,bringingpeople2people.org,Active,Yes,Yes,No,Cloudflare Proxy,No,Proxy origin unknown,(no A record),Yes,,Redirect,Standard,,,,,None,3 - Needs Migration
-Org-NoWP,busineighbor.org,Unknown,No,No,No,Hostinger,No,Matches Hostinger,153.92.213.212,No,,Unreachable,Standard,,,,,None,3 - Needs Migration
-For-Profit,causevay.com,Unknown,No,No,No,InterServer DA,No,Matches InterServer DA,192.64.86.202,No,,Error,Standard,,,,,None,3 - Needs Migration
-For-Profit,cortesdesignworks.com,Active,Yes,No,Yes,InterServer DA,No,Matches InterServer DA,192.64.86.202,No,,Live,Standard,,,,,None,3 - Needs Migration
-Org-NoWP,ctvip.org,Unknown,No,No,Yes,Hostinger,No,Matches Hostinger,153.92.213.212,No,,Live,Standard,,,,,None,3 - Needs Migration
-InterServer-Org,cvrs-us.org,Active,Yes,Yes,Yes,InterServer DA,No,Correct InterServer mapping,192.64.86.202,Yes,,Unreachable,Standard,,,,,None,3 - Needs Migration
-InterServer-Org,dropletsoflove.org,Active,Yes,Yes,Yes,InterServer DA,No,Correct InterServer mapping,192.64.86.202,Yes,,Unreachable,Standard,,,,,None,3 - Needs Migration
-Krystal-New,e2inc.org,Unknown,No,No,No,Krystal.io,No,New Krystal Host,185.199.224.x,No,,Live,Standard,,,,,None,3 - Needs Migration
-Org-WPAdmin,educationandempowerment.org,Active,Yes,Yes,Yes,Hostinger,No,Matches Hostinger,153.92.213.212,Yes,,Live,Standard,,,,,None,3 - Needs Migration
-For-Profit,emc-professional.com,Active,Yes,Yes,Yes,InterServer DA,No,.org has no A record,192.64.86.202,Yes,,Live,Standard,,,,,None,3 - Needs Migration
-InterServer-Org,exceptionalridersprogram.org,Active,Yes,Yes,Yes,InterServer DA,No,.com migrated to GitHub Pages,192.64.86.202,Yes,,Live,Standard,,,,,None,3 - Needs Migration
-For-Profit,exceptionalridersprogram.com,Active,Yes,Yes,Yes,Krystal.io,No,Moved to Krystal.io,185.199.220.110,Yes,,Live,Standard,,,,,None,3 - Needs Migration
-Org-WPAdmin,facinggiantsnc.org,Active,Yes,Yes,Yes,Hostinger,No,Duplicate exists on InterServer,153.92.213.212,Yes,,Live,Standard,,,,,None,3 - Needs Migration
-Org-NoWP,ffchtml.onlineimpacts.org,Unknown,No,No,No,Hostinger,No,Subdomain-like structure,153.92.213.212,No,,Error,Standard,,,,,None,3 - Needs Migration
-Org-WPAdmin,ftnfcog.org,Active,Yes,No,Yes,Hostinger,No,Matches Hostinger,153.92.213.212,No,,Live,Standard,,,,,None,3 - Needs Migration
-Org-WPAdmin,graftonareahistory.org,Active,Yes,Yes,Yes,Cloudflare Proxy,No,Proxy origin unknown,141.193.213.10;141.193.213.11,Yes,,Live,Standard,,,,,None,3 - Needs Migration
-InterServer-Org,harmonycenterfoundation.org,Active,Yes,Yes,No,InterServer DA,No,Correct InterServer mapping,192.64.86.202,Yes,,Live,Standard,,,,,None,3 - Needs Migration
-Cloudflare-Only,hasbeensandgonnabees.org,Active,Yes,Yes,No,Cloudflare Proxy,No,Proxy origin unknown,52.184.222.116,Yes,,Unreachable,Standard,,,,,None,3 - Needs Migration
-Org-WPAdmin,homesforchange.org,Unknown,No,No,Yes,Hostinger,No,Matches Hostinger,153.92.213.212,No,,Live,Standard,,,,,None,3 - Needs Migration
-For-Profit,hunnewellscottages.com,Active,Yes,Yes,Yes,Cloudflare Proxy,No,Misconfigured,(no A record),Yes,,Live,Standard,,,,,None,3 - Needs Migration
-For-Profit,iawea.net,Unknown,No,No,No,HostPapa,No,.net not paired,204.44.192.77,No,,Redirect,Standard,,,,,None,3 - Needs Migration
-Org-NoWP,ihadrousa.org,Active,Yes,Yes,Yes,Hostinger,No,.com also on Hostinger,153.92.213.212,Yes,,Error,Standard,,,,,None,3 - Needs Migration
-For-Profit,ihadrousa.com,Active,Yes,Yes,No,Hostinger,No,.org also on Hostinger,153.92.213.212,Yes,,Error,Standard,,,,,None,3 - Needs Migration
-Org-WPAdmin,kainkaryasri.org,Unknown,No,No,Yes,Hostinger,No,Matches Hostinger,153.92.213.212,No,,Live,Standard,,,,,None,3 - Needs Migration
-Org-WPAdmin,ksgf.org,Unknown,No,No,Yes,Hostinger,No,Matches Hostinger,153.92.213.212,No,,Live,Standard,,,,,None,3 - Needs Migration
-InterServer-Org,legion-in-the-woods.org,Active,Yes,Yes,No,InterServer RS1,No,Correct InterServer RS1,216.158.234.18,Yes,,Live,Standard,,,,,None,3 - Needs Migration
-Org-WPAdmin,letsdanceactivities.org,Active,Yes,Yes,Yes,Hostinger,No,.com also on Hostinger,153.92.213.212,Yes,,Live,Standard,,,,,None,3 - Needs Migration
-For-Profit,letsdanceactivities.com,Active,Yes,Yes,No,Hostinger,No,.org also on Hostinger,153.92.213.212,Yes,,Redirect,Standard,,,,,None,3 - Needs Migration
-Krystal-New,letspiritlead.org,Unknown,No,Yes,No,Krystal.io,No,New Krystal Host,74.50.79.163,Yes,,Live,Standard,,,,,None,3 - Needs Migration
-Org-WPAdmin,lifelessonslearned.us.org,Active,Yes,Yes,Yes,Hostinger,No,Treated as .org family,153.92.213.212,Yes,,Live,Standard,,,,,None,3 - Needs Migration
-Krystal-New,movewithcompassion.org,Unknown,No,No,No,Krystal.io,No,New Krystal Host,185.199.224.x,No,,Live,Standard,,,,,None,3 - Needs Migration
-For-Profit,moyermanagement.com,Active,Yes,No,Yes,HostPapa,No,Matches HostPapa,185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153,No,,Live,Standard,,,,,None,3 - Needs Migration
-Krystal-New,muckfichigan.com,Unknown,No,No,No,Krystal.io,No,New Krystal Host,185.199.224.x,No,,Live,Standard,,,,,None,3 - Needs Migration
-Org-WPAdmin,my-missions.org,Active,Yes,Yes,Yes,Hostinger,No,Matches Hostinger,153.92.213.212,Yes,,Live,Standard,,,,,None,3 - Needs Migration
-Org-WPAdmin,myservicehours.org,Unknown,No,No,Yes,Hostinger,No,Matches Hostinger,153.92.213.212,No,,Live,Standard,,,,,None,3 - Needs Migration
-Org-WPAdmin,naturaldividends.org,Unknown,No,No,Yes,Hostinger,No,Matches Hostinger,153.92.213.212,No,,Unreachable,Standard,,,,,None,3 - Needs Migration
-Org-WPAdmin,nestiva.org,Unknown,No,No,No,Hostinger,No,Matches Hostinger,153.92.213.212,No,,Unreachable,Standard,,,,,None,3 - Needs Migration
-Org-WPAdmin,nochaos.org,Active,Yes,Yes,Yes,Hostinger,No,Matches Hostinger,153.92.213.212,Yes,,Live,Standard,,,,,None,3 - Needs Migration
-Krystal-New,npbandparents.org,Unknown,No,No,No,Krystal.io,No,New Krystal Host,185.199.224.x,No,,Live,Standard,,,,,None,3 - Needs Migration
-Krystal-New,nu4children.org,Unknown,No,No,No,Krystal.io,No,New Krystal Host,185.199.224.x,No,,Live,Standard,,,,,None,3 - Needs Migration
-Org-WPAdmin,onlineimpacts.org,Unknown,No,No,Yes,Hostinger,No,Matches Hostinger,153.92.213.212,No,,Live,Standard,,,,,None,3 - Needs Migration
-Org-WPAdmin,paaboosterclub.org,Active,Yes,Yes,No,Hostinger,No,Matches Hostinger,153.92.213.212,Yes,,Error,Standard,,,,,None,3 - Needs Migration
-Org-WPAdmin,ptuganda.org,Active,Yes,Yes,No,Hostinger,No,Matches Hostinger,153.92.213.212,Yes,,Live,Standard,,,,,None,3 - Needs Migration
-For-Profit,redlionchimneysweep.com,Unknown,No,No,No,InterServer DA,No,Matches InterServer,192.64.86.202,No,,Error,Standard,,,,,None,3 - Needs Migration
-Krystal-New,scwcinc.org,Unknown,No,No,No,Krystal.io,No,New Krystal Host,185.199.224.x,No,,Live,Standard,,,,,None,3 - Needs Migration
-For-Profit,shelteraid.us,Unknown,No,No,Yes,HostPapa,No,.us not paired,204.44.192.77,No,,Unreachable,Standard,,,,,None,3 - Needs Migration
-Org-NoWP,stg.graftonareahistory.org,Unknown,No,No,No,Hostinger,No,Staging subdomain,153.92.213.212,No,,Unreachable,Standard,,,,,None,3 - Needs Migration
-Krystal-New,teamwrangler.org,Unknown,No,No,No,Krystal.io,No,Inferred from Krystal image (DNS Check failed),185.199.224.x,No,,Unreachable,Standard,,,,,None,3 - Needs Migration
-Org-WPAdmin,thebirf.org,Unknown,No,No,Yes,Hostinger,No,Matches Hostinger,153.92.213.212,No,,Live,Standard,,,,,None,3 - Needs Migration
-Krystal-New,thedeviators.org,Unknown,No,No,No,Krystal.io,No,Inferred from Krystal image (DNS Check failed),185.199.224.x,No,,Live,Standard,,,,,None,3 - Needs Migration
-Org-WPAdmin,theeverythingproject.org,Active,Yes,No,Yes,Hostinger,No,Matches Hostinger,153.92.213.212,No,,Live,Standard,,,,,None,3 - Needs Migration
-For-Profit,thelastchancesanctuary.com,Active,Yes,Yes,Yes,Cloudflare Proxy,No,Misconfigured,153.92.213.212,Yes,,Redirect,Standard,,,,,None,3 - Needs Migration
-For-Profit,thetrendylittlegeek.com,Active,Yes,Yes,No,HostPapa,No,Matches HostPapa,204.44.192.77,Yes,,Live,Standard,,,,,None,3 - Needs Migration
-Org-WPAdmin,transferca.org,Unknown,No,No,Yes,Hostinger,No,Matches Hostinger,153.92.213.212,No,,Live,Standard,,,,,None,3 - Needs Migration
-For-Profit,trendylittlegeek.com,Active,Yes,Yes,No,HostPapa,No,Matches HostPapa,204.44.192.77,Yes,,Live,Standard,,,,,None,3 - Needs Migration
-Krystal-New,tribute-aviation.org,Unknown,No,No,No,Krystal.io,No,Inferred from Krystal image (DNS Check failed),185.199.224.x,No,,Unreachable,Standard,,,,,None,3 - Needs Migration
-Org-WPAdmin,turksotx.org,Unknown,No,No,Yes,Hostinger,No,Matches Hostinger,153.92.213.212,No,,Live,Standard,,,,,None,3 - Needs Migration
-Krystal-New,viewpointnorth.org,Unknown,No,No,No,Krystal.io,No,Inferred from Krystal image (DNS Check failed),185.199.224.x,No,,Unreachable,Standard,,,,,None,3 - Needs Migration
-Krystal-New,vtyouthchat.org,Unknown,No,No,No,Krystal.io,No,Inferred from Krystal image (DNS Check failed),185.199.224.x,No,,Unreachable,Standard,,,,,None,3 - Needs Migration
-Cloudflare-Only,fencingtogether.org,Active,Yes,Yes,No,GitHub Pages,Yes,Fully migrated,185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153,Yes,https://github.com/FencingTogether/website,Live,Standard,,,,,None,4 - Done / Stable
-Subdomain,ffcsites.org,Active,Yes,Yes,No,GitHub Pages,Yes,Fully migrated,185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153,Yes,,Redirect,Standard,,,,,None,4 - Done / Stable
-Subdomain,ffcworkingsite1.org,Active,Yes,Yes,No,GitHub Pages,Yes,Fully migrated,185.199.108.153;185.199.109.153;185.199.110.153;185.199.111.153,Yes,https://github.com/FreeForCharity/FFC-IN-Single_Page_Template_HTML,Live,Standard,,,,,None,4 - Done / Stable
-Org-NoWP,ffcworkingsite2.org,Active,Yes,Yes,No,GitHub Pages,Yes,Fully migrated,185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153,Yes,https://github.com/FreeForCharity/FFC_Single_Page_Template,Live,Standard,,,,,None,4 - Done / Stable
-Cloudflare-Only,pagbooster.org,Active,Yes,Yes,Yes,GitHub Pages,Yes,Fully migrated,185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153,Yes,https://github.com/FreeForCharity/FFC-EX-PAGboosters.org,Live,Standard,,,,,None,4 - Done / Stable
-Cloudflare-Only,thekccf.org,Active,Yes,Yes,No,GitHub Pages,Yes,Fully migrated,185.199.111.153;185.199.109.153;185.199.110.153;185.199.108.153,Yes,https://github.com/koenig-childhood-cancer-foundation/KCCF-web,Live,Standard,,,,,None,4 - Done / Stable
-Unknown,3dmc2.com,Active,Yes,No,No,,,,(no A record),No,,Live,Standard,,,,,None,5 - Needs Triage
-Unknown,americanlegionpost64.com,Active,Yes,No,No,,,,(no A record),No,,Redirect,Standard,,,,,None,5 - Needs Triage
-Unknown,amplifiedaid.org,Active,Yes,No,Yes,,,,(no A record),No,,Live,Standard,,,,,None,5 - Needs Triage
-Unknown,aprilmoyer.com,Active,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,5 - Needs Triage
-Unknown,aprilunlimited.com,Active,Yes,No,Yes,,,,216.222.200.253,No,,Unreachable,Standard,,,,,None,5 - Needs Triage
-Unknown,avengedfastpitch.org,Active,Yes,No,Yes,,,,(no A record),No,,Live,Standard,,,,,None,5 - Needs Triage
-Unknown,bhakthinivedana.com/sandbox,Unknown,No,No,No,,,,(no A record),No,,Redirect,Standard,,,,,None,5 - Needs Triage
-Unknown,birthfree.org,Active,Yes,No,No,,,,172.67.181.220;104.21.18.132,No,,Error,Standard,,,,,None,5 - Needs Triage
-Unknown,bowiesblessings.org,Active,Yes,No,No,,,,(no A record),No,,Live,Standard,,,,,None,5 - Needs Triage
-Unknown,burnsurvivorscharity.org,Active,Yes,No,No,,,,(no A record),No,,Error,Standard,,,,,None,5 - Needs Triage
-For-Profit,canadatokeywestcoastalrun.com,Unknown,No,Yes,No,No A Record,Yes,Domain inactive; .org exists,(no A record),Yes,,Redirect,Standard,,,,,None,5 - Needs Triage
-Unknown,cechanover.org,Pending,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,5 - Needs Triage
-Unknown,clarkemoyer.com,Active,Yes,No,Yes,,,,185.199.111.153;185.199.110.153;185.199.108.153;185.199.109.153,No,,Live,Standard,,,,,None,5 - Needs Triage
-Unknown,clarkmoyer.com,Active,Yes,No,No,,,,52.184.222.116,No,,Redirect,Standard,,,,,None,5 - Needs Triage
-Cloudflare-Only,cochiserobotics.org,Active,Yes,Yes,No,FFC-WHM-01,No,Not on any known server list,52.184.222.116,Yes,,Unreachable,Standard,,,,,None,5 - Needs Triage
-Unknown,communitychristianpentecostal.org,Active,Yes,No,No,,,,(no A record),No,,Error,Standard,,,,,None,5 - Needs Triage
-Unknown,completequarters.org,Active,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,5 - Needs Triage
-Unknown,completequarters.com,Active,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,5 - Needs Triage
-Unknown,craftedraise.org,Active,Yes,No,No,,,,(no A record),No,,Live,Standard,,,,,None,5 - Needs Triage
-Unknown,cucu-il.org,Active,Yes,No,Yes,,,,(no A record),No,,Live,Standard,,,,,None,5 - Needs Triage
-Unknown,darkclouds.us,Active,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,5 - Needs Triage
-Unknown,database.onlineimpacts.org,Unknown,No,No,Yes,,,,(no A record),No,,Live,Standard,,,,,None,5 - Needs Triage
-InterServer-Org,emc-professional.org,Active,Yes,Yes,No,No A Record,Yes,.com points to InterServer,(no A record),Yes,,Redirect,Standard,,,,,None,5 - Needs Triage
-Unknown,empowerconnectfoundation.org,Active,Yes,No,Yes,,,,(no A record),No,,Live,Standard,,,,,None,5 - Needs Triage
-Unknown,escdcpac.org,Active,Yes,No,No,,,,(no A record),No,,Error,Standard,,,,,None,5 - Needs Triage
-Unknown,facinggiantsnc.com,Active,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,5 - Needs Triage
-Unknown,ffc.ngo,Unknown,No,Yes,No,,,,(no A record),Yes,,Redirect,Standard,,,,,None,5 - Needs Triage
-Org-NoWP,ffcdomains.org,Active,Yes,Yes,No,No A Record,Yes,Inactive,(no A record),Yes,,Redirect,Standard,,,,,None,5 - Needs Triage
-Org-NoWP,ffcdomains.com,Active,Yes,Yes,No,No A Record,Yes,Paired with ffcdomains.org (inactive),(no A record),Yes,,Redirect,Standard,,,,,None,5 - Needs Triage
-Unknown,ffchosting.onlineimpacts.org,Unknown,No,No,Yes,,,,(no A record),No,,Live,Standard,,,,,None,5 - Needs Triage
-Org-WPAdmin,ffchosting.org,Active,Yes,Yes,No,No A Record,Yes,Inactive,(no A record),Yes,,Redirect,Standard,,,,,None,5 - Needs Triage
-Unknown,ffchosting.com,Active,Yes,Yes,No,,,,(no A record),Yes,,Redirect,Standard,,,,,None,5 - Needs Triage
-Unknown,ffctools.onlineimpacts.org,Unknown,No,No,Yes,,,,(no A record),No,,Live,Standard,,,,,None,5 - Needs Triage
-Unknown,focus-on-free.com,Active,Yes,No,No,,,,216.222.200.253,No,,Live,Standard,,,,,None,5 - Needs Triage
-Unknown,focusonfree.org,Active,Yes,No,No,,,,104.21.52.163;172.67.201.83,No,,Error,Standard,,,,,None,5 - Needs Triage
-Unknown,focusonfree.us,Active,Yes,No,No,,,,172.67.202.82;104.21.76.244,No,,Error,Standard,,,,,None,5 - Needs Triage
-Unknown,freeforcharity.ngo,Unknown,No,Yes,No,,,,(no A record),Yes,,Redirect,Standard,,,,,None,5 - Needs Triage
-Unknown,freetoolsfornonprofits.org,Active,Yes,Yes,No,,,,(no A record),Yes,,Unreachable,Standard,,,,,None,5 - Needs Triage
-Unknown,ghcd.onlineimpacts.org,Unknown,No,No,No,,,,(no A record),No,,Live,Standard,,,,,None,5 - Needs Triage
-Unknown,greenrecon.org,Active,Yes,No,No,,,,(no A record),No,,Live,Standard,,,,,None,5 - Needs Triage
-Unknown,harmonycenterofhillsdale.org,Pending,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,5 - Needs Triage
-Unknown,hcohi.net,Pending,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,5 - Needs Triage
-Unknown,ieeeforthuachuca.org,Active,Yes,Yes,No,,,,54.163.236.200,Yes,,Unreachable,Standard,,,,,None,5 - Needs Triage
-Unknown,jeeyar.onlineimpacts.org,Unknown,No,No,Yes,,,,(no A record),No,,Redirect,Standard,,,,,None,5 - Needs Triage
-Unknown,jsbt.org.au,Unknown,No,No,Yes,,,,(no A record),No,,Unknown,Standard,,,,,None,5 - Needs Triage
-Unknown,kieranrunnelsdev.org,Active,Yes,No,Yes,,,,(no A record),No,,Live,Standard,,,,,None,5 - Needs Triage
-Unknown,kierstensride.org,Unknown,No,No,Yes,,,,(no A record),No,,Live,Standard,,,,,None,5 - Needs Triage
-Unknown,kingstoncommunitycenter.org,Active,Yes,No,No,,,,(no A record),No,,Error,Standard,,,,,None,5 - Needs Triage
-Unknown,kittencoveinc.org,Active,Yes,No,No,,,,(no A record),No,,Live,Standard,,,,,None,5 - Needs Triage
-Unknown,letsleadwise.org,Active,Yes,No,No,,,,(no A record),No,,Live,Standard,,,,,None,5 - Needs Triage
-Unknown,makeacalendarinvite.org,Active,Yes,Yes,Yes,,,,204.44.192.77,Yes,,Live,Standard,,,,,None,5 - Needs Triage
-Unknown,melaninmagicfoundation.org,Unknown,No,Yes,No,,,,66.23.226.51,Yes,,Unreachable,Standard,,,,,None,5 - Needs Triage
-Unknown,moyerinvestments.com,Active,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,5 - Needs Triage
-Unknown,moyermanagement.org,Active,Yes,No,No,,,,159.65.76.163,No,,Unreachable,Standard,,,,,None,5 - Needs Triage
-Unknown,moyermanagementsystems.com,Active,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,5 - Needs Triage
-Unknown,newenglandbattalion.org,Pending,Yes,No,No,,,,(no A record),No,,Redirect,Standard,,,,,None,5 - Needs Triage
-Unknown,nolef.onlineimpacts.org,Unknown,No,No,Yes,,,,(no A record),No,,Live,Standard,,,,,None,5 - Needs Triage
-Unknown,nottinghampc.org,Unknown,No,No,Yes,,,,(no A record),No,,Live,Standard,,,,,None,5 - Needs Triage
-Unknown,npfan.org,Active,Yes,No,No,,,,(no A record),No,,Redirect,Standard,,,,,None,5 - Needs Triage
-Unknown,ohiomtawest.org,Active,Yes,Yes,No,,,,(no A record),Yes,,Redirect,Standard,,,,,None,5 - Needs Triage
-Unknown,oimpacts.org,Active,Yes,No,No,,,,(no A record),No,,Error,Standard,,,,,None,5 - Needs Triage
-Unknown,operationfullcircle.org,Active,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,5 - Needs Triage
-Unknown,operationhomesforheroes.org,Pending,Yes,No,No,,,,(no A record),No,,Live,Standard,,,,,None,5 - Needs Triage
-Unknown,padmajaramanujadasi.com,Unknown,No,No,Yes,,,,(no A record),No,,Redirect,Standard,,,,,None,5 - Needs Triage
-Cloudflare-Only,pantryforadaircounty.org,Active,Yes,Yes,No,FFC-WHM-01,No,Not on any known server list,52.184.222.116,Yes,,Unreachable,Standard,,,,,None,5 - Needs Triage
-Unknown,pfplus.org,Unknown,No,No,Yes,,,,(no A record),No,,Live,Standard,,,,,None,5 - Needs Triage
-Unknown,phoenixartsandadvocacy.org,Active,Yes,No,No,,,,(no A record),No,,Live,Standard,,,,,None,5 - Needs Triage
-Unknown,physicalinvestor.com,Active,Yes,No,No,,,,172.67.142.110;104.21.71.27,No,,Error,Standard,,,,,None,5 - Needs Triage
-Unknown,qtbb.org,Active,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,5 - Needs Triage
-Cloudflare-Only,roottostem.org,Active,Yes,Yes,No,FFC-WHM-01,No,Not on any known server list,52.184.222.116,Yes,,Unreachable,Standard,,,,,None,5 - Needs Triage
-Unknown,safemap.org,Active,Yes,No,No,,,,(no A record),No,,Error,Standard,,,,,None,5 - Needs Triage
-Unknown,sfcityarts.org,Active,Yes,No,No,,,,(no A record),No,,Redirect,Standard,,,,,None,5 - Needs Triage
-Cloudflare-Only,soulfoodwhangarei.org,Active,Yes,Yes,No,FFC-WHM-01,No,Not on any known server list,52.184.222.116,Yes,,Unreachable,Standard,,,,,None,5 - Needs Triage
-Subdomain,southamptonfriends.com,Active,Yes,Yes,No,No A Record,Yes,Paired with .org (active on InterServer),(no A record),Yes,,Redirect,Standard,,,,,None,5 - Needs Triage
-Unknown,ssrn.net,Unknown,No,Yes,No,,,,217.19.248.132,Yes,,Unreachable,Standard,,,,,None,5 - Needs Triage
-Unknown,staging.alltypetowing.com,Unknown,No,No,Yes,,,,(no A record),No,,Unreachable,Standard,,,,,None,5 - Needs Triage
-Unknown,staging.americanlegionpost64.org,Unknown,No,No,No,,,,(no A record),No,,Live,Standard,,,,,None,5 - Needs Triage
-Unknown,staging.bulldogztowing.com,Unknown,No,No,Yes,,,,(no A record),No,,Live,Standard,,,,,None,5 - Needs Triage
-Unknown,staging.clarkemoyer.com,Unknown,No,No,Yes,,,,(no A record),No,,Unreachable,Standard,,,,,None,5 - Needs Triage
-Unknown,staging.facinggiantsnc.org,Unknown,No,No,Yes,,,,(no A record),No,,Live,Standard,,,,,None,5 - Needs Triage
-Unknown,staging.iawea.us,Unknown,No,No,Yes,,,,(no A record),No,,Live,Standard,,,,,None,5 - Needs Triage
-Unknown,staging.instituteofforgiveness.org,Unknown,No,No,Yes,,,,(no A record),No,,Live,Standard,,,,,None,5 - Needs Triage
-Unknown,staging.jwvpost619.org,Unknown,No,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,5 - Needs Triage
-Unknown,staging.southamptonfriends.org,Unknown,No,No,No,,,,(no A record),No,,Live,Standard,,,,,None,5 - Needs Triage
-Unknown,stepeople.org,Active,Yes,No,No,,,,(no A record),No,,Error,Standard,,,,,None,5 - Needs Triage
-Unknown,stylesbysheba.com,Unknown,No,No,Yes,,,,(no A record),No,,Live,Standard,,,,,None,5 - Needs Triage
-Cloudflare-Only,tamkeensports.org,Active,Yes,Yes,No,External,No,External hosting,174.138.190.170,Yes,,Live,Standard,,,,,None,5 - Needs Triage
-Unknown,tasteandseelocal.org,Active,Yes,No,No,,,,(no A record),No,,Live,Standard,,,,,None,5 - Needs Triage
-Unknown,technologyadoptionbarriers.org,Active,Yes,Yes,No,,,,184.72.224.80;34.227.238.166;3.91.109.122;100.24.182.117;35.172.73.102;34.199.202.106,Yes,,Live,Standard,,,,,None,5 - Needs Triage
-Cloudflare-Only,theafghanistanaffairs.org,Active,Yes,Yes,No,External,No,External hosting,204.13.238.115,Yes,,Error,Standard,,,,,None,5 - Needs Triage
-Unknown,thecrookedhouse.org,Unknown,No,No,No,,,,198.185.159.145;198.185.159.144;198.49.23.145;198.49.23.144,No,,Redirect,Standard,,,,,None,5 - Needs Triage
-Unknown,thegracehouseinc.org,Unknown,No,No,Yes,,,,(no A record),No,,Live,Standard,,,,,None,5 - Needs Triage
-Unknown,thekccf.onlineimpacts.org,Unknown,No,No,No,,,,(no A record),No,,Live,Standard,,,,,None,5 - Needs Triage
-Unknown,thescottiecfoundation.org,Pending,Yes,No,No,,,,34.111.179.208,No,,Error,Standard,,,,,None,5 - Needs Triage
-Unknown,thestudiovisit.org,Active,Yes,No,No,,,,(no A record),No,,Live,Standard,,,,,None,5 - Needs Triage
-Unknown,thrivecollectionagency.org,Active,Yes,No,No,,,,(no A record),No,,Error,Standard,,,,,None,5 - Needs Triage
-Unknown,tpainepta.org,Active,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,5 - Needs Triage
-Unknown,trinitylutheranconcord.org,Active,Yes,No,No,,,,(no A record),No,,Redirect,Standard,,,,,None,5 - Needs Triage
-Unknown,trinityucclewistown.org,Active,Yes,No,No,,,,(no A record),No,,Redirect,Standard,,,,,None,5 - Needs Triage
-Unknown,veterans.onlineimpacts.org,Unknown,No,No,Yes,,,,(no A record),No,,Live,Standard,,,,,None,5 - Needs Triage
-Unknown,vetmast.org,Unknown,No,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,5 - Needs Triage
-Cloudflare-Only,wamhelp.org,Active,Yes,Yes,Yes,External,No,External hosting,66.23.226.51,Yes,,Live,Standard,,,,,None,5 - Needs Triage
-Unknown,wh1374403.ispot.cc/wp,Unknown,No,No,Yes,,,,(no A record),No,,Redirect,Standard,,,,,None,5 - Needs Triage
-Unknown,wisdomfinancialministries.org,Active,Yes,No,No,,,,(no A record),No,,Live,Standard,,,,,None,5 - Needs Triage
-Unknown,wonderseedstudios.org,Active,Yes,No,No,,,,(no A record),No,,Redirect,Standard,,,,,None,5 - Needs Triage
-Unknown,workreadyrva.com,Unknown,No,No,Yes,,,,(no A record),No,,Live,Standard,,,,,None,5 - Needs Triage
-Unknown,www.americanlegionpost64.org,Unknown,No,No,Yes,,,,(no A record),No,,Redirect,Standard,,,,,None,5 - Needs Triage
-Unknown,www.henricovareentrycouncil.com,Unknown,No,No,Yes,,,,(no A record),No,,Live,Standard,,,,,None,5 - Needs Triage
-Unknown,www.jeeyarasramam.org,Unknown,No,No,No,,,,(no A record),No,,Error,Standard,,,,,None,5 - Needs Triage
-Unknown,www.nolefturns.org,Unknown,No,No,No,,,,(no A record),No,,Live,Standard,,,,,None,5 - Needs Triage
-Unknown,www.shebawilliams.com,Unknown,No,No,Yes,,,,(no A record),No,,Unreachable,Standard,,,,,None,5 - Needs Triage
-Unknown,www.virginiajusticeconference.com,Unknown,No,No,Yes,,,,(no A record),No,,Unreachable,Standard,,,,,None,5 - Needs Triage
-Unknown,www.wonderseedstudios.org,Unknown,No,No,Yes,,,,(no A record),No,,Live,Standard,,,,,None,5 - Needs Triage
-Cloudflare-Only,youngfatherscare.org,Active,Yes,Yes,No,External,No,Adjacent to InterServer but not exact match,192.64.86.203,Yes,,Live,Standard,,,,,None,5 - Needs Triage
-InterServer-Org,nittanypost245.org,Cancelled,Yes,Yes,No,InterServer DA,No,Correct InterServer mapping,192.64.86.202,Yes,https://github.com/FreeForCharity/FFC-EX-nittanypost245.org,Live,Standard,No,2026-06-06,27,2026-06-06,Active,6 - Inactive / Archive
-Unknown,armstrongacesbaseball.org,Fraud,Yes,Yes,No,,,,204.44.192.77,Yes,https://github.com/FreeForCharity/FFC-EX-armstrongacesbaseball.org,Live,Standard,No,2026-06-02,20,2026-06-02,Active,6 - Inactive / Archive
-Unknown,1726nerds.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,1stepfcc.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,abundances.org,Expired,Yes,No,No,,,,(no A record),No,,Live,Standard,,,,,None,6 - Inactive / Archive
-Unknown,adrian2018.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,alliancesofveteransandfamiliesservices.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,alpha1bat1legion.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,alphaonelegion.com,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,amarodhikar.org,Cancelled,Yes,No,No,,,,(no A record),No,,Live,Standard,,,,,None,6 - Inactive / Archive
-Unknown,ampwup.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,ampwupi.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,andrellharris.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,andrellharris.com,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,andrellharris.us,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,annabryant.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,bat1alpha1legion.com,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Cloudflare-Only,bboc4vets.org,Expired,Yes,Yes,No,FFC-WHM-01,No,Not on any known server list,52.184.222.116,Yes,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,beauty4myashes.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,bellsofhope.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,bhhc-usa.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Org-WPAdmin,brianmustofoundation.org,Cancelled,Yes,No,No,Hostinger,No,Matches Hostinger,153.92.213.212,No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,bringing-people-2-people.com,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,broadcastvoice.net,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,btcsv.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,buckeyebullsbaseball.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,cochisedubsaz.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-For-Profit,communitytechsupply.com,Expired,Yes,No,No,InterServer DA,No,Matches InterServer DA,192.64.86.202,No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,cysoclabs.com,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,darbycharlesblackmemorialfund.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,dcbmf.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,ecjeli.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,ecjelife.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,etherfrolics.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,faithorgnc.org,Transferred Away,Yes,No,No,,,,(no A record),No,,Redirect,Standard,,,,,None,6 - Inactive / Archive
-Unknown,ffchostingmultisite.org,Transferred Away,Yes,Yes,No,,,,(no A record),Yes,,Redirect,Standard,,,,,None,6 - Inactive / Archive
-Unknown,fhuhbl.com,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,fosterakid.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,fosterakids.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,glstraining.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,gustolifeskillstraining.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,h4sd.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,harborcityfoodpantry.org,Cancelled,Yes,No,No,,,,185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153,No,,Error,Standard,,,,,None,6 - Inactive / Archive
-For-Profit,hardpointconsulting.com,Transferred Away,Yes,No,Yes,HostPapa,No,Matches HostPapa,204.44.192.77,No,,Live,Standard,,,,,None,6 - Inactive / Archive
-Unknown,heroes2others.org,Fraud,Yes,No,No,,,,(no A record),No,,Live,Standard,,,,,None,6 - Inactive / Archive
-Unknown,historyinplay.org,Transferred Away,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,historyinplay.com,Transferred Away,Yes,No,No,,,,(no A record),No,,Redirect,Standard,,,,,None,6 - Inactive / Archive
-Unknown,huachucashuttle.com,Transferred Away,Yes,No,No,,,,(no A record),No,,Live,Standard,,,,,None,6 - Inactive / Archive
-Unknown,huachucashuttlehbl.com,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,impactsierravista.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,innovatesphere.org,Cancelled,Yes,No,No,,,,(no A record),No,,Live,Standard,,,,,None,6 - Inactive / Archive
-Unknown,javawockies.org,Transferred Away,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Org-WPAdmin,jeansnsneaks.org,Cancelled,Yes,No,Yes,Hostinger,No,Matches Hostinger,153.92.213.212,No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,joelhockermemorialfoundation.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,joelhockermemorialfoundation.com,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,juliannaswishes.com,Cancelled,Yes,No,No,,,,(no A record),No,,Error,Standard,,,,,None,6 - Inactive / Archive
-Unknown,kansaslenfacccoalitionkl.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,kingsremnantmessianicministries.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,kpmministries.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,krishnacharity.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,ktdorganization.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,kydol.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,ladiesof5280.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,ladiesof5280.com,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,lakebrentwoodresort.com,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,lastchancesanctuary.com,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,lifechangingfaces.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,lifechangingfaces.com,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,locali60west.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,martinez2018.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,mattressfiberglass.net,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,mattressfiberglass.org,Fraud,Yes,No,No,,,,(no A record),No,,Live,Standard,,,,,None,6 - Inactive / Archive
-Unknown,medicsofmayhem.com,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,megan220.com,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,mountainboundk9sar.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,mydartmouth-una.us.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,northeasterntrailridersassociation.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,ocydevelopment.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,ocydi.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,oitemplates.org,Cancelled,Yes,No,No,,,,(no A record),No,,Error,Standard,,,,,None,6 - Inactive / Archive
-Unknown,petrcraft.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,phominhtemple.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,platoon1alpha.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Org-WPAdmin,postpartumcarefoundation.org,Cancelled,Yes,Yes,Yes,Hostinger,No,.com also exists,153.92.213.212,Yes,,Live,Standard,,,,,None,6 - Inactive / Archive
-Unknown,postpartumcarefoundation.com,Cancelled,Yes,Yes,No,,,,153.92.213.212,Yes,,Redirect,Standard,,,,,None,6 - Inactive / Archive
-Unknown,pronovaestates.com,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,pydccenter.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,pydci.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,redeemussocial.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,resilient-grace.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Org-WPAdmin,rhwcustoms.org,Expired,Yes,No,Yes,HostPapa,No,Duplicate on Hostinger,204.44.192.77,No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,rhwcustoms.com,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,root2stem-edu.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,rotchurch.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,rotci.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,rougegn.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,saharacc.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,scainc.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,sfcoffeeco.net,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,sfcoffeeco.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,sfcoffeeco.com,Transferred Away,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,shopcommunitycenters.org,Transferred Away,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,sierravistadreamcenter.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,sierravistadreamcenter.com,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,skillsprivateacademy.net,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,skillsprivateacademy.org,Transferred Away,Yes,No,No,,,,(no A record),No,,Redirect,Standard,,,,,None,6 - Inactive / Archive
-Unknown,skillsprivateacademy.com,Transferred Away,Yes,No,No,,,,(no A record),No,,Redirect,Standard,,,,,None,6 - Inactive / Archive
-Unknown,skillsprivatetutoring.net,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,skillsprivatetutoring.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,skillsprivatetutoring.com,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,socialenterprisestudiosinc.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,socialenterprisestudiosinc.com,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,somact.org,Transferred Away,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,southamptonfriendspa.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,southlakeseniorfunding.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,spiritofthelandcharitabletrust.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,srs806.org,Expired,Yes,No,No,,,,(no A record),No,,Live,Standard,,,,,None,6 - Inactive / Archive
-Unknown,stampedesoftball.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,sunshinenetworkchicago.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,svbuddhisttemple.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,svfreethinkers.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,tech4security.net,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,tech4security.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,tech4security.com,Expired,Yes,No,No,,,,(no A record),No,,Live,Standard,,,,,None,6 - Inactive / Archive
-Unknown,tech4thesick.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,techforsecurity.com,Expired,Yes,No,No,,,,(no A record),No,,Live,Standard,,,,,None,6 - Inactive / Archive
-Unknown,technologyforsecurity.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,technologyforsecurity.com,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Cloudflare-Only,technologymonastery.us,Expired,Yes,Yes,No,External,No,External hosting,192.185.118.32,Yes,,Live,Standard,,,,,None,6 - Inactive / Archive
-Unknown,thefederalinvestor.com,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,themilitaryinvestor.com,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,thinkitwice.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,thirdcoastfiretraining.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,thirdcoastfiretraining.com,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,thofaith.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,treehouse-project.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,trendylittlegeek.net,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,unitygreen21.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,wisdomadvisory.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,wnwstrategies.com,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,wonderseed.net,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,wonderseed.org,Expired,Yes,No,No,,,,(no A record),No,,Live,Standard,,,,,None,6 - Inactive / Archive
-Unknown,wonderseedfoundation.net,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,wonderseedfoundation.org,Transferred Away,Yes,No,No,,,,(no A record),No,,Live,Standard,,,,,None,6 - Inactive / Archive
-Unknown,wonderseedstudio.net,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,wonderseedstudio.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,wonderseedstudio.com,Cancelled,Yes,No,No,,,,(no A record),No,,Live,Standard,,,,,None,6 - Inactive / Archive
-Unknown,wonderseedstudios.net,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,wonderseedstudios.com,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,wonderseedverse.net,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,wonderseedverse.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,wonderseedverse.com,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,wonderseedworld.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,wonderseedworld.com,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,woundedresponderproject.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,youngmothersofamerica.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
-Unknown,ziggymarleygeorgefoundation.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,6 - Inactive / Archive
+Section,Domain,Status,In WHMCS,In Cloudflare,In WPMUDEV,Server In Use,Old Server Abandoned?,Notes,Cloudflare IP,Is In Cloudflare,Repo URL,Site Health,Priority,Repo Archived,Last PR Closed,Open PRs,Last Commit,Dev Status,Left FFC,Work Tier
+Subdomain,ffcadmin.org,Active,Yes,Yes,No,GitHub Pages,Yes,Fully migrated,185.199.108.153;185.199.109.153;185.199.110.153;185.199.111.153,Yes,https://github.com/FreeForCharity/FFC-IN-ffcadmin.org,Live,Standard,No,2026-06-08,2,2026-06-08,Active,,1 - Active Development
+Unknown,bearupinternationalministries.org,Unknown,No,No,No,,,,185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153,No,https://github.com/FreeForCharity/FFC-EX-bearupinternationalministries.org,Live,Standard,No,2026-06-07,16,2026-06-07,Active,,1 - Active Development
+Unknown,mitchellnchistory.org,Unknown,No,Yes,No,,,,35.212.109.210,Yes,https://github.com/FreeForCharity/FFC-EX-mitchellnchistory.org,Live,Standard,No,2026-06-07,3,2026-06-07,Active,,1 - Active Development
+Unknown,thewayofyeshuaministries.org,Unknown,No,No,No,,,,185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153,No,https://github.com/FreeForCharity/FFC-EX-thewayofyeshuaministries.org,Live,Standard,No,2026-06-07,4,2026-06-07,Active,,1 - Active Development
+Unknown,rebirthsdc.org,Unknown,No,No,No,,,,185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153,No,https://github.com/FreeForCharity/FFC-EX-rebirthsdc.org,Live,Standard,No,2026-06-04,4,2026-06-04,Active,,1 - Active Development
+Cloudflare-Only,3dmc2.org,Active,Yes,Yes,No,Cloudflare Proxy,No,Proxy origin unknown,184.182.219.182,Yes,https://github.com/FreeForCharity/FFC-EX-3dmc2.org,Unreachable,Standard,No,2026-06-02,20,2026-06-02,Active,,1 - Active Development
+Unknown,amargraves.org,Active,Yes,No,No,,,,185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153,No,https://github.com/FreeForCharity/FFC-EX-amargraves.org,Live,Standard,No,2026-06-02,21,2026-06-02,Active,,1 - Active Development
+Unknown,americanlegionpost64.org,Active,Yes,No,Yes,,,,(no A record),No,https://github.com/FreeForCharity/FFC-EX-americanlegionpost64.org,Live,Standard,No,2026-06-02,20,2026-06-02,Active,,1 - Active Development
+For-Profit,aprilhansen.com,Transferred Away,Yes,Yes,Yes,HostPapa,No,Matches HostPapa server list,204.44.192.77,Yes,https://github.com/FreeForCharity/FFC-EX-aprilhansen.com,Live,Standard,No,2026-06-02,19,2026-06-02,Active,,1 - Active Development
+Unknown,browncanyonranch.org,Active,Yes,Yes,No,,,,204.44.192.77,Yes,https://github.com/FreeForCharity/FFC-EX-browncanyonranch.org,Live,Standard,No,2026-06-02,20,2026-06-02,Active,,1 - Active Development
+Unknown,bucktownbullsbaseball.org,Active,Yes,Yes,No,,,,204.44.192.77,Yes,https://github.com/FreeForCharity/FFC-EX-bucktownbullsbaseball.org,Redirect,Standard,No,2026-06-02,20,2026-06-02,Active,,1 - Active Development
+For-Profit,bulldogztowing.com,Active,Yes,Yes,Yes,HostPapa,No,Matches HostPapa server list,204.44.192.77,Yes,https://github.com/FreeForCharity/FFC-EX-bulldogztowing.com,Live,Standard,No,2026-06-02,20,2026-06-02,Active,,1 - Active Development
+Org-WPAdmin,canadatokeywestcoastalrun.org,Active,Yes,Yes,Yes,Hostinger,No,.com has no A record,153.92.213.212,Yes,https://github.com/FreeForCharity/FFC-EX-canadatokeywestcoastalrun.org,Live,Standard,No,2026-06-02,20,2026-06-02,Active,,1 - Active Development
+Cloudflare-Only,coronadonationalforestheritagesociety.org,Active,Yes,Yes,No,HostPapa,No,Appears only in Cloudflare,204.44.192.77,Yes,https://github.com/FreeForCharity/FFC-EX-coronadonationalforestheritagesociety.org,Live,Standard,No,2026-06-02,20,2026-06-02,Active,,1 - Active Development
+Unknown,falloutshelterecovillage.org,Active,Yes,Yes,No,,,,204.44.192.77,Yes,https://github.com/FreeForCharity/FFC-EX-falloutshelterecovillage.org,Live,Standard,No,2026-06-02,20,2026-06-02,Active,,1 - Active Development
+For-Profit,foxtrotenterprises.com,Unknown,No,No,Yes,HostPapa,No,Matches HostPapa,204.44.192.77,No,https://github.com/FreeForCharity/FFC-EX-foxtrotenterprises.com,Live,Standard,No,2026-06-02,20,2026-06-02,Active,,1 - Active Development
+Cloudflare-Only,freedomrisingusa.org,Active,Yes,Yes,No,GitHub Pages,Yes,Fully migrated,185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153,Yes,https://github.com/FreeForCharity/freedomrisingusa.org,Live,Standard,No,2026-06-02,22,2026-06-02,Active,,1 - Active Development
+Org-WPAdmin,freeforcharity.org,Transferred Away,Yes,Yes,Yes,InterServer cPanel,No,Duplicate on HostPapa + Hostinger,66.45.234.13,Yes,https://github.com/FreeForCharity/FreeForCharity.org,Live,Standard,No,2026-06-02,24,2026-06-02,Active,,1 - Active Development
+Krystal-New,hclwellness.org,Unknown,No,No,Yes,Krystal.io,No,New Krystal Host,185.199.224.x,No,https://github.com/FreeForCharity/FFC-EX-hclwellness.org,Error,Standard,No,2026-06-02,5,2026-06-06,Active,,1 - Active Development
+Unknown,instituteofforgiveness.org,Active,Yes,Yes,Yes,,,,204.44.192.77,Yes,https://github.com/FreeForCharity/FFC-EX-instituteofforgiveness.org,Live,Standard,No,2026-06-02,20,2026-06-02,Active,,1 - Active Development
+Unknown,jwvpost619.org,Active,Yes,Yes,No,,,,67.211.214.117,Yes,https://github.com/FreeForCharity/FFC-EX-jwvpost619.org,Live,Standard,No,2026-06-02,18,2026-06-02,Active,,1 - Active Development
+Cloudflare-Only,legioninthewoods.org,Unknown,No,Yes,No,GitHub Pages,Yes,Fully migrated (dashless variant),185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153,Yes,https://github.com/FreeForCharity/legioninthewoods.org,Live,Standard,No,2026-06-02,23,2026-06-02,Active,,1 - Active Development
+Unknown,nj4israel.org,Active,Yes,No,Yes,,,,(no A record),No,https://github.com/FreeForCharity/FFC-EX-nj4israel.org,Live,Standard,No,2026-06-02,20,2026-06-02,Active,,1 - Active Development
+Unknown,savewatersaveplanet.org,Active,Yes,No,Yes,,,,216.222.200.253,No,https://github.com/FreeForCharity/FFC-EX-savewatersaveplanet.org,Live,Standard,No,2026-06-02,20,2026-06-02,Active,,1 - Active Development
+Org-WPAdmin,southamptonfriends.org,Active,Yes,Yes,Yes,InterServer DA,No,Duplicate on Hostinger,192.64.86.202,Yes,https://github.com/FreeForCharity/FFC-EX-southamptonfriends.org,Live,Standard,No,2026-06-02,20,2026-06-02,Active,,1 - Active Development
+Unknown,sporting2impact.org,Active,Yes,No,No,,,,185.199.111.153;185.199.109.153;185.199.110.153;185.199.108.153,No,https://github.com/FreeForCharity/FFC-EX-sporting2Impact.org,Error,Standard,No,2026-06-02,22,2026-06-02,Active,,1 - Active Development
+Unknown,technomonasteries.org,Unknown,No,No,No,,,,70.32.23.118,No,https://github.com/FreeForCharity/FFC-EX-technomonasteries.org,Live,Standard,No,2026-06-02,19,2026-06-02,Active,,1 - Active Development
+Unknown,clarasbridge.org,Unknown,No,No,No,,,,185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153,No,https://github.com/FreeForCharity/FFC-EX-clarasbridge.org,Live,Standard,No,2026-05-28,27,2026-05-28,Active,,1 - Active Development
+Unknown,aariasblueelephant.org,Pending,Yes,No,No,,,,185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153,No,https://github.com/FreeForCharity/FFC-EX-aariasblueelephant.org,Live,Standard,No,2026-05-27,23,2026-06-03,Active,,1 - Active Development
+Unknown,friendsof362.org,Unknown,No,No,No,,,,(no A record),No,https://github.com/FreeForCharity/FFC-EX-friendsof362.org,Unreachable,Standard,No,2026-05-27,22,2026-06-02,Active,,1 - Active Development
+Unknown,slopestohope.org,Active,Yes,No,No,,,,185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153,No,https://github.com/FreeForCharity/FFC-EX-slopestohope.org,Live,Standard,No,2026-05-27,11,2026-06-02,Active,,1 - Active Development
+For-Profit,srrn.net,Unknown,No,Yes,Yes,Hostinger,No,.net not paired,153.92.213.212,Yes,https://github.com/FreeForCharity/FFC-EX-SRRN.net,Redirect,Standard,No,2026-05-27,8,2026-05-27,Active,,1 - Active Development
+Cloudflare-Only,technologymonastery.org,Active,Yes,Yes,Yes,InterServer RS1,No,Matches InterServer RS1 IP,216.158.234.18,Yes,https://github.com/FreeForCharity/TechnologyMonastery.org,Live,Standard,No,2026-05-27,0,2026-05-28,Active,,1 - Active Development
+Unknown,thecrookedhouse.net,Unknown,No,No,No,,,,185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153,No,https://github.com/FreeForCharity/FFC-EX-thecrookedhouse.net,Live,Standard,No,2026-05-27,0,2026-05-27,Active,,1 - Active Development
+Cloudflare-Only,bintobetter.org,Active,Yes,Yes,No,GitHub Pages,Yes,Fully migrated,185.199.108.153;185.199.111.153;185.199.110.153;185.199.109.153,Yes,https://github.com/FreeForCharity/FFC-EX-bintobetter.org,Live,Standard,No,2026-05-12,0,2026-05-27,Active,,1 - Active Development
+For-Profit,alltypetowing.com,Active,Yes,Yes,Yes,HostPapa,No,Matches HostPapa server list,204.44.192.77,Yes,https://github.com/FreeForCharity/FFC-EX-AllTypeTowing.com,Live,Standard,No,2026-01-27,0,2026-03-25,Stalled,,"2 - Has Repo, Stalled"
+Org-WPAdmin,acharyaapp.org,Unknown,No,No,Yes,Hostinger,No,.com exists as subdomain,153.92.213.212,No,,Redirect,Standard,,,,,None,,3 - Needs Migration
+Org-WPAdmin,ambofoundation.org,Active,Yes,No,Yes,Hostinger,No,Matches Hostinger,153.92.213.212,No,,Live,Standard,,,,,None,,3 - Needs Migration
+Org-WPAdmin,apollonianfp.org,Active,Yes,Yes,No,Hostinger,No,Matches Hostinger,153.92.213.212,Yes,,Error,Standard,,,,,None,,3 - Needs Migration
+Subdomain,az.acharyaapp.org,Unknown,No,No,No,Hostinger,No,Subdomain of acharyaapp.org,153.92.213.212,No,,Unreachable,Standard,,,,,None,,3 - Needs Migration
+Cloudflare-Only,bringingpeople2people.org,Active,Yes,Yes,No,Cloudflare Proxy,No,Proxy origin unknown,(no A record),Yes,,Redirect,Standard,,,,,None,,3 - Needs Migration
+Org-NoWP,busineighbor.org,Unknown,No,No,No,Hostinger,No,Matches Hostinger,153.92.213.212,No,,Unreachable,Standard,,,,,None,,3 - Needs Migration
+For-Profit,causevay.com,Unknown,No,No,No,InterServer DA,No,Matches InterServer DA,192.64.86.202,No,,Error,Standard,,,,,None,,3 - Needs Migration
+For-Profit,cortesdesignworks.com,Active,Yes,No,Yes,InterServer DA,No,Matches InterServer DA,192.64.86.202,No,,Live,Standard,,,,,None,,3 - Needs Migration
+Org-NoWP,ctvip.org,Unknown,No,No,Yes,Hostinger,No,Matches Hostinger,153.92.213.212,No,,Live,Standard,,,,,None,,3 - Needs Migration
+InterServer-Org,cvrs-us.org,Active,Yes,Yes,Yes,InterServer DA,No,Correct InterServer mapping,192.64.86.202,Yes,,Live,Standard,,,,,None,,3 - Needs Migration
+InterServer-Org,dropletsoflove.org,Active,Yes,Yes,Yes,InterServer DA,No,Correct InterServer mapping,192.64.86.202,Yes,,Live,Standard,,,,,None,,3 - Needs Migration
+Krystal-New,e2inc.org,Unknown,No,No,No,Krystal.io,No,New Krystal Host,185.199.224.x,No,,Live,Standard,,,,,None,,3 - Needs Migration
+Org-WPAdmin,educationandempowerment.org,Active,Yes,Yes,Yes,Hostinger,No,Matches Hostinger,153.92.213.212,Yes,,Live,Standard,,,,,None,,3 - Needs Migration
+For-Profit,emc-professional.com,Active,Yes,Yes,Yes,InterServer DA,No,.org has no A record,192.64.86.202,Yes,,Live,Standard,,,,,None,,3 - Needs Migration
+InterServer-Org,exceptionalridersprogram.org,Active,Yes,Yes,Yes,InterServer DA,No,.com migrated to GitHub Pages,192.64.86.202,Yes,,Live,Standard,,,,,None,,3 - Needs Migration
+For-Profit,exceptionalridersprogram.com,Active,Yes,Yes,Yes,Krystal.io,No,Moved to Krystal.io,185.199.220.110,Yes,,Unreachable,Standard,,,,,None,,3 - Needs Migration
+Org-WPAdmin,facinggiantsnc.org,Active,Yes,Yes,Yes,Hostinger,No,Duplicate exists on InterServer,153.92.213.212,Yes,,Live,Standard,,,,,None,,3 - Needs Migration
+Org-NoWP,ffchtml.onlineimpacts.org,Unknown,No,No,No,Hostinger,No,Subdomain-like structure,153.92.213.212,No,,Error,Standard,,,,,None,,3 - Needs Migration
+Org-WPAdmin,ftnfcog.org,Active,Yes,No,Yes,Hostinger,No,Matches Hostinger,153.92.213.212,No,,Live,Standard,,,,,None,,3 - Needs Migration
+Org-WPAdmin,graftonareahistory.org,Active,Yes,Yes,Yes,Cloudflare Proxy,No,Proxy origin unknown,141.193.213.10;141.193.213.11,Yes,,Live,Standard,,,,,None,,3 - Needs Migration
+InterServer-Org,harmonycenterfoundation.org,Active,Yes,Yes,No,InterServer DA,No,Correct InterServer mapping,192.64.86.202,Yes,,Live,Standard,,,,,None,,3 - Needs Migration
+Cloudflare-Only,hasbeensandgonnabees.org,Active,Yes,Yes,No,Cloudflare Proxy,No,Proxy origin unknown,52.184.222.116,Yes,,Unreachable,Standard,,,,,None,,3 - Needs Migration
+Org-WPAdmin,homesforchange.org,Unknown,No,No,Yes,Hostinger,No,Matches Hostinger,153.92.213.212,No,,Live,Standard,,,,,None,,3 - Needs Migration
+For-Profit,hunnewellscottages.com,Active,Yes,Yes,Yes,Cloudflare Proxy,No,Misconfigured,(no A record),Yes,,Live,Standard,,,,,None,,3 - Needs Migration
+For-Profit,iawea.net,Unknown,No,No,No,HostPapa,No,.net not paired,204.44.192.77,No,,Redirect,Standard,,,,,None,,3 - Needs Migration
+Org-NoWP,ihadrousa.org,Active,Yes,Yes,Yes,Hostinger,No,.com also on Hostinger,153.92.213.212,Yes,,Error,Standard,,,,,None,,3 - Needs Migration
+For-Profit,ihadrousa.com,Active,Yes,Yes,No,Hostinger,No,.org also on Hostinger,153.92.213.212,Yes,,Error,Standard,,,,,None,,3 - Needs Migration
+Org-WPAdmin,kainkaryasri.org,Unknown,No,No,Yes,Hostinger,No,Matches Hostinger,153.92.213.212,No,,Live,Standard,,,,,None,,3 - Needs Migration
+Org-WPAdmin,ksgf.org,Unknown,No,No,Yes,Hostinger,No,Matches Hostinger,153.92.213.212,No,,Live,Standard,,,,,None,,3 - Needs Migration
+InterServer-Org,legion-in-the-woods.org,Active,Yes,Yes,No,InterServer RS1,No,Correct InterServer RS1,216.158.234.18,Yes,,Live,Standard,,,,,None,,3 - Needs Migration
+Org-WPAdmin,letsdanceactivities.org,Active,Yes,Yes,Yes,Hostinger,No,.com also on Hostinger,153.92.213.212,Yes,,Live,Standard,,,,,None,,3 - Needs Migration
+For-Profit,letsdanceactivities.com,Active,Yes,Yes,No,Hostinger,No,.org also on Hostinger,153.92.213.212,Yes,,Redirect,Standard,,,,,None,,3 - Needs Migration
+Krystal-New,letspiritlead.org,Unknown,No,Yes,No,Krystal.io,No,New Krystal Host,74.50.79.163,Yes,,Live,Standard,,,,,None,,3 - Needs Migration
+Org-WPAdmin,lifelessonslearned.us.org,Active,Yes,Yes,Yes,Hostinger,No,Treated as .org family,153.92.213.212,Yes,,Live,Standard,,,,,None,,3 - Needs Migration
+Krystal-New,movewithcompassion.org,Unknown,No,No,No,Krystal.io,No,New Krystal Host,185.199.224.x,No,,Live,Standard,,,,,None,,3 - Needs Migration
+For-Profit,moyermanagement.com,Active,Yes,No,Yes,HostPapa,No,Matches HostPapa,185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153,No,,Live,Standard,,,,,None,,3 - Needs Migration
+Krystal-New,muckfichigan.com,Unknown,No,No,No,Krystal.io,No,New Krystal Host,185.199.224.x,No,,Live,Standard,,,,,None,,3 - Needs Migration
+Org-WPAdmin,my-missions.org,Active,Yes,Yes,Yes,Hostinger,No,Matches Hostinger,153.92.213.212,Yes,,Live,Standard,,,,,None,,3 - Needs Migration
+Org-WPAdmin,myservicehours.org,Unknown,No,No,Yes,Hostinger,No,Matches Hostinger,153.92.213.212,No,,Live,Standard,,,,,None,,3 - Needs Migration
+Org-WPAdmin,naturaldividends.org,Unknown,No,No,Yes,Hostinger,No,Matches Hostinger,153.92.213.212,No,,Unreachable,Standard,,,,,None,,3 - Needs Migration
+Org-WPAdmin,nestiva.org,Unknown,No,No,No,Hostinger,No,Matches Hostinger,153.92.213.212,No,,Unreachable,Standard,,,,,None,,3 - Needs Migration
+Org-WPAdmin,nochaos.org,Active,Yes,Yes,Yes,Hostinger,No,Matches Hostinger,153.92.213.212,Yes,,Live,Standard,,,,,None,,3 - Needs Migration
+Krystal-New,npbandparents.org,Unknown,No,No,No,Krystal.io,No,New Krystal Host,185.199.224.x,No,,Live,Standard,,,,,None,,3 - Needs Migration
+Krystal-New,nu4children.org,Unknown,No,No,No,Krystal.io,No,New Krystal Host,185.199.224.x,No,,Live,Standard,,,,,None,,3 - Needs Migration
+Org-WPAdmin,onlineimpacts.org,Unknown,No,No,Yes,Hostinger,No,Matches Hostinger,153.92.213.212,No,,Live,Standard,,,,,None,,3 - Needs Migration
+Org-WPAdmin,paaboosterclub.org,Active,Yes,Yes,No,Hostinger,No,Matches Hostinger,153.92.213.212,Yes,,Error,Standard,,,,,None,,3 - Needs Migration
+Org-WPAdmin,ptuganda.org,Active,Yes,Yes,No,Hostinger,No,Matches Hostinger,153.92.213.212,Yes,,Live,Standard,,,,,None,,3 - Needs Migration
+For-Profit,redlionchimneysweep.com,Unknown,No,No,No,InterServer DA,No,Matches InterServer,192.64.86.202,No,,Error,Standard,,,,,None,,3 - Needs Migration
+Krystal-New,scwcinc.org,Unknown,No,No,No,Krystal.io,No,New Krystal Host,185.199.224.x,No,,Live,Standard,,,,,None,,3 - Needs Migration
+For-Profit,shelteraid.us,Unknown,No,No,Yes,HostPapa,No,.us not paired,204.44.192.77,No,,Unreachable,Standard,,,,,None,,3 - Needs Migration
+Org-NoWP,stg.graftonareahistory.org,Unknown,No,No,No,Hostinger,No,Staging subdomain,153.92.213.212,No,,Unreachable,Standard,,,,,None,,3 - Needs Migration
+Krystal-New,teamwrangler.org,Unknown,No,No,No,Krystal.io,No,Inferred from Krystal image (DNS Check failed),185.199.224.x,No,,Unreachable,Standard,,,,,None,,3 - Needs Migration
+Org-WPAdmin,thebirf.org,Unknown,No,No,Yes,Hostinger,No,Matches Hostinger,153.92.213.212,No,,Live,Standard,,,,,None,,3 - Needs Migration
+Krystal-New,thedeviators.org,Unknown,No,No,No,Krystal.io,No,Inferred from Krystal image (DNS Check failed),185.199.224.x,No,,Live,Standard,,,,,None,,3 - Needs Migration
+Org-WPAdmin,theeverythingproject.org,Active,Yes,No,Yes,Hostinger,No,Matches Hostinger,153.92.213.212,No,,Live,Standard,,,,,None,,3 - Needs Migration
+For-Profit,thelastchancesanctuary.com,Active,Yes,Yes,Yes,Cloudflare Proxy,No,Misconfigured,153.92.213.212,Yes,,Redirect,Standard,,,,,None,,3 - Needs Migration
+For-Profit,thetrendylittlegeek.com,Active,Yes,Yes,No,HostPapa,No,Matches HostPapa,204.44.192.77,Yes,,Live,Standard,,,,,None,,3 - Needs Migration
+Org-WPAdmin,transferca.org,Unknown,No,No,Yes,Hostinger,No,Matches Hostinger,153.92.213.212,No,,Live,Standard,,,,,None,,3 - Needs Migration
+For-Profit,trendylittlegeek.com,Active,Yes,Yes,No,HostPapa,No,Matches HostPapa,204.44.192.77,Yes,,Live,Standard,,,,,None,,3 - Needs Migration
+Krystal-New,tribute-aviation.org,Unknown,No,No,No,Krystal.io,No,Inferred from Krystal image (DNS Check failed),185.199.224.x,No,,Unreachable,Standard,,,,,None,,3 - Needs Migration
+Org-WPAdmin,turksotx.org,Unknown,No,No,Yes,Hostinger,No,Matches Hostinger,153.92.213.212,No,,Live,Standard,,,,,None,,3 - Needs Migration
+Krystal-New,viewpointnorth.org,Unknown,No,No,No,Krystal.io,No,Inferred from Krystal image (DNS Check failed),185.199.224.x,No,,Unreachable,Standard,,,,,None,,3 - Needs Migration
+Krystal-New,vtyouthchat.org,Unknown,No,No,No,Krystal.io,No,Inferred from Krystal image (DNS Check failed),185.199.224.x,No,,Unreachable,Standard,,,,,None,,3 - Needs Migration
+Cloudflare-Only,fencingtogether.org,Active,Yes,Yes,No,GitHub Pages,Yes,Fully migrated,185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153,Yes,https://github.com/FencingTogether/website,Live,Standard,,,,,None,,4 - Done / Stable
+Subdomain,ffcsites.org,Active,Yes,Yes,No,GitHub Pages,Yes,Fully migrated,185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153,Yes,,Redirect,Standard,,,,,None,,4 - Done / Stable
+Subdomain,ffcworkingsite1.org,Active,Yes,Yes,No,GitHub Pages,Yes,Fully migrated,185.199.108.153;185.199.109.153;185.199.110.153;185.199.111.153,Yes,https://github.com/FreeForCharity/FFC-IN-Single_Page_Template_HTML,Live,Standard,,,,,None,,4 - Done / Stable
+Org-NoWP,ffcworkingsite2.org,Active,Yes,Yes,No,GitHub Pages,Yes,Fully migrated,185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153,Yes,https://github.com/FreeForCharity/FFC_Single_Page_Template,Live,Standard,,,,,None,,4 - Done / Stable
+Cloudflare-Only,pagbooster.org,Active,Yes,Yes,Yes,GitHub Pages,Yes,Fully migrated,185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153,Yes,https://github.com/FreeForCharity/FFC-EX-PAGboosters.org,Live,Standard,,,,,None,,4 - Done / Stable
+Cloudflare-Only,thekccf.org,Active,Yes,Yes,No,GitHub Pages,Yes,Fully migrated,185.199.111.153;185.199.109.153;185.199.110.153;185.199.108.153,Yes,https://github.com/koenig-childhood-cancer-foundation/KCCF-web,Live,Standard,,,,,None,,4 - Done / Stable
+Unknown,3dmc2.com,Active,Yes,No,No,,,,(no A record),No,,Live,Standard,,,,,None,,5 - Needs Triage
+Unknown,americanlegionpost64.com,Active,Yes,No,No,,,,(no A record),No,,Redirect,Standard,,,,,None,,5 - Needs Triage
+Unknown,amplifiedaid.org,Active,Yes,No,Yes,,,,(no A record),No,,Live,Standard,,,,,None,,5 - Needs Triage
+Unknown,aprilmoyer.com,Active,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,5 - Needs Triage
+Unknown,aprilunlimited.com,Active,Yes,No,Yes,,,,216.222.200.253,No,,Live,Standard,,,,,None,,5 - Needs Triage
+Unknown,avengedfastpitch.org,Active,Yes,No,Yes,,,,(no A record),No,,Live,Standard,,,,,None,,5 - Needs Triage
+Unknown,bhakthinivedana.com/sandbox,Unknown,No,No,No,,,,(no A record),No,,Redirect,Standard,,,,,None,,5 - Needs Triage
+Unknown,birthfree.org,Active,Yes,No,No,,,,172.67.181.220;104.21.18.132,No,,Error,Standard,,,,,None,,5 - Needs Triage
+Unknown,bowiesblessings.org,Active,Yes,No,No,,,,(no A record),No,,Live,Standard,,,,,None,,5 - Needs Triage
+Unknown,burnsurvivorscharity.org,Active,Yes,No,No,,,,(no A record),No,,Error,Standard,,,,,None,,5 - Needs Triage
+For-Profit,canadatokeywestcoastalrun.com,Unknown,No,Yes,No,No A Record,Yes,Domain inactive; .org exists,(no A record),Yes,,Redirect,Standard,,,,,None,,5 - Needs Triage
+Unknown,cechanover.org,Pending,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,5 - Needs Triage
+Unknown,clarkemoyer.com,Active,Yes,No,Yes,,,,185.199.111.153;185.199.110.153;185.199.108.153;185.199.109.153,No,,Live,Standard,,,,,None,,5 - Needs Triage
+Unknown,clarkmoyer.com,Active,Yes,No,No,,,,52.184.222.116,No,,Redirect,Standard,,,,,None,,5 - Needs Triage
+Cloudflare-Only,cochiserobotics.org,Active,Yes,Yes,No,FFC-WHM-01,No,Not on any known server list,52.184.222.116,Yes,,Unreachable,Standard,,,,,None,,5 - Needs Triage
+Unknown,communitychristianpentecostal.org,Active,Yes,No,No,,,,(no A record),No,,Error,Standard,,,,,None,,5 - Needs Triage
+Unknown,completequarters.org,Active,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,5 - Needs Triage
+Unknown,completequarters.com,Active,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,5 - Needs Triage
+Unknown,craftedraise.org,Active,Yes,No,No,,,,(no A record),No,,Live,Standard,,,,,None,,5 - Needs Triage
+Unknown,cucu-il.org,Active,Yes,No,Yes,,,,(no A record),No,,Live,Standard,,,,,None,,5 - Needs Triage
+Unknown,darkclouds.us,Active,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,5 - Needs Triage
+Unknown,database.onlineimpacts.org,Unknown,No,No,Yes,,,,(no A record),No,,Live,Standard,,,,,None,,5 - Needs Triage
+InterServer-Org,emc-professional.org,Active,Yes,Yes,No,No A Record,Yes,.com points to InterServer,(no A record),Yes,,Redirect,Standard,,,,,None,,5 - Needs Triage
+Unknown,empowerconnectfoundation.org,Active,Yes,No,Yes,,,,(no A record),No,,Unreachable,Standard,,,,,None,,5 - Needs Triage
+Unknown,escdcpac.org,Active,Yes,No,No,,,,(no A record),No,,Error,Standard,,,,,None,,5 - Needs Triage
+Unknown,facinggiantsnc.com,Active,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,5 - Needs Triage
+Unknown,ffc.ngo,Unknown,No,Yes,No,,,,(no A record),Yes,,Redirect,Standard,,,,,None,,5 - Needs Triage
+Org-NoWP,ffcdomains.org,Active,Yes,Yes,No,No A Record,Yes,Inactive,(no A record),Yes,,Redirect,Standard,,,,,None,,5 - Needs Triage
+Org-NoWP,ffcdomains.com,Active,Yes,Yes,No,No A Record,Yes,Paired with ffcdomains.org (inactive),(no A record),Yes,,Redirect,Standard,,,,,None,,5 - Needs Triage
+Unknown,ffchosting.onlineimpacts.org,Unknown,No,No,Yes,,,,(no A record),No,,Live,Standard,,,,,None,,5 - Needs Triage
+Org-WPAdmin,ffchosting.org,Active,Yes,Yes,No,No A Record,Yes,Inactive,(no A record),Yes,,Redirect,Standard,,,,,None,,5 - Needs Triage
+Unknown,ffchosting.com,Active,Yes,Yes,No,,,,(no A record),Yes,,Redirect,Standard,,,,,None,,5 - Needs Triage
+Unknown,ffchostingmultisite.org,Transferred Away,Yes,Yes,No,,,,(no A record),Yes,,Redirect,Standard,,,,,None,,5 - Needs Triage
+Unknown,ffctools.onlineimpacts.org,Unknown,No,No,Yes,,,,(no A record),No,,Live,Standard,,,,,None,,5 - Needs Triage
+Unknown,focus-on-free.com,Active,Yes,No,No,,,,216.222.200.253,No,,Live,Standard,,,,,None,,5 - Needs Triage
+Unknown,focusonfree.org,Active,Yes,No,No,,,,104.21.52.163;172.67.201.83,No,,Error,Standard,,,,,None,,5 - Needs Triage
+Unknown,focusonfree.us,Active,Yes,No,No,,,,172.67.202.82;104.21.76.244,No,,Error,Standard,,,,,None,,5 - Needs Triage
+Unknown,freeforcharity.ngo,Unknown,No,Yes,No,,,,(no A record),Yes,,Redirect,Standard,,,,,None,,5 - Needs Triage
+Unknown,freetoolsfornonprofits.org,Active,Yes,Yes,No,,,,(no A record),Yes,,Unreachable,Standard,,,,,None,,5 - Needs Triage
+Unknown,ghcd.onlineimpacts.org,Unknown,No,No,No,,,,(no A record),No,,Live,Standard,,,,,None,,5 - Needs Triage
+Unknown,greenrecon.org,Active,Yes,No,No,,,,(no A record),No,,Live,Standard,,,,,None,,5 - Needs Triage
+Unknown,harmonycenterofhillsdale.org,Pending,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,5 - Needs Triage
+Unknown,hcohi.net,Pending,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,5 - Needs Triage
+Unknown,ieeeforthuachuca.org,Active,Yes,Yes,No,,,,54.163.236.200,Yes,,Unreachable,Standard,,,,,None,,5 - Needs Triage
+Unknown,jeeyar.onlineimpacts.org,Unknown,No,No,Yes,,,,(no A record),No,,Unreachable,Standard,,,,,None,,5 - Needs Triage
+Unknown,jsbt.org.au,Unknown,No,No,Yes,,,,(no A record),No,,Unknown,Standard,,,,,None,,5 - Needs Triage
+Unknown,kieranrunnelsdev.org,Active,Yes,No,Yes,,,,(no A record),No,,Live,Standard,,,,,None,,5 - Needs Triage
+Unknown,kierstensride.org,Unknown,No,No,Yes,,,,(no A record),No,,Live,Standard,,,,,None,,5 - Needs Triage
+Unknown,kingstoncommunitycenter.org,Active,Yes,No,No,,,,(no A record),No,,Error,Standard,,,,,None,,5 - Needs Triage
+Unknown,kittencoveinc.org,Active,Yes,No,No,,,,(no A record),No,,Live,Standard,,,,,None,,5 - Needs Triage
+Unknown,letsleadwise.org,Active,Yes,No,No,,,,(no A record),No,,Live,Standard,,,,,None,,5 - Needs Triage
+Unknown,makeacalendarinvite.org,Active,Yes,Yes,Yes,,,,204.44.192.77,Yes,,Live,Standard,,,,,None,,5 - Needs Triage
+Unknown,melaninmagicfoundation.org,Unknown,No,Yes,No,,,,66.23.226.51,Yes,,Unreachable,Standard,,,,,None,,5 - Needs Triage
+Unknown,moyerinvestments.com,Active,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,5 - Needs Triage
+Unknown,moyermanagement.org,Active,Yes,No,No,,,,159.65.76.163,No,,Unreachable,Standard,,,,,None,,5 - Needs Triage
+Unknown,moyermanagementsystems.com,Active,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,5 - Needs Triage
+Unknown,newenglandbattalion.org,Pending,Yes,No,No,,,,(no A record),No,,Redirect,Standard,,,,,None,,5 - Needs Triage
+Unknown,nolef.onlineimpacts.org,Unknown,No,No,Yes,,,,(no A record),No,,Live,Standard,,,,,None,,5 - Needs Triage
+Unknown,nottinghampc.org,Unknown,No,No,Yes,,,,(no A record),No,,Live,Standard,,,,,None,,5 - Needs Triage
+Unknown,npfan.org,Active,Yes,No,No,,,,(no A record),No,,Redirect,Standard,,,,,None,,5 - Needs Triage
+Unknown,ohiomtawest.org,Active,Yes,Yes,No,,,,(no A record),Yes,,Redirect,Standard,,,,,None,,5 - Needs Triage
+Unknown,oimpacts.org,Active,Yes,No,No,,,,(no A record),No,,Error,Standard,,,,,None,,5 - Needs Triage
+Unknown,operationfullcircle.org,Active,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,5 - Needs Triage
+Unknown,operationhomesforheroes.org,Pending,Yes,No,No,,,,(no A record),No,,Live,Standard,,,,,None,,5 - Needs Triage
+Unknown,padmajaramanujadasi.com,Unknown,No,No,Yes,,,,(no A record),No,,Redirect,Standard,,,,,None,,5 - Needs Triage
+Cloudflare-Only,pantryforadaircounty.org,Active,Yes,Yes,No,FFC-WHM-01,No,Not on any known server list,52.184.222.116,Yes,,Unreachable,Standard,,,,,None,,5 - Needs Triage
+Unknown,pfplus.org,Unknown,No,No,Yes,,,,(no A record),No,,Live,Standard,,,,,None,,5 - Needs Triage
+Unknown,phoenixartsandadvocacy.org,Active,Yes,No,No,,,,(no A record),No,,Live,Standard,,,,,None,,5 - Needs Triage
+Unknown,physicalinvestor.com,Active,Yes,No,No,,,,172.67.142.110;104.21.71.27,No,,Error,Standard,,,,,None,,5 - Needs Triage
+Unknown,qtbb.org,Active,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,5 - Needs Triage
+Cloudflare-Only,roottostem.org,Active,Yes,Yes,No,FFC-WHM-01,No,Not on any known server list,52.184.222.116,Yes,,Unreachable,Standard,,,,,None,,5 - Needs Triage
+Unknown,safemap.org,Active,Yes,No,No,,,,(no A record),No,,Error,Standard,,,,,None,,5 - Needs Triage
+Unknown,sfcityarts.org,Active,Yes,No,No,,,,(no A record),No,,Redirect,Standard,,,,,None,,5 - Needs Triage
+Cloudflare-Only,soulfoodwhangarei.org,Active,Yes,Yes,No,FFC-WHM-01,No,Not on any known server list,52.184.222.116,Yes,,Unreachable,Standard,,,,,None,,5 - Needs Triage
+Subdomain,southamptonfriends.com,Active,Yes,Yes,No,No A Record,Yes,Paired with .org (active on InterServer),(no A record),Yes,,Redirect,Standard,,,,,None,,5 - Needs Triage
+Unknown,ssrn.net,Unknown,No,Yes,No,,,,217.19.248.132,Yes,,Unreachable,Standard,,,,,None,,5 - Needs Triage
+Unknown,staging.alltypetowing.com,Unknown,No,No,Yes,,,,(no A record),No,,Unreachable,Standard,,,,,None,,5 - Needs Triage
+Unknown,staging.americanlegionpost64.org,Unknown,No,No,No,,,,(no A record),No,,Live,Standard,,,,,None,,5 - Needs Triage
+Unknown,staging.bulldogztowing.com,Unknown,No,No,Yes,,,,(no A record),No,,Live,Standard,,,,,None,,5 - Needs Triage
+Unknown,staging.clarkemoyer.com,Unknown,No,No,Yes,,,,(no A record),No,,Unreachable,Standard,,,,,None,,5 - Needs Triage
+Unknown,staging.facinggiantsnc.org,Unknown,No,No,Yes,,,,(no A record),No,,Live,Standard,,,,,None,,5 - Needs Triage
+Unknown,staging.iawea.us,Unknown,No,No,Yes,,,,(no A record),No,,Live,Standard,,,,,None,,5 - Needs Triage
+Unknown,staging.instituteofforgiveness.org,Unknown,No,No,Yes,,,,(no A record),No,,Live,Standard,,,,,None,,5 - Needs Triage
+Unknown,staging.jwvpost619.org,Unknown,No,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,5 - Needs Triage
+Unknown,staging.southamptonfriends.org,Unknown,No,No,No,,,,(no A record),No,,Live,Standard,,,,,None,,5 - Needs Triage
+Unknown,stepeople.org,Active,Yes,No,No,,,,(no A record),No,,Error,Standard,,,,,None,,5 - Needs Triage
+Unknown,stylesbysheba.com,Unknown,No,No,Yes,,,,(no A record),No,,Live,Standard,,,,,None,,5 - Needs Triage
+Cloudflare-Only,tamkeensports.org,Active,Yes,Yes,No,External,No,External hosting,174.138.190.170,Yes,,Unreachable,Standard,,,,,None,,5 - Needs Triage
+Unknown,tasteandseelocal.org,Active,Yes,No,No,,,,(no A record),No,,Live,Standard,,,,,None,,5 - Needs Triage
+Unknown,technologyadoptionbarriers.org,Active,Yes,Yes,No,,,,184.72.224.80;34.227.238.166;3.91.109.122;100.24.182.117;35.172.73.102;34.199.202.106,Yes,,Live,Standard,,,,,None,,5 - Needs Triage
+Cloudflare-Only,theafghanistanaffairs.org,Active,Yes,Yes,No,External,No,External hosting,204.13.238.115,Yes,,Error,Standard,,,,,None,,5 - Needs Triage
+Unknown,thecrookedhouse.org,Unknown,No,No,No,,,,198.185.159.145;198.185.159.144;198.49.23.145;198.49.23.144,No,,Redirect,Standard,,,,,None,,5 - Needs Triage
+Unknown,thegracehouseinc.org,Unknown,No,No,Yes,,,,(no A record),No,,Live,Standard,,,,,None,,5 - Needs Triage
+Unknown,thekccf.onlineimpacts.org,Unknown,No,No,No,,,,(no A record),No,,Live,Standard,,,,,None,,5 - Needs Triage
+Unknown,thescottiecfoundation.org,Pending,Yes,No,No,,,,34.111.179.208,No,,Error,Standard,,,,,None,,5 - Needs Triage
+Unknown,thestudiovisit.org,Active,Yes,No,No,,,,(no A record),No,,Live,Standard,,,,,None,,5 - Needs Triage
+Unknown,thrivecollectionagency.org,Active,Yes,No,No,,,,(no A record),No,,Error,Standard,,,,,None,,5 - Needs Triage
+Unknown,tpainepta.org,Active,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,5 - Needs Triage
+Unknown,trinitylutheranconcord.org,Active,Yes,No,No,,,,(no A record),No,,Redirect,Standard,,,,,None,,5 - Needs Triage
+Unknown,trinityucclewistown.org,Active,Yes,No,No,,,,(no A record),No,,Redirect,Standard,,,,,None,,5 - Needs Triage
+Unknown,veterans.onlineimpacts.org,Unknown,No,No,Yes,,,,(no A record),No,,Live,Standard,,,,,None,,5 - Needs Triage
+Unknown,vetmast.org,Unknown,No,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,5 - Needs Triage
+Cloudflare-Only,wamhelp.org,Active,Yes,Yes,Yes,External,No,External hosting,66.23.226.51,Yes,,Live,Standard,,,,,None,,5 - Needs Triage
+Unknown,wh1374403.ispot.cc/wp,Unknown,No,No,Yes,,,,(no A record),No,,Redirect,Standard,,,,,None,,5 - Needs Triage
+Unknown,wisdomfinancialministries.org,Active,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,5 - Needs Triage
+Unknown,wonderseedstudios.org,Active,Yes,No,No,,,,(no A record),No,,Redirect,Standard,,,,,None,,5 - Needs Triage
+Unknown,workreadyrva.com,Unknown,No,No,Yes,,,,(no A record),No,,Live,Standard,,,,,None,,5 - Needs Triage
+Unknown,www.americanlegionpost64.org,Unknown,No,No,Yes,,,,(no A record),No,,Redirect,Standard,,,,,None,,5 - Needs Triage
+Unknown,www.henricovareentrycouncil.com,Unknown,No,No,Yes,,,,(no A record),No,,Live,Standard,,,,,None,,5 - Needs Triage
+Unknown,www.jeeyarasramam.org,Unknown,No,No,No,,,,(no A record),No,,Error,Standard,,,,,None,,5 - Needs Triage
+Unknown,www.nolefturns.org,Unknown,No,No,No,,,,(no A record),No,,Live,Standard,,,,,None,,5 - Needs Triage
+Unknown,www.shebawilliams.com,Unknown,No,No,Yes,,,,(no A record),No,,Live,Standard,,,,,None,,5 - Needs Triage
+Unknown,www.virginiajusticeconference.com,Unknown,No,No,Yes,,,,(no A record),No,,Live,Standard,,,,,None,,5 - Needs Triage
+Unknown,www.wonderseedstudios.org,Unknown,No,No,Yes,,,,(no A record),No,,Live,Standard,,,,,None,,5 - Needs Triage
+Cloudflare-Only,youngfatherscare.org,Active,Yes,Yes,No,External,No,Adjacent to InterServer but not exact match,192.64.86.203,Yes,,Live,Standard,,,,,None,,5 - Needs Triage
+InterServer-Org,nittanypost245.org,Cancelled,Yes,Yes,No,InterServer DA,No,Correct InterServer mapping,192.64.86.202,Yes,https://github.com/FreeForCharity/FFC-EX-nittanypost245.org,Live,Standard,No,2026-06-06,0,2026-06-06,Active,,6 - Inactive / Archive
+Unknown,armstrongacesbaseball.org,Fraud,Yes,Yes,No,,,,204.44.192.77,Yes,https://github.com/FreeForCharity/FFC-EX-armstrongacesbaseball.org,Live,Standard,No,2026-06-02,0,2026-06-02,Active,,6 - Inactive / Archive
+Unknown,1726nerds.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,1stepfcc.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,abundances.org,Expired,Yes,No,No,,,,(no A record),No,,Live,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,adrian2018.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,alliancesofveteransandfamiliesservices.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,alpha1bat1legion.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,alphaonelegion.com,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,amarodhikar.org,Cancelled,Yes,No,No,,,,(no A record),No,,Live,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,ampwup.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,ampwupi.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,andrellharris.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,andrellharris.com,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,andrellharris.us,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,annabryant.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,bat1alpha1legion.com,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Cloudflare-Only,bboc4vets.org,Expired,Yes,Yes,No,FFC-WHM-01,No,Not on any known server list,52.184.222.116,Yes,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,beauty4myashes.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,bellsofhope.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,bhhc-usa.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Org-WPAdmin,brianmustofoundation.org,Cancelled,Yes,No,No,Hostinger,No,Matches Hostinger,153.92.213.212,No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,bringing-people-2-people.com,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,broadcastvoice.net,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,btcsv.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,buckeyebullsbaseball.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,cochisedubsaz.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+For-Profit,communitytechsupply.com,Expired,Yes,No,No,InterServer DA,No,Matches InterServer DA,192.64.86.202,No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,cysoclabs.com,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,darbycharlesblackmemorialfund.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,dcbmf.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,ecjeli.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,ecjelife.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,etherfrolics.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,faithorgnc.org,Transferred Away,Yes,No,No,,,,(no A record),No,,Redirect,Standard,,,,,None,Yes,6 - Inactive / Archive
+Unknown,fhuhbl.com,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,fosterakid.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,fosterakids.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,glstraining.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,gustolifeskillstraining.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,h4sd.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,harborcityfoodpantry.org,Cancelled,Yes,No,No,,,,185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153,No,,Error,Standard,,,,,None,,6 - Inactive / Archive
+For-Profit,hardpointconsulting.com,Transferred Away,Yes,No,Yes,HostPapa,No,Matches HostPapa,204.44.192.77,No,,Live,Standard,,,,,None,Yes,6 - Inactive / Archive
+Unknown,heroes2others.org,Fraud,Yes,No,No,,,,(no A record),No,,Live,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,historyinplay.org,Transferred Away,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,Yes,6 - Inactive / Archive
+Unknown,historyinplay.com,Transferred Away,Yes,No,No,,,,(no A record),No,,Redirect,Standard,,,,,None,Yes,6 - Inactive / Archive
+Unknown,huachucashuttle.com,Transferred Away,Yes,No,No,,,,(no A record),No,,Live,Standard,,,,,None,Yes,6 - Inactive / Archive
+Unknown,huachucashuttlehbl.com,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,impactsierravista.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,innovatesphere.org,Cancelled,Yes,No,No,,,,(no A record),No,,Live,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,javawockies.org,Transferred Away,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,Yes,6 - Inactive / Archive
+Org-WPAdmin,jeansnsneaks.org,Cancelled,Yes,No,Yes,Hostinger,No,Matches Hostinger,153.92.213.212,No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,joelhockermemorialfoundation.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,joelhockermemorialfoundation.com,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,juliannaswishes.com,Cancelled,Yes,No,No,,,,(no A record),No,,Error,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,kansaslenfacccoalitionkl.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,kingsremnantmessianicministries.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,kpmministries.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,krishnacharity.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,ktdorganization.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,kydol.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,ladiesof5280.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,ladiesof5280.com,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,lakebrentwoodresort.com,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,lastchancesanctuary.com,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,lifechangingfaces.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,lifechangingfaces.com,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,locali60west.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,martinez2018.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,mattressfiberglass.net,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,mattressfiberglass.org,Fraud,Yes,No,No,,,,(no A record),No,,Live,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,medicsofmayhem.com,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,megan220.com,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,mountainboundk9sar.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,mydartmouth-una.us.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,northeasterntrailridersassociation.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,ocydevelopment.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,ocydi.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,oitemplates.org,Cancelled,Yes,No,No,,,,(no A record),No,,Error,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,petrcraft.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,phominhtemple.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,platoon1alpha.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Org-WPAdmin,postpartumcarefoundation.org,Cancelled,Yes,Yes,Yes,Hostinger,No,.com also exists,153.92.213.212,Yes,,Live,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,postpartumcarefoundation.com,Cancelled,Yes,Yes,No,,,,153.92.213.212,Yes,,Redirect,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,pronovaestates.com,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,pydccenter.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,pydci.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,redeemussocial.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,resilient-grace.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Org-WPAdmin,rhwcustoms.org,Expired,Yes,No,Yes,HostPapa,No,Duplicate on Hostinger,204.44.192.77,No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,rhwcustoms.com,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,root2stem-edu.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,rotchurch.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,rotci.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,rougegn.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,saharacc.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,scainc.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,sfcoffeeco.net,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,sfcoffeeco.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,sfcoffeeco.com,Transferred Away,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,Yes,6 - Inactive / Archive
+Unknown,shopcommunitycenters.org,Transferred Away,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,Yes,6 - Inactive / Archive
+Unknown,sierravistadreamcenter.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,sierravistadreamcenter.com,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,skillsprivateacademy.net,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,skillsprivateacademy.org,Transferred Away,Yes,No,No,,,,(no A record),No,,Redirect,Standard,,,,,None,Yes,6 - Inactive / Archive
+Unknown,skillsprivateacademy.com,Transferred Away,Yes,No,No,,,,(no A record),No,,Redirect,Standard,,,,,None,Yes,6 - Inactive / Archive
+Unknown,skillsprivatetutoring.net,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,skillsprivatetutoring.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,skillsprivatetutoring.com,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,socialenterprisestudiosinc.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,socialenterprisestudiosinc.com,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,somact.org,Transferred Away,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,Yes,6 - Inactive / Archive
+Unknown,southamptonfriendspa.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,southlakeseniorfunding.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,spiritofthelandcharitabletrust.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,srs806.org,Expired,Yes,No,No,,,,(no A record),No,,Live,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,stampedesoftball.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,sunshinenetworkchicago.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,svbuddhisttemple.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,svfreethinkers.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,tech4security.net,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,tech4security.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,tech4security.com,Expired,Yes,No,No,,,,(no A record),No,,Live,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,tech4thesick.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,techforsecurity.com,Expired,Yes,No,No,,,,(no A record),No,,Live,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,technologyforsecurity.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,technologyforsecurity.com,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Cloudflare-Only,technologymonastery.us,Expired,Yes,Yes,No,External,No,External hosting,192.185.118.32,Yes,,Live,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,thefederalinvestor.com,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,themilitaryinvestor.com,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,thinkitwice.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,thirdcoastfiretraining.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,thirdcoastfiretraining.com,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,thofaith.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,treehouse-project.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,trendylittlegeek.net,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,unitygreen21.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,wisdomadvisory.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,wnwstrategies.com,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,wonderseed.net,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,wonderseed.org,Expired,Yes,No,No,,,,(no A record),No,,Live,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,wonderseedfoundation.net,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,wonderseedfoundation.org,Transferred Away,Yes,No,No,,,,(no A record),No,,Live,Standard,,,,,None,Yes,6 - Inactive / Archive
+Unknown,wonderseedstudio.net,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,wonderseedstudio.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,wonderseedstudio.com,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,wonderseedstudios.net,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,wonderseedstudios.com,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,wonderseedverse.net,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,wonderseedverse.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,wonderseedverse.com,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,wonderseedworld.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,wonderseedworld.com,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,woundedresponderproject.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,youngmothersofamerica.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive
+Unknown,ziggymarleygeorgefoundation.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard,,,,,None,,6 - Inactive / Archive

--- a/docs/sites_list.json
+++ b/docs/sites_list.json
@@ -1,5 +1,28 @@
 [
   {
+    "Section": "Subdomain",
+    "Domain": "ffcadmin.org",
+    "Status": "Active",
+    "In WHMCS": "Yes",
+    "In Cloudflare": "Yes",
+    "In WPMUDEV": "No",
+    "Server In Use": "GitHub Pages",
+    "Old Server Abandoned?": "Yes",
+    "Notes": "Fully migrated",
+    "Cloudflare IP": "185.199.108.153;185.199.109.153;185.199.110.153;185.199.111.153",
+    "Is In Cloudflare": "Yes",
+    "Repo URL": "https://github.com/FreeForCharity/FFC-IN-ffcadmin.org",
+    "Site Health": "Live",
+    "Priority": "Standard",
+    "Repo Archived": "No",
+    "Last PR Closed": "2026-06-08",
+    "Open PRs": "2",
+    "Last Commit": "2026-06-08",
+    "Dev Status": "Active",
+    "Left FFC": "",
+    "Work Tier": "1 - Active Development"
+  },
+  {
     "Section": "Unknown",
     "Domain": "bearupinternationalministries.org",
     "Status": "Unknown",
@@ -19,28 +42,7 @@
     "Open PRs": "16",
     "Last Commit": "2026-06-07",
     "Dev Status": "Active",
-    "Work Tier": "1 - Active Development"
-  },
-  {
-    "Section": "Subdomain",
-    "Domain": "ffcadmin.org",
-    "Status": "Active",
-    "In WHMCS": "Yes",
-    "In Cloudflare": "Yes",
-    "In WPMUDEV": "No",
-    "Server In Use": "GitHub Pages",
-    "Old Server Abandoned?": "Yes",
-    "Notes": "Fully migrated",
-    "Cloudflare IP": "185.199.108.153;185.199.109.153;185.199.110.153;185.199.111.153",
-    "Is In Cloudflare": "Yes",
-    "Repo URL": "https://github.com/FreeForCharity/FFC-IN-ffcadmin.org",
-    "Site Health": "Live",
-    "Priority": "Standard",
-    "Repo Archived": "No",
-    "Last PR Closed": "2026-06-07",
-    "Open PRs": "3",
-    "Last Commit": "2026-06-07",
-    "Dev Status": "Active",
+    "Left FFC": "",
     "Work Tier": "1 - Active Development"
   },
   {
@@ -63,6 +65,7 @@
     "Open PRs": "3",
     "Last Commit": "2026-06-07",
     "Dev Status": "Active",
+    "Left FFC": "",
     "Work Tier": "1 - Active Development"
   },
   {
@@ -82,9 +85,10 @@
     "Priority": "Standard",
     "Repo Archived": "No",
     "Last PR Closed": "2026-06-07",
-    "Open PRs": "5",
+    "Open PRs": "4",
     "Last Commit": "2026-06-07",
     "Dev Status": "Active",
+    "Left FFC": "",
     "Work Tier": "1 - Active Development"
   },
   {
@@ -107,6 +111,7 @@
     "Open PRs": "4",
     "Last Commit": "2026-06-04",
     "Dev Status": "Active",
+    "Left FFC": "",
     "Work Tier": "1 - Active Development"
   },
   {
@@ -129,6 +134,7 @@
     "Open PRs": "20",
     "Last Commit": "2026-06-02",
     "Dev Status": "Active",
+    "Left FFC": "",
     "Work Tier": "1 - Active Development"
   },
   {
@@ -151,6 +157,7 @@
     "Open PRs": "21",
     "Last Commit": "2026-06-02",
     "Dev Status": "Active",
+    "Left FFC": "",
     "Work Tier": "1 - Active Development"
   },
   {
@@ -166,13 +173,14 @@
     "Cloudflare IP": "(no A record)",
     "Is In Cloudflare": "No",
     "Repo URL": "https://github.com/FreeForCharity/FFC-EX-americanlegionpost64.org",
-    "Site Health": "Unreachable",
+    "Site Health": "Live",
     "Priority": "Standard",
     "Repo Archived": "No",
     "Last PR Closed": "2026-06-02",
     "Open PRs": "20",
     "Last Commit": "2026-06-02",
     "Dev Status": "Active",
+    "Left FFC": "",
     "Work Tier": "1 - Active Development"
   },
   {
@@ -188,13 +196,14 @@
     "Cloudflare IP": "204.44.192.77",
     "Is In Cloudflare": "Yes",
     "Repo URL": "https://github.com/FreeForCharity/FFC-EX-aprilhansen.com",
-    "Site Health": "Unreachable",
+    "Site Health": "Live",
     "Priority": "Standard",
     "Repo Archived": "No",
     "Last PR Closed": "2026-06-02",
     "Open PRs": "19",
     "Last Commit": "2026-06-02",
     "Dev Status": "Active",
+    "Left FFC": "",
     "Work Tier": "1 - Active Development"
   },
   {
@@ -217,6 +226,7 @@
     "Open PRs": "20",
     "Last Commit": "2026-06-02",
     "Dev Status": "Active",
+    "Left FFC": "",
     "Work Tier": "1 - Active Development"
   },
   {
@@ -239,6 +249,7 @@
     "Open PRs": "20",
     "Last Commit": "2026-06-02",
     "Dev Status": "Active",
+    "Left FFC": "",
     "Work Tier": "1 - Active Development"
   },
   {
@@ -261,6 +272,7 @@
     "Open PRs": "20",
     "Last Commit": "2026-06-02",
     "Dev Status": "Active",
+    "Left FFC": "",
     "Work Tier": "1 - Active Development"
   },
   {
@@ -283,6 +295,7 @@
     "Open PRs": "20",
     "Last Commit": "2026-06-02",
     "Dev Status": "Active",
+    "Left FFC": "",
     "Work Tier": "1 - Active Development"
   },
   {
@@ -305,6 +318,7 @@
     "Open PRs": "20",
     "Last Commit": "2026-06-02",
     "Dev Status": "Active",
+    "Left FFC": "",
     "Work Tier": "1 - Active Development"
   },
   {
@@ -327,6 +341,7 @@
     "Open PRs": "20",
     "Last Commit": "2026-06-02",
     "Dev Status": "Active",
+    "Left FFC": "",
     "Work Tier": "1 - Active Development"
   },
   {
@@ -349,6 +364,7 @@
     "Open PRs": "20",
     "Last Commit": "2026-06-02",
     "Dev Status": "Active",
+    "Left FFC": "",
     "Work Tier": "1 - Active Development"
   },
   {
@@ -371,6 +387,7 @@
     "Open PRs": "22",
     "Last Commit": "2026-06-02",
     "Dev Status": "Active",
+    "Left FFC": "",
     "Work Tier": "1 - Active Development"
   },
   {
@@ -393,6 +410,7 @@
     "Open PRs": "24",
     "Last Commit": "2026-06-02",
     "Dev Status": "Active",
+    "Left FFC": "",
     "Work Tier": "1 - Active Development"
   },
   {
@@ -415,6 +433,7 @@
     "Open PRs": "5",
     "Last Commit": "2026-06-06",
     "Dev Status": "Active",
+    "Left FFC": "",
     "Work Tier": "1 - Active Development"
   },
   {
@@ -437,6 +456,7 @@
     "Open PRs": "20",
     "Last Commit": "2026-06-02",
     "Dev Status": "Active",
+    "Left FFC": "",
     "Work Tier": "1 - Active Development"
   },
   {
@@ -459,6 +479,7 @@
     "Open PRs": "18",
     "Last Commit": "2026-06-02",
     "Dev Status": "Active",
+    "Left FFC": "",
     "Work Tier": "1 - Active Development"
   },
   {
@@ -481,6 +502,7 @@
     "Open PRs": "23",
     "Last Commit": "2026-06-02",
     "Dev Status": "Active",
+    "Left FFC": "",
     "Work Tier": "1 - Active Development"
   },
   {
@@ -503,6 +525,7 @@
     "Open PRs": "20",
     "Last Commit": "2026-06-02",
     "Dev Status": "Active",
+    "Left FFC": "",
     "Work Tier": "1 - Active Development"
   },
   {
@@ -525,6 +548,7 @@
     "Open PRs": "20",
     "Last Commit": "2026-06-02",
     "Dev Status": "Active",
+    "Left FFC": "",
     "Work Tier": "1 - Active Development"
   },
   {
@@ -547,6 +571,7 @@
     "Open PRs": "20",
     "Last Commit": "2026-06-02",
     "Dev Status": "Active",
+    "Left FFC": "",
     "Work Tier": "1 - Active Development"
   },
   {
@@ -569,6 +594,7 @@
     "Open PRs": "22",
     "Last Commit": "2026-06-02",
     "Dev Status": "Active",
+    "Left FFC": "",
     "Work Tier": "1 - Active Development"
   },
   {
@@ -591,6 +617,7 @@
     "Open PRs": "19",
     "Last Commit": "2026-06-02",
     "Dev Status": "Active",
+    "Left FFC": "",
     "Work Tier": "1 - Active Development"
   },
   {
@@ -613,6 +640,7 @@
     "Open PRs": "27",
     "Last Commit": "2026-05-28",
     "Dev Status": "Active",
+    "Left FFC": "",
     "Work Tier": "1 - Active Development"
   },
   {
@@ -635,6 +663,7 @@
     "Open PRs": "23",
     "Last Commit": "2026-06-03",
     "Dev Status": "Active",
+    "Left FFC": "",
     "Work Tier": "1 - Active Development"
   },
   {
@@ -657,6 +686,7 @@
     "Open PRs": "22",
     "Last Commit": "2026-06-02",
     "Dev Status": "Active",
+    "Left FFC": "",
     "Work Tier": "1 - Active Development"
   },
   {
@@ -676,9 +706,10 @@
     "Priority": "Standard",
     "Repo Archived": "No",
     "Last PR Closed": "2026-05-27",
-    "Open PRs": "0",
+    "Open PRs": "11",
     "Last Commit": "2026-06-02",
     "Dev Status": "Active",
+    "Left FFC": "",
     "Work Tier": "1 - Active Development"
   },
   {
@@ -698,9 +729,10 @@
     "Priority": "Standard",
     "Repo Archived": "No",
     "Last PR Closed": "2026-05-27",
-    "Open PRs": "0",
+    "Open PRs": "8",
     "Last Commit": "2026-05-27",
     "Dev Status": "Active",
+    "Left FFC": "",
     "Work Tier": "1 - Active Development"
   },
   {
@@ -723,6 +755,7 @@
     "Open PRs": "0",
     "Last Commit": "2026-05-28",
     "Dev Status": "Active",
+    "Left FFC": "",
     "Work Tier": "1 - Active Development"
   },
   {
@@ -745,6 +778,7 @@
     "Open PRs": "0",
     "Last Commit": "2026-05-27",
     "Dev Status": "Active",
+    "Left FFC": "",
     "Work Tier": "1 - Active Development"
   },
   {
@@ -767,6 +801,7 @@
     "Open PRs": "0",
     "Last Commit": "2026-05-27",
     "Dev Status": "Active",
+    "Left FFC": "",
     "Work Tier": "1 - Active Development"
   },
   {
@@ -789,6 +824,7 @@
     "Open PRs": "0",
     "Last Commit": "2026-03-25",
     "Dev Status": "Stalled",
+    "Left FFC": "",
     "Work Tier": "2 - Has Repo, Stalled"
   },
   {
@@ -811,6 +847,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "3 - Needs Migration"
   },
   {
@@ -833,6 +870,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "3 - Needs Migration"
   },
   {
@@ -855,6 +893,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "3 - Needs Migration"
   },
   {
@@ -877,6 +916,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "3 - Needs Migration"
   },
   {
@@ -899,6 +939,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "3 - Needs Migration"
   },
   {
@@ -921,6 +962,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "3 - Needs Migration"
   },
   {
@@ -943,6 +985,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "3 - Needs Migration"
   },
   {
@@ -965,6 +1008,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "3 - Needs Migration"
   },
   {
@@ -987,6 +1031,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "3 - Needs Migration"
   },
   {
@@ -1002,13 +1047,14 @@
     "Cloudflare IP": "192.64.86.202",
     "Is In Cloudflare": "Yes",
     "Repo URL": "",
-    "Site Health": "Unreachable",
+    "Site Health": "Live",
     "Priority": "Standard",
     "Repo Archived": "",
     "Last PR Closed": "",
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "3 - Needs Migration"
   },
   {
@@ -1024,13 +1070,14 @@
     "Cloudflare IP": "192.64.86.202",
     "Is In Cloudflare": "Yes",
     "Repo URL": "",
-    "Site Health": "Unreachable",
+    "Site Health": "Live",
     "Priority": "Standard",
     "Repo Archived": "",
     "Last PR Closed": "",
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "3 - Needs Migration"
   },
   {
@@ -1053,6 +1100,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "3 - Needs Migration"
   },
   {
@@ -1075,6 +1123,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "3 - Needs Migration"
   },
   {
@@ -1097,6 +1146,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "3 - Needs Migration"
   },
   {
@@ -1119,6 +1169,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "3 - Needs Migration"
   },
   {
@@ -1134,13 +1185,14 @@
     "Cloudflare IP": "185.199.220.110",
     "Is In Cloudflare": "Yes",
     "Repo URL": "",
-    "Site Health": "Live",
+    "Site Health": "Unreachable",
     "Priority": "Standard",
     "Repo Archived": "",
     "Last PR Closed": "",
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "3 - Needs Migration"
   },
   {
@@ -1163,6 +1215,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "3 - Needs Migration"
   },
   {
@@ -1185,6 +1238,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "3 - Needs Migration"
   },
   {
@@ -1207,6 +1261,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "3 - Needs Migration"
   },
   {
@@ -1229,6 +1284,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "3 - Needs Migration"
   },
   {
@@ -1251,6 +1307,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "3 - Needs Migration"
   },
   {
@@ -1273,6 +1330,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "3 - Needs Migration"
   },
   {
@@ -1295,6 +1353,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "3 - Needs Migration"
   },
   {
@@ -1317,6 +1376,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "3 - Needs Migration"
   },
   {
@@ -1339,6 +1399,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "3 - Needs Migration"
   },
   {
@@ -1361,6 +1422,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "3 - Needs Migration"
   },
   {
@@ -1383,6 +1445,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "3 - Needs Migration"
   },
   {
@@ -1405,6 +1468,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "3 - Needs Migration"
   },
   {
@@ -1427,6 +1491,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "3 - Needs Migration"
   },
   {
@@ -1449,6 +1514,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "3 - Needs Migration"
   },
   {
@@ -1471,6 +1537,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "3 - Needs Migration"
   },
   {
@@ -1493,6 +1560,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "3 - Needs Migration"
   },
   {
@@ -1515,6 +1583,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "3 - Needs Migration"
   },
   {
@@ -1537,6 +1606,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "3 - Needs Migration"
   },
   {
@@ -1559,6 +1629,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "3 - Needs Migration"
   },
   {
@@ -1581,6 +1652,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "3 - Needs Migration"
   },
   {
@@ -1603,6 +1675,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "3 - Needs Migration"
   },
   {
@@ -1625,6 +1698,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "3 - Needs Migration"
   },
   {
@@ -1647,6 +1721,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "3 - Needs Migration"
   },
   {
@@ -1669,6 +1744,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "3 - Needs Migration"
   },
   {
@@ -1691,6 +1767,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "3 - Needs Migration"
   },
   {
@@ -1713,6 +1790,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "3 - Needs Migration"
   },
   {
@@ -1735,6 +1813,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "3 - Needs Migration"
   },
   {
@@ -1757,6 +1836,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "3 - Needs Migration"
   },
   {
@@ -1779,6 +1859,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "3 - Needs Migration"
   },
   {
@@ -1801,6 +1882,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "3 - Needs Migration"
   },
   {
@@ -1823,6 +1905,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "3 - Needs Migration"
   },
   {
@@ -1845,6 +1928,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "3 - Needs Migration"
   },
   {
@@ -1867,6 +1951,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "3 - Needs Migration"
   },
   {
@@ -1889,6 +1974,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "3 - Needs Migration"
   },
   {
@@ -1911,6 +1997,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "3 - Needs Migration"
   },
   {
@@ -1933,6 +2020,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "3 - Needs Migration"
   },
   {
@@ -1955,6 +2043,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "3 - Needs Migration"
   },
   {
@@ -1977,6 +2066,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "3 - Needs Migration"
   },
   {
@@ -1999,6 +2089,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "3 - Needs Migration"
   },
   {
@@ -2021,6 +2112,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "3 - Needs Migration"
   },
   {
@@ -2043,6 +2135,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "3 - Needs Migration"
   },
   {
@@ -2065,6 +2158,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "3 - Needs Migration"
   },
   {
@@ -2087,6 +2181,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "3 - Needs Migration"
   },
   {
@@ -2109,6 +2204,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "3 - Needs Migration"
   },
   {
@@ -2131,6 +2227,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "3 - Needs Migration"
   },
   {
@@ -2153,6 +2250,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "3 - Needs Migration"
   },
   {
@@ -2175,6 +2273,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "3 - Needs Migration"
   },
   {
@@ -2197,6 +2296,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "4 - Done / Stable"
   },
   {
@@ -2219,6 +2319,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "4 - Done / Stable"
   },
   {
@@ -2241,6 +2342,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "4 - Done / Stable"
   },
   {
@@ -2263,6 +2365,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "4 - Done / Stable"
   },
   {
@@ -2285,6 +2388,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "4 - Done / Stable"
   },
   {
@@ -2307,6 +2411,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "4 - Done / Stable"
   },
   {
@@ -2329,6 +2434,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -2351,6 +2457,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -2373,6 +2480,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -2395,6 +2503,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -2410,13 +2519,14 @@
     "Cloudflare IP": "216.222.200.253",
     "Is In Cloudflare": "No",
     "Repo URL": "",
-    "Site Health": "Unreachable",
+    "Site Health": "Live",
     "Priority": "Standard",
     "Repo Archived": "",
     "Last PR Closed": "",
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -2439,6 +2549,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -2461,6 +2572,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -2483,6 +2595,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -2505,6 +2618,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -2527,6 +2641,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -2549,6 +2664,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -2571,6 +2687,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -2593,6 +2710,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -2615,6 +2733,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -2637,6 +2756,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -2659,6 +2779,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -2681,6 +2802,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -2703,6 +2825,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -2725,6 +2848,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -2747,6 +2871,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -2769,6 +2894,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -2791,6 +2917,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -2813,6 +2940,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -2828,13 +2956,14 @@
     "Cloudflare IP": "(no A record)",
     "Is In Cloudflare": "No",
     "Repo URL": "",
-    "Site Health": "Live",
+    "Site Health": "Unreachable",
     "Priority": "Standard",
     "Repo Archived": "",
     "Last PR Closed": "",
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -2857,6 +2986,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -2879,6 +3009,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -2901,6 +3032,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -2923,6 +3055,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -2945,6 +3078,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -2967,6 +3101,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -2989,6 +3124,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -3011,6 +3147,30 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
+    "Work Tier": "5 - Needs Triage"
+  },
+  {
+    "Section": "Unknown",
+    "Domain": "ffchostingmultisite.org",
+    "Status": "Transferred Away",
+    "In WHMCS": "Yes",
+    "In Cloudflare": "Yes",
+    "In WPMUDEV": "No",
+    "Server In Use": "",
+    "Old Server Abandoned?": "",
+    "Notes": "",
+    "Cloudflare IP": "(no A record)",
+    "Is In Cloudflare": "Yes",
+    "Repo URL": "",
+    "Site Health": "Redirect",
+    "Priority": "Standard",
+    "Repo Archived": "",
+    "Last PR Closed": "",
+    "Open PRs": "",
+    "Last Commit": "",
+    "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -3033,6 +3193,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -3055,6 +3216,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -3077,6 +3239,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -3099,6 +3262,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -3121,6 +3285,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -3143,6 +3308,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -3165,6 +3331,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -3187,6 +3354,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -3209,6 +3377,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -3231,6 +3400,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -3253,6 +3423,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -3268,13 +3439,14 @@
     "Cloudflare IP": "(no A record)",
     "Is In Cloudflare": "No",
     "Repo URL": "",
-    "Site Health": "Redirect",
+    "Site Health": "Unreachable",
     "Priority": "Standard",
     "Repo Archived": "",
     "Last PR Closed": "",
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -3297,6 +3469,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -3319,6 +3492,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -3341,6 +3515,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -3363,6 +3538,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -3385,6 +3561,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -3407,6 +3584,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -3429,6 +3607,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -3451,6 +3630,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -3473,6 +3653,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -3495,6 +3676,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -3517,6 +3699,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -3539,6 +3722,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -3561,6 +3745,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -3583,6 +3768,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -3605,6 +3791,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -3627,6 +3814,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -3649,6 +3837,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -3671,6 +3860,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -3693,6 +3883,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -3715,6 +3906,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -3737,6 +3929,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -3759,6 +3952,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -3781,6 +3975,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -3803,6 +3998,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -3825,6 +4021,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -3847,6 +4044,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -3869,6 +4067,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -3891,6 +4090,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -3913,6 +4113,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -3935,6 +4136,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -3957,6 +4159,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -3979,6 +4182,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -4001,6 +4205,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -4023,6 +4228,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -4045,6 +4251,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -4067,6 +4274,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -4089,6 +4297,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -4111,6 +4320,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -4133,6 +4343,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -4155,6 +4366,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -4177,6 +4389,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -4199,6 +4412,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -4214,13 +4428,14 @@
     "Cloudflare IP": "174.138.190.170",
     "Is In Cloudflare": "Yes",
     "Repo URL": "",
-    "Site Health": "Live",
+    "Site Health": "Unreachable",
     "Priority": "Standard",
     "Repo Archived": "",
     "Last PR Closed": "",
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -4243,6 +4458,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -4265,6 +4481,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -4287,6 +4504,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -4309,6 +4527,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -4331,6 +4550,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -4353,6 +4573,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -4375,6 +4596,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -4397,6 +4619,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -4419,6 +4642,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -4441,6 +4665,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -4463,6 +4688,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -4485,6 +4711,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -4507,6 +4734,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -4529,6 +4757,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -4551,6 +4780,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -4573,6 +4803,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -4588,13 +4819,14 @@
     "Cloudflare IP": "(no A record)",
     "Is In Cloudflare": "No",
     "Repo URL": "",
-    "Site Health": "Live",
+    "Site Health": "Unreachable",
     "Priority": "Standard",
     "Repo Archived": "",
     "Last PR Closed": "",
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -4617,6 +4849,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -4639,6 +4872,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -4661,6 +4895,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -4683,6 +4918,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -4705,6 +4941,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -4727,6 +4964,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -4742,13 +4980,14 @@
     "Cloudflare IP": "(no A record)",
     "Is In Cloudflare": "No",
     "Repo URL": "",
-    "Site Health": "Unreachable",
+    "Site Health": "Live",
     "Priority": "Standard",
     "Repo Archived": "",
     "Last PR Closed": "",
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -4764,13 +5003,14 @@
     "Cloudflare IP": "(no A record)",
     "Is In Cloudflare": "No",
     "Repo URL": "",
-    "Site Health": "Unreachable",
+    "Site Health": "Live",
     "Priority": "Standard",
     "Repo Archived": "",
     "Last PR Closed": "",
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -4793,6 +5033,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -4815,6 +5056,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "5 - Needs Triage"
   },
   {
@@ -4834,9 +5076,10 @@
     "Priority": "Standard",
     "Repo Archived": "No",
     "Last PR Closed": "2026-06-06",
-    "Open PRs": "27",
+    "Open PRs": "0",
     "Last Commit": "2026-06-06",
     "Dev Status": "Active",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -4856,9 +5099,10 @@
     "Priority": "Standard",
     "Repo Archived": "No",
     "Last PR Closed": "2026-06-02",
-    "Open PRs": "20",
+    "Open PRs": "0",
     "Last Commit": "2026-06-02",
     "Dev Status": "Active",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -4881,6 +5125,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -4903,6 +5148,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -4925,6 +5171,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -4947,6 +5194,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -4969,6 +5217,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -4991,6 +5240,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -5013,6 +5263,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -5035,6 +5286,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -5057,6 +5309,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -5079,6 +5332,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -5101,6 +5355,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -5123,6 +5378,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -5145,6 +5401,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -5167,6 +5424,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -5189,6 +5447,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -5211,6 +5470,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -5233,6 +5493,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -5255,6 +5516,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -5277,6 +5539,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -5299,6 +5562,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -5321,6 +5585,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -5343,6 +5608,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -5365,6 +5631,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -5387,6 +5654,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -5409,6 +5677,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -5431,6 +5700,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -5453,6 +5723,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -5475,6 +5746,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -5497,6 +5769,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -5519,6 +5792,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -5541,6 +5815,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -5563,6 +5838,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -5585,28 +5861,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
-    "Work Tier": "6 - Inactive / Archive"
-  },
-  {
-    "Section": "Unknown",
-    "Domain": "ffchostingmultisite.org",
-    "Status": "Transferred Away",
-    "In WHMCS": "Yes",
-    "In Cloudflare": "Yes",
-    "In WPMUDEV": "No",
-    "Server In Use": "",
-    "Old Server Abandoned?": "",
-    "Notes": "",
-    "Cloudflare IP": "(no A record)",
-    "Is In Cloudflare": "Yes",
-    "Repo URL": "",
-    "Site Health": "Redirect",
-    "Priority": "Standard",
-    "Repo Archived": "",
-    "Last PR Closed": "",
-    "Open PRs": "",
-    "Last Commit": "",
-    "Dev Status": "None",
+    "Left FFC": "Yes",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -5629,6 +5884,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -5651,6 +5907,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -5673,6 +5930,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -5695,6 +5953,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -5717,6 +5976,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -5739,6 +5999,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -5761,6 +6022,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -5783,6 +6045,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "Yes",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -5805,6 +6068,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -5827,6 +6091,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "Yes",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -5849,6 +6114,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "Yes",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -5871,6 +6137,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "Yes",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -5893,6 +6160,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -5915,6 +6183,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -5937,6 +6206,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -5959,6 +6229,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "Yes",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -5981,6 +6252,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -6003,6 +6275,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -6025,6 +6298,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -6047,6 +6321,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -6069,6 +6344,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -6091,6 +6367,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -6113,6 +6390,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -6135,6 +6413,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -6157,6 +6436,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -6179,6 +6459,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -6201,6 +6482,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -6223,6 +6505,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -6245,6 +6528,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -6267,6 +6551,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -6289,6 +6574,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -6311,6 +6597,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -6333,6 +6620,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -6355,6 +6643,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -6377,6 +6666,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -6399,6 +6689,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -6421,6 +6712,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -6443,6 +6735,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -6465,6 +6758,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -6487,6 +6781,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -6509,6 +6804,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -6531,6 +6827,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -6553,6 +6850,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -6575,6 +6873,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -6597,6 +6896,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -6619,6 +6919,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -6641,6 +6942,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -6663,6 +6965,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -6685,6 +6988,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -6707,6 +7011,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -6729,6 +7034,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -6751,6 +7057,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -6773,6 +7080,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -6795,6 +7103,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -6817,6 +7126,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -6839,6 +7149,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -6861,6 +7172,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -6883,6 +7195,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -6905,6 +7218,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -6927,6 +7241,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -6949,6 +7264,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -6971,6 +7287,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -6993,6 +7310,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -7015,6 +7333,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -7037,6 +7356,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "Yes",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -7059,6 +7379,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "Yes",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -7081,6 +7402,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -7103,6 +7425,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -7125,6 +7448,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -7147,6 +7471,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "Yes",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -7169,6 +7494,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "Yes",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -7191,6 +7517,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -7213,6 +7540,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -7235,6 +7563,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -7257,6 +7586,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -7279,6 +7609,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -7301,6 +7632,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "Yes",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -7323,6 +7655,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -7345,6 +7678,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -7367,6 +7701,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -7389,6 +7724,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -7411,6 +7747,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -7433,6 +7770,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -7455,6 +7793,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -7477,6 +7816,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -7499,6 +7839,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -7521,6 +7862,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -7543,6 +7885,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -7565,6 +7908,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -7587,6 +7931,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -7609,6 +7954,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -7631,6 +7977,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -7653,6 +8000,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -7675,6 +8023,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -7697,6 +8046,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -7719,6 +8069,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -7741,6 +8092,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -7763,6 +8115,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -7785,6 +8138,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -7807,6 +8161,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -7829,6 +8184,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -7851,6 +8207,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -7873,6 +8230,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -7895,6 +8253,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -7917,6 +8276,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -7939,6 +8299,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -7961,6 +8322,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -7983,6 +8345,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "Yes",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -8005,6 +8368,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -8027,6 +8391,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -8042,13 +8407,14 @@
     "Cloudflare IP": "(no A record)",
     "Is In Cloudflare": "No",
     "Repo URL": "",
-    "Site Health": "Live",
+    "Site Health": "Unreachable",
     "Priority": "Standard",
     "Repo Archived": "",
     "Last PR Closed": "",
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -8071,6 +8437,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -8093,6 +8460,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -8115,6 +8483,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -8137,6 +8506,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -8159,6 +8529,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -8181,6 +8552,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -8203,6 +8575,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -8225,6 +8598,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -8247,6 +8621,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   },
   {
@@ -8269,6 +8644,7 @@
     "Open PRs": "",
     "Last Commit": "",
     "Dev Status": "None",
+    "Left FFC": "",
     "Work Tier": "6 - Inactive / Archive"
   }
 ]

--- a/src/app/sites-list/page.tsx
+++ b/src/app/sites-list/page.tsx
@@ -33,6 +33,7 @@ interface SiteData {
   lastCommit: string
   devStatus: string
   workTier: string
+  leftFfc: string
 }
 
 function getSitesData(): SiteData[] {
@@ -62,29 +63,38 @@ function getSitesData(): SiteData[] {
     openPrs: r['Open PRs'] || '',
     lastCommit: r['Last Commit'] || '',
     devStatus: r['Dev Status'] || '',
-    // Trust the enriched Work Tier, but defensively force hard-dead statuses to
-    // Tier 6 so stale/incorrect data never surfaces a dead domain as work.
-    workTier: coerceDeadTier(r['Work Tier'] || deriveTier(r), r['Status']),
+    leftFfc: r['Left FFC'] || derivedLeftFfc(r),
+    // Trust the enriched Work Tier, but defensively force genuinely-dead domains
+    // to Tier 6 so stale/incorrect data never surfaces one as work.
+    workTier: coerceDeadTier(r['Work Tier'] || deriveTier(r), r),
   }))
 }
 
 const HARD_DEAD = ['expired', 'cancelled', 'fraud', 'terminated']
 
-// Hard-dead lifecycle states always belong in Tier 6, regardless of repo activity.
-// "Transferred Away" is deliberately NOT here: a domain whose registration moved
-// can still be a live, actively-developed site (e.g. the flagship freeforcharity.org),
-// so the generator's dev-aware Work Tier keeps those in Tier 1 rather than burying
-// them in archive. Transferred domains without active development land in Tier 6
-// via the generator / deriveTier fallback.
-function coerceDeadTier(tier: string, status: string): string {
-  return HARD_DEAD.includes((status || '').toLowerCase()) ? '6 - Inactive / Archive' : tier
+// "Transferred Away" means the registration left eNom. It only means FFC lost the
+// domain if it's also no longer in FFC Cloudflare; a transfer that stayed in
+// Cloudflare is fine and the domain is tiered normally.
+function derivedLeftFfc(r: Record<string, string>): string {
+  return (r['Status'] || '').toLowerCase() === 'transferred away' &&
+    (r['In Cloudflare'] || '').toLowerCase() !== 'yes'
+    ? 'Yes'
+    : ''
+}
+
+// Force genuinely-dead domains to Tier 6: hard-dead lifecycle states, plus
+// transfers that left FFC Cloudflare. A transfer still in Cloudflare is NOT dead.
+function coerceDeadTier(tier: string, r: Record<string, string>): string {
+  const status = (r['Status'] || '').toLowerCase()
+  if (HARD_DEAD.includes(status) || derivedLeftFfc(r) === 'Yes') return '6 - Inactive / Archive'
+  return tier
 }
 
 // Fallback tiering for data that predates the enrichment step (no dev signal).
 function deriveTier(r: Record<string, string>): string {
   const status = (r['Status'] || '').toLowerCase()
   const server = (r['Server In Use'] || '').toLowerCase()
-  if ([...HARD_DEAD, 'transferred away'].includes(status)) return '6 - Inactive / Archive'
+  if (HARD_DEAD.includes(status) || derivedLeftFfc(r) === 'Yes') return '6 - Inactive / Archive'
   if (server === 'github pages') return '4 - Done / Stable'
   if (
     ['hostpapa', 'interserver', 'hostinger', 'krystal', 'cloudflare proxy'].some((s) =>
@@ -297,6 +307,12 @@ export default function SitesListPage() {
   const byTier = (num: string) => sites.filter((s) => s.workTier.startsWith(num))
   const counts = Object.fromEntries(TIERS.map((t) => [t.num, byTier(t.num).length]))
 
+  // Domains transferred away from eNom AND no longer in FFC Cloudflare — i.e.
+  // they actually left FFC. Surfaced prominently for cleanup/outreach.
+  const leftFfcSites = sites
+    .filter((s) => s.leftFfc === 'Yes')
+    .sort((a, b) => a.domain.localeCompare(b.domain))
+
   const stat = (label: string, value: number, color: string, icon: string) => (
     <div className={`bg-white rounded-lg shadow-md border p-4 text-center ${color}`}>
       <p className="text-3xl font-bold">
@@ -340,6 +356,22 @@ export default function SitesListPage() {
           {stat('Needs Migration', counts['3'], 'border-blue-200', '🚚')}
           {stat('Done / Stable', counts['4'], 'border-teal-200', '✅')}
         </div>
+
+        {/* Domains that left FFC (transferred away + not in FFC Cloudflare) */}
+        {leftFfcSites.length > 0 && (
+          <details className="mb-8 rounded-lg shadow-md border border-red-300 bg-red-50 overflow-hidden">
+            <summary className="px-6 py-4 cursor-pointer bg-red-100 text-red-900 border-b border-red-200">
+              <span className="text-lg font-bold">🚨 Left FFC — needs attention</span>
+              <span className="ml-2 text-sm font-semibold opacity-80">({leftFfcSites.length})</span>
+              <p className="text-sm mt-1 opacity-80 font-normal">
+                Transferred away from eNom <strong>and</strong> no longer in FFC Cloudflare — FFC no
+                longer manages DNS for these. Still in WHMCS, so worth a cleanup/outreach pass (some
+                are still live under their new owner).
+              </p>
+            </summary>
+            <TierTable sites={leftFfcSites} num="6" />
+          </details>
+        )}
 
         {/* Work Tier sections */}
         {TIERS.map((t) => {

--- a/src/app/sites-list/page.tsx
+++ b/src/app/sites-list/page.tsx
@@ -63,7 +63,7 @@ function getSitesData(): SiteData[] {
     openPrs: r['Open PRs'] || '',
     lastCommit: r['Last Commit'] || '',
     devStatus: r['Dev Status'] || '',
-    leftFfc: r['Left FFC'] || derivedLeftFfc(r),
+    leftFfc: isLeftFfc(r) ? 'Yes' : '',
     // Trust the enriched Work Tier, but defensively force genuinely-dead domains
     // to Tier 6 so stale/incorrect data never surfaces one as work.
     workTier: coerceDeadTier(r['Work Tier'] || deriveTier(r), r),
@@ -75,18 +75,25 @@ const HARD_DEAD = ['expired', 'cancelled', 'fraud', 'terminated']
 // "Transferred Away" means the registration left eNom. It only means FFC lost the
 // domain if it's also no longer in FFC Cloudflare; a transfer that stayed in
 // Cloudflare is fine and the domain is tiered normally.
-function derivedLeftFfc(r: Record<string, string>): string {
-  return (r['Status'] || '').toLowerCase() === 'transferred away' &&
+function derivedLeftFfc(r: Record<string, string>): boolean {
+  return (
+    (r['Status'] || '').toLowerCase() === 'transferred away' &&
     (r['In Cloudflare'] || '').toLowerCase() !== 'yes'
-    ? 'Yes'
-    : ''
+  )
+}
+
+// Single source of truth for "left FFC": trust the generator's explicit column
+// when the data is enriched (Work Tier present); only derive it for pre-enrichment data.
+function isLeftFfc(r: Record<string, string>): boolean {
+  if (r['Work Tier']) return (r['Left FFC'] || '').toLowerCase() === 'yes'
+  return derivedLeftFfc(r)
 }
 
 // Force genuinely-dead domains to Tier 6: hard-dead lifecycle states, plus
 // transfers that left FFC Cloudflare. A transfer still in Cloudflare is NOT dead.
 function coerceDeadTier(tier: string, r: Record<string, string>): string {
   const status = (r['Status'] || '').toLowerCase()
-  if (HARD_DEAD.includes(status) || derivedLeftFfc(r) === 'Yes') return '6 - Inactive / Archive'
+  if (HARD_DEAD.includes(status) || isLeftFfc(r)) return '6 - Inactive / Archive'
   return tier
 }
 
@@ -94,7 +101,7 @@ function coerceDeadTier(tier: string, r: Record<string, string>): string {
 function deriveTier(r: Record<string, string>): string {
   const status = (r['Status'] || '').toLowerCase()
   const server = (r['Server In Use'] || '').toLowerCase()
-  if (HARD_DEAD.includes(status) || derivedLeftFfc(r) === 'Yes') return '6 - Inactive / Archive'
+  if (HARD_DEAD.includes(status) || isLeftFfc(r)) return '6 - Inactive / Archive'
   if (server === 'github pages') return '4 - Done / Stable'
   if (
     ['hostpapa', 'interserver', 'hostinger', 'krystal', 'cloudflare proxy'].some((s) =>


### PR DESCRIPTION
## What

Refines the Work-Tier handling of **"Transferred Away"** using its real meaning: a transfer out of eNom is only a problem if the domain is **no longer in FFC Cloudflare**.

- Transferred Away **+ in FFC Cloudflare** → tiered normally, not dead (`freeforcharity.org` correctly stays Tier 1).
- Transferred Away **+ not in Cloudflare** → the domain actually left FFC → Tier 6, and surfaced in a new **🚨 "Left FFC — needs attention"** section (12 domains today) so they're visible for cleanup/outreach instead of buried in archive.

Reads the new `Left FFC` column from the generator (with a Cloudflare-aware fallback if data predates it). Build + type-check + lint pass.

## Companion PR
➡️ **FreeForCharity/FFC-Cloudflare-Automation** (Cloudflare-aware tiering + `Left FFC` column in the generator).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pa2dNVqNCeqqehW4oygN3h)_