### PR TITLE
fix: correct broken Taproot Foundation links

### DIFF
--- a/src/app/movsm/page.tsx
+++ b/src/app/movsm/page.tsx
@@ -210,7 +210,7 @@ export default function MovsmPage() {
             Already active? Collaborate with the team in <strong>Microsoft Teams</strong>. Many
             volunteers also find us through{' '}
             <a
-              href="https://www.taproot.org/"
+              href="https://taprootfoundation.org/"
               target="_blank"
               rel="noopener noreferrer"
               className="text-blue-600 underline hover:text-blue-800"

--- a/src/app/volunteer/page.tsx
+++ b/src/app/volunteer/page.tsx
@@ -587,7 +587,7 @@ export default function VolunteerPage() {
                 <span className="text-teal-600 mr-2 mt-0.5">&bull;</span>
                 <span>
                   <a
-                    href="https://www.taproot.org/"
+                    href="https://taprootfoundation.org/"
                     target="_blank"
                     rel="noopener noreferrer"
                     className="text-blue-600 underline hover:text-blue-800"


### PR DESCRIPTION
Updates broken links pointing to `taproot.org` (which redirects to `taproottheatre.org`) to point to the correct URL (`https://taprootfoundation.org/`).

**Files updated:**
- `src/app/volunteer/page.tsx`
- `src/app/movsm/page.tsx`

Build and local checks have been verified.