### PR TITLE
feat: Cloudflare dashboard quick-link on Sites List rows (#187)

### DIFF
--- a/__tests__/sites-data-cloudflare-link.test.ts
+++ b/__tests__/sites-data-cloudflare-link.test.ts
@@ -1,0 +1,23 @@
+import { cloudflareZoneUrl, FFC_CLOUDFLARE_ACCOUNT_ID } from '../src/app/sites-list/sitesData'
+
+describe('cloudflareZoneUrl quick-link (#187)', () => {
+  it('builds a per-zone dashboard URL for domains in FFC Cloudflare', () => {
+    const url = cloudflareZoneUrl({ domain: 'example.org', inCloudflare: 'Yes' })
+    expect(url).toBe(`https://dash.cloudflare.com/${FFC_CLOUDFLARE_ACCOUNT_ID}/example.org`)
+  })
+
+  it('is case-insensitive on the In Cloudflare flag', () => {
+    expect(cloudflareZoneUrl({ domain: 'example.org', inCloudflare: 'yes' })).toContain(
+      'dash.cloudflare.com'
+    )
+  })
+
+  it('returns empty string when the site is not in Cloudflare', () => {
+    expect(cloudflareZoneUrl({ domain: 'example.org', inCloudflare: 'No' })).toBe('')
+    expect(cloudflareZoneUrl({ domain: 'example.org', inCloudflare: '' })).toBe('')
+  })
+
+  it('returns empty string when there is no domain', () => {
+    expect(cloudflareZoneUrl({ domain: '', inCloudflare: 'Yes' })).toBe('')
+  })
+})

--- a/src/app/sites-list/page.tsx
+++ b/src/app/sites-list/page.tsx
@@ -122,71 +122,75 @@ function TierTable({ sites, num }: { sites: SiteData[]; num: string }) {
           </tr>
         </thead>
         <tbody className="bg-white divide-y divide-gray-100">
-          {sites.map((s) => (
-            <tr key={`${num}-${s.domain}`} className="hover:bg-gray-50">
-              <td className="px-4 py-2 whitespace-nowrap font-medium">
-                <a
-                  href={`https://${s.domain}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-blue-600 hover:underline"
-                >
-                  {s.domain}
-                </a>
-                {cloudflareZoneUrl(s) && (
+          {sites.map((s) => {
+            const cfUrl = cloudflareZoneUrl(s)
+            return (
+              <tr key={`${num}-${s.domain}`} className="hover:bg-gray-50">
+                <td className="px-4 py-2 whitespace-nowrap font-medium">
                   <a
-                    href={cloudflareZoneUrl(s)}
+                    href={`https://${s.domain}`}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="ml-2 inline-flex items-center text-xs text-orange-600 hover:underline"
-                    title={`Open ${s.domain} in the Cloudflare dashboard`}
+                    className="text-blue-600 hover:underline"
                   >
-                    <span aria-hidden="true">☁</span>
-                    <span className="ml-0.5">CF</span>
+                    {s.domain}
                   </a>
+                  {cfUrl && (
+                    <a
+                      href={cfUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="ml-2 inline-flex items-center text-xs text-orange-600 hover:underline"
+                      aria-label={`Open ${s.domain} in the Cloudflare dashboard`}
+                      title={`Open ${s.domain} in the Cloudflare dashboard`}
+                    >
+                      <span aria-hidden="true">☁</span>
+                      <span className="ml-0.5">CF</span>
+                    </a>
+                  )}
+                </td>
+                {showRepoCols && (
+                  <>
+                    <td className="px-4 py-2 whitespace-nowrap text-xs">
+                      {s.repoUrl ? (
+                        <a
+                          href={s.repoUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-indigo-600 hover:underline"
+                          title={repoName(s.repoUrl)}
+                        >
+                          {repoName(s.repoUrl).split('/').pop()}
+                        </a>
+                      ) : (
+                        dash
+                      )}
+                    </td>
+                    <td className="px-4 py-2 whitespace-nowrap text-xs text-gray-600">
+                      {s.lastPrClosed || dash}
+                    </td>
+                    <td className="px-4 py-2 whitespace-nowrap text-xs text-gray-600">
+                      {s.openPrs && s.openPrs !== '0' ? s.openPrs : dash}
+                    </td>
+                  </>
                 )}
-              </td>
-              {showRepoCols && (
-                <>
-                  <td className="px-4 py-2 whitespace-nowrap text-xs">
-                    {s.repoUrl ? (
-                      <a
-                        href={s.repoUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-indigo-600 hover:underline"
-                        title={repoName(s.repoUrl)}
-                      >
-                        {repoName(s.repoUrl).split('/').pop()}
-                      </a>
-                    ) : (
-                      dash
-                    )}
-                  </td>
-                  <td className="px-4 py-2 whitespace-nowrap text-xs text-gray-600">
-                    {s.lastPrClosed || dash}
-                  </td>
-                  <td className="px-4 py-2 whitespace-nowrap text-xs text-gray-600">
-                    {s.openPrs && s.openPrs !== '0' ? s.openPrs : dash}
-                  </td>
-                </>
-              )}
-              <td className="px-4 py-2 whitespace-nowrap">
-                <span
-                  className={`px-2 py-0.5 rounded-full text-xs font-semibold border ${healthBadge(s.siteHealth)}`}
-                >
-                  {s.siteHealth || 'N/A'}
-                </span>
-              </td>
-              <td className="px-4 py-2 whitespace-nowrap text-xs text-gray-700">
-                {s.serverInUse || dash}
-              </td>
-              <td className="px-4 py-2 whitespace-nowrap text-xs text-gray-700">{s.status}</td>
-              <td className="px-4 py-2 text-xs text-gray-500 max-w-xs truncate" title={s.notes}>
-                {s.notes}
-              </td>
-            </tr>
-          ))}
+                <td className="px-4 py-2 whitespace-nowrap">
+                  <span
+                    className={`px-2 py-0.5 rounded-full text-xs font-semibold border ${healthBadge(s.siteHealth)}`}
+                  >
+                    {s.siteHealth || 'N/A'}
+                  </span>
+                </td>
+                <td className="px-4 py-2 whitespace-nowrap text-xs text-gray-700">
+                  {s.serverInUse || dash}
+                </td>
+                <td className="px-4 py-2 whitespace-nowrap text-xs text-gray-700">{s.status}</td>
+                <td className="px-4 py-2 text-xs text-gray-500 max-w-xs truncate" title={s.notes}>
+                  {s.notes}
+                </td>
+              </tr>
+            )
+          })}
         </tbody>
       </table>
     </div>

--- a/src/app/sites-list/page.tsx
+++ b/src/app/sites-list/page.tsx
@@ -4,7 +4,14 @@ import DomainExpiry from './DomainExpiry'
 import NonprofitCallout from '@/components/NonprofitCallout'
 import { loadDomainExpiry } from '@/lib/dashboardData'
 import { ViewNav } from './PersonaView'
-import { SiteData, loadSites, dataRefreshedAge, healthBadge, healthCategory } from './sitesData'
+import {
+  SiteData,
+  loadSites,
+  dataRefreshedAge,
+  healthBadge,
+  healthCategory,
+  cloudflareZoneUrl,
+} from './sitesData'
 
 export const metadata: Metadata = {
   title: 'Sites Master List',
@@ -126,6 +133,18 @@ function TierTable({ sites, num }: { sites: SiteData[]; num: string }) {
                 >
                   {s.domain}
                 </a>
+                {cloudflareZoneUrl(s) && (
+                  <a
+                    href={cloudflareZoneUrl(s)}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="ml-2 inline-flex items-center text-xs text-orange-600 hover:underline"
+                    title={`Open ${s.domain} in the Cloudflare dashboard`}
+                  >
+                    <span aria-hidden="true">☁</span>
+                    <span className="ml-0.5">CF</span>
+                  </a>
+                )}
               </td>
               {showRepoCols && (
                 <>

--- a/src/app/sites-list/sitesData.ts
+++ b/src/app/sites-list/sitesData.ts
@@ -44,8 +44,9 @@ export const FFC_CLOUDFLARE_ACCOUNT_ID = '0fa33828a8a294ba7c3e945cec827f12'
 // Quick-link to a domain's Cloudflare zone overview, when FFC manages its DNS.
 // Returns '' when the site isn't in FFC Cloudflare (no useful destination).
 export function cloudflareZoneUrl(s: Pick<SiteData, 'domain' | 'inCloudflare'>): string {
-  if ((s.inCloudflare || '').toLowerCase() !== 'yes' || !s.domain) return ''
-  return `https://dash.cloudflare.com/${FFC_CLOUDFLARE_ACCOUNT_ID}/${s.domain}`
+  const domain = (s.domain || '').trim()
+  if ((s.inCloudflare || '').toLowerCase() !== 'yes' || !domain) return ''
+  return `https://dash.cloudflare.com/${FFC_CLOUDFLARE_ACCOUNT_ID}/${encodeURIComponent(domain)}`
 }
 
 export function derivedLeftFfc(r: Record<string, string>): boolean {

--- a/src/app/sites-list/sitesData.ts
+++ b/src/app/sites-list/sitesData.ts
@@ -37,6 +37,17 @@ export interface SiteData {
 
 export const HARD_DEAD = ['expired', 'cancelled', 'fraud', 'terminated']
 
+// FFC's Cloudflare account ID — a non-secret identifier used to build dashboard
+// deep-links. The per-zone overview lives at dash.cloudflare.com/<account>/<domain>.
+export const FFC_CLOUDFLARE_ACCOUNT_ID = '0fa33828a8a294ba7c3e945cec827f12'
+
+// Quick-link to a domain's Cloudflare zone overview, when FFC manages its DNS.
+// Returns '' when the site isn't in FFC Cloudflare (no useful destination).
+export function cloudflareZoneUrl(s: Pick<SiteData, 'domain' | 'inCloudflare'>): string {
+  if ((s.inCloudflare || '').toLowerCase() !== 'yes' || !s.domain) return ''
+  return `https://dash.cloudflare.com/${FFC_CLOUDFLARE_ACCOUNT_ID}/${s.domain}`
+}
+
 export function derivedLeftFfc(r: Record<string, string>): boolean {
   return (
     (r['Status'] || '').toLowerCase() === 'transferred away' &&


### PR DESCRIPTION
## Summary

Delivers the **quick-action links** sub-task from #187 (FFC Technical Team dashboard) for the Sites List.

Every site row that FFC manages in Cloudflare (`In Cloudflare = Yes`) now shows a compact **☁ CF** link next to the domain that opens that domain's Cloudflare zone overview directly:

```
https://dash.cloudflare.com/0fa33828a8a294ba7c3e945cec827f12/<domain>
```

This is the genuinely new capability the issue asked for — one click from the operational dashboard to the right Cloudflare zone, on every tier table (and the "Left FFC" table). The **GitHub repo** quick-link already exists in the dev tiers via `Repo URL`. The **WHMCS billing** deep-link is intentionally omitted — the admin host and service IDs are sensitive and shouldn't be exposed on the public page.

## Implementation
- `src/app/sites-list/sitesData.ts` — adds `FFC_CLOUDFLARE_ACCOUNT_ID` (a non-secret identifier) and `cloudflareZoneUrl(site)`, which returns the per-zone URL only when the site is in FFC Cloudflare and has a domain.
- `src/app/sites-list/page.tsx` — renders the `☁ CF` link in the Domain cell of `TierTable`, shown across all tiers.
- `__tests__/sites-data-cloudflare-link.test.ts` — covers the URL shape, case-insensitive flag, and the empty-string cases (not in CF / no domain).

Type-check, lint, and build clean. **405 tests passing.**

## Scope note
The remaining #187 sub-tasks (Cloudflare ops automation, GSC/DNS, WHMCS billing deep-links, marketing-repo data) are blocked on external systems and aren't buildable in this static repo; this PR ships the part that is.

Refs #187.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X4omPQW2ErDyZsMtxypuMe)_