### PR TITLE
build(deps): hold eslint-plugin-react-hooks at 7.0.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,13 @@ updates:
       - dependency-name: 'typescript'
         update-types:
           - 'version-update:semver-major'
+      # eslint-plugin-react-hooks >= 7.1 adds stricter rules (immutability,
+      # setState-in-effect, use-before-declare) that currently error in
+      # CookieConsent.tsx. Hold at 7.0.x until that refactor lands (see #389).
+      - dependency-name: 'eslint-plugin-react-hooks'
+        update-types:
+          - 'version-update:semver-major'
+          - 'version-update:semver-minor'
     groups:
       # Group development dependencies together (minor and patch updates)
       development-dependencies:


### PR DESCRIPTION
Safe mitigation for **#389**.

`eslint-plugin-react-hooks` 7.1+ adds stricter rules (`immutability`, setState-in-effect, use-before-declare) that currently **error** in `src/components/CookieConsent.tsx` (7 errors). CI is green today only because `--frozen-lockfile` pins `7.0.1`; a Dependabot bump would break lint CI.

This adds a Dependabot `ignore` for minor+major bumps of that plugin (patches within 7.0.x still allowed), buying time for the proper consent-component refactor tracked in **#389** — rather than rushing a risky change to the consent/analytics path.

Config-only; no app changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pa2dNVqNCeqqehW4oygN3h)_