### PR TITLE
feat: sites list row quick-actions, data signals, and refresh diff

### DIFF
--- a/.github/workflows/update-sites-data.yml
+++ b/.github/workflows/update-sites-data.yml
@@ -38,6 +38,11 @@ jobs:
             echo "fetched=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          # Keep the outgoing snapshot so the Sites List can highlight rows
+          # that changed between refreshes (#425).
+          if [ -f docs/sites_list.csv ]; then
+            cp docs/sites_list.csv docs/sites_list.prev.csv
+          fi
           mv "$tmp/sites_list.csv" docs/sites_list.csv
           mv "$tmp/sites_list.json" docs/sites_list.json
           echo "fetched=true" >> "$GITHUB_OUTPUT"

--- a/__tests__/sites-data-helpers.test.ts
+++ b/__tests__/sites-data-helpers.test.ts
@@ -1,0 +1,166 @@
+import {
+  cloudflareDnsRecordsUrl,
+  dnsCheckerUrl,
+  pagesSettingsUrl,
+  newIssueUrl,
+  rowMarkdown,
+  migrationSteps,
+  diffSummary,
+  daysUntil,
+  sslBadge,
+  lighthouseBadge,
+  dataGeneratedAt,
+  dataIsStale,
+  FFC_CLOUDFLARE_ACCOUNT_ID,
+} from '../src/app/sites-list/sitesData'
+
+describe('per-row quick-action links (#410, #411, #423)', () => {
+  it('builds the cloudflare dns-records url for sites in cloudflare', () => {
+    expect(cloudflareDnsRecordsUrl({ domain: 'example.org', inCloudflare: 'Yes' })).toBe(
+      `https://dash.cloudflare.com/${FFC_CLOUDFLARE_ACCOUNT_ID}/example.org/dns/records`
+    )
+    expect(cloudflareDnsRecordsUrl({ domain: 'example.org', inCloudflare: 'No' })).toBe('')
+  })
+
+  it('builds a dns checker url', () => {
+    expect(dnsCheckerUrl('example.org')).toBe('https://dnschecker.org/#A/example.org')
+    expect(dnsCheckerUrl('')).toBe('')
+  })
+
+  it('links pages settings only for github pages sites with a repo', () => {
+    const repoUrl = 'https://github.com/FreeForCharity/FFC-EX-example.org'
+    expect(pagesSettingsUrl({ repoUrl, serverInUse: 'GitHub Pages' })).toBe(
+      `${repoUrl}/settings/pages`
+    )
+    expect(pagesSettingsUrl({ repoUrl, serverInUse: 'HostPapa' })).toBe('')
+    expect(pagesSettingsUrl({ repoUrl: '', serverInUse: 'GitHub Pages' })).toBe('')
+  })
+
+  it('prefills the new-issue link, preferring the site repo', () => {
+    const site = {
+      domain: 'example.org',
+      repoUrl: 'https://github.com/FreeForCharity/FFC-EX-example.org',
+      workTier: '3 - Needs Migration',
+      siteHealth: 'Live',
+      serverInUse: 'HostPapa',
+    }
+    const url = newIssueUrl(site)
+    expect(url).toContain(`${site.repoUrl}/issues/new?title=`)
+    expect(url).toContain(encodeURIComponent('[example.org] '))
+    expect(decodeURIComponent(url)).toContain('Work tier: 3 - Needs Migration')
+    const noRepo = newIssueUrl({ ...site, repoUrl: '' })
+    expect(noRepo).toContain('FFC-IN-ffcadmin.org/issues/new')
+  })
+})
+
+describe('copy-row markdown (#409)', () => {
+  it('summarizes the row on a single line', () => {
+    const md = rowMarkdown({
+      domain: 'example.org',
+      workTier: '3 - Needs Migration',
+      siteHealth: 'Live',
+      serverInUse: 'HostPapa',
+      repoUrl: 'https://github.com/FreeForCharity/FFC-EX-example.org',
+    })
+    expect(md).toContain('**example.org**')
+    expect(md).toContain('tier: 3 - Needs Migration')
+    expect(md).toContain('repo: https://github.com/FreeForCharity/FFC-EX-example.org')
+    expect(md).not.toContain('\n')
+  })
+})
+
+describe('migration progress (#424)', () => {
+  it('derives the four steps from existing fields', () => {
+    const steps = migrationSteps({
+      inCloudflare: 'Yes',
+      repoUrl: 'https://github.com/x/y',
+      serverInUse: 'GitHub Pages',
+      siteHealth: 'Live',
+    })
+    expect(steps).toHaveLength(4)
+    expect(steps.every((s) => s.done)).toBe(true)
+  })
+
+  it('marks pending steps for an unmigrated site', () => {
+    const steps = migrationSteps({
+      inCloudflare: 'Yes',
+      repoUrl: '',
+      serverInUse: 'HostPapa',
+      siteHealth: 'Live',
+    })
+    expect(steps.filter((s) => s.done)).toHaveLength(2)
+  })
+})
+
+describe('refresh diff (#425)', () => {
+  it('summarizes field movement between snapshots', () => {
+    const prev = {
+      'Site Health': 'Live',
+      Status: 'Active',
+      'Work Tier': '3',
+      'Server In Use': 'HostPapa',
+    }
+    const curr = {
+      'Site Health': 'Error',
+      Status: 'Active',
+      'Work Tier': '3',
+      'Server In Use': 'HostPapa',
+    }
+    expect(diffSummary(prev, curr)).toBe('Health: Live → Error')
+  })
+
+  it('flags domains new since the last refresh', () => {
+    expect(diffSummary(undefined, { Domain: 'new.org' })).toBe('New since last refresh')
+  })
+
+  it('returns empty when nothing the team cares about changed', () => {
+    const rec = {
+      'Site Health': 'Live',
+      Status: 'Active',
+      'Work Tier': '4',
+      'Server In Use': 'GitHub Pages',
+    }
+    expect(diffSummary(rec, { ...rec })).toBe('')
+  })
+})
+
+describe('optional data-signal badges (#418, #421)', () => {
+  it('computes days until a date', () => {
+    const in20Days = new Date(Date.now() + 20 * 86_400_000).toISOString()
+    expect(daysUntil(in20Days)).toBeGreaterThanOrEqual(19)
+    expect(daysUntil('')).toBeNull()
+    expect(daysUntil('not a date')).toBeNull()
+  })
+
+  it('colors ssl expiry by urgency', () => {
+    const soon = new Date(Date.now() + 5 * 86_400_000).toISOString()
+    const later = new Date(Date.now() + 90 * 86_400_000).toISOString()
+    expect(sslBadge(soon)).toContain('red')
+    expect(sslBadge(later)).toContain('green')
+    expect(sslBadge('')).toContain('gray')
+  })
+
+  it('colors lighthouse scores by standard thresholds', () => {
+    expect(lighthouseBadge(95)).toContain('green')
+    expect(lighthouseBadge(70)).toContain('yellow')
+    expect(lighthouseBadge(30)).toContain('red')
+  })
+})
+
+describe('snapshot freshness (#416)', () => {
+  it('dates the snapshot by the newest activity it recorded', () => {
+    const sites = [
+      { lastCommit: '2026-06-01', lastPrClosed: '2026-06-08' },
+      { lastCommit: '2026-05-20', lastPrClosed: '' },
+    ]
+    expect(dataGeneratedAt(sites)).toBe('2026-06-08')
+  })
+
+  it('flags stale snapshots and trusts fresh ones', () => {
+    const old = [{ lastCommit: '2020-01-01', lastPrClosed: '' }]
+    const fresh = [{ lastCommit: new Date().toISOString().slice(0, 10), lastPrClosed: '' }]
+    expect(dataIsStale(old)).toBe(true)
+    expect(dataIsStale(fresh)).toBe(false)
+    expect(dataIsStale([{ lastCommit: '', lastPrClosed: '' }])).toBe(false)
+  })
+})

--- a/docs/data-contracts.md
+++ b/docs/data-contracts.md
@@ -116,3 +116,25 @@ Dashboards must never crash on missing/stale data:
   awaiting-first-run placeholder.
 - **Stale `generatedAt`** (older than the cadence above) → the dashboard shows a
   "may be out of date" note alongside the data.
+
+## `docs/sites_list.csv` — optional enrichment columns (#418–#421, #425)
+
+The Sites List reads these **optional** columns when the upstream
+`FFC-Cloudflare-Automation` generator emits them, and renders nothing when it
+doesn't (no empty columns):
+
+| Column            | Shape        | Renders as                                        |
+| ----------------- | ------------ | ------------------------------------------------- |
+| `SSL Expiry`      | ISO date     | Badge (red ≤ 14 days, amber ≤ 30, green beyond)   |
+| `NS Match`        | `Yes` / `No` | ⚠ NS flag next to the domain when `No`            |
+| `Redirect Target` | URL          | "→ target" detail under the Redirect health badge |
+| `Lighthouse`      | 0–100        | Badge (green ≥ 90, amber ≥ 50, red below)         |
+
+**Refresh diff:** `update-sites-data.yml` copies the outgoing snapshot to
+`docs/sites_list.prev.csv` before overwriting. At build time the page compares
+Health/Status/Tier/Server per domain and marks changed rows with a Δ badge.
+When no `.prev.csv` exists yet, diffing silently does nothing.
+
+**Owners:** `src/data/site-owners.ts` (this repo) maps lowercase domain →
+GitHub handle or display name; an Owner column appears in any tier table where
+at least one row is mapped.

--- a/src/app/sites-list/CopyRowButton.tsx
+++ b/src/app/sites-list/CopyRowButton.tsx
@@ -1,0 +1,30 @@
+'use client'
+
+import { useState } from 'react'
+
+/**
+ * Copies a server-prepared Markdown summary of a site row to the clipboard
+ * (#409). Tiny client island inside the otherwise server-rendered tables.
+ */
+export default function CopyRowButton({ text, domain }: { text: string; domain: string }) {
+  const [copied, setCopied] = useState(false)
+  return (
+    <button
+      type="button"
+      onClick={async () => {
+        try {
+          await navigator.clipboard.writeText(text)
+          setCopied(true)
+          setTimeout(() => setCopied(false), 1500)
+        } catch {
+          // Clipboard unavailable (permissions/non-secure context) — no-op.
+        }
+      }}
+      aria-label={`Copy ${domain} row as Markdown`}
+      title={`Copy ${domain} row as Markdown`}
+      className="text-gray-400 hover:text-gray-700 hover:underline"
+    >
+      {copied ? '✓ copied' : '⧉ copy'}
+    </button>
+  )
+}

--- a/src/app/sites-list/PersonaView.tsx
+++ b/src/app/sites-list/PersonaView.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link'
-import { SiteData, healthBadge } from './sitesData'
+import { SiteData, healthBadge, migrationSteps } from './sitesData'
 
 const VIEWS = [
   { href: '/sites-list', label: 'Overview', icon: '📋' },
@@ -28,7 +28,7 @@ export function ViewNav({ current }: { current: string }) {
   )
 }
 
-type Col = 'host' | 'wp' | 'age' | 'repo' | 'lastPr' | 'staging'
+type Col = 'host' | 'wp' | 'age' | 'repo' | 'lastPr' | 'staging' | 'progress'
 
 export function PersonaView({
   href,
@@ -60,6 +60,7 @@ export function PersonaView({
     repo: 'Repo',
     lastPr: 'Last PR',
     staging: 'Staging',
+    progress: 'Progress',
   }
   const dash = <span className="text-gray-300">—</span>
   const cell = (s: SiteData, c: Col) => {
@@ -87,6 +88,19 @@ export function PersonaView({
         return s.lastPrClosed || dash
       case 'staging':
         return s.isStaging === 'Yes' ? '🧪' : dash
+      case 'progress': {
+        const steps = migrationSteps(s)
+        const done = steps.filter((x) => x.done).length
+        return (
+          <span title={steps.map((x) => `${x.done ? '✓' : '○'} ${x.label}`).join('\n')}>
+            <span aria-hidden="true" className="tracking-widest text-ffc-teal-dark">
+              {steps.map((x) => (x.done ? '●' : '○')).join('')}
+            </span>
+            <span className="sr-only">{`${done} of ${steps.length} migration steps complete`}</span>
+            <span className="ml-1 text-[11px] text-gray-500 tabular-nums">{done}/4</span>
+          </span>
+        )
+      }
     }
   }
 

--- a/src/app/sites-list/migration/page.tsx
+++ b/src/app/sites-list/migration/page.tsx
@@ -17,7 +17,7 @@ export default function MigrationView() {
       accent="from-blue-600 to-indigo-600"
       sites={loadSites()}
       score={(s) => s.migrationScore}
-      columns={['host', 'wp', 'age']}
+      columns={['host', 'wp', 'age', 'progress']}
       refreshed={dataRefreshedAge()}
     />
   )

--- a/src/app/sites-list/page.tsx
+++ b/src/app/sites-list/page.tsx
@@ -2,8 +2,10 @@ import { Metadata } from 'next'
 import HealthDashboard from './HealthDashboard'
 import DomainExpiry from './DomainExpiry'
 import NonprofitCallout from '@/components/NonprofitCallout'
-import { loadDomainExpiry } from '@/lib/dashboardData'
+import { loadDomainExpiry, relativeAge } from '@/lib/dashboardData'
+import { isGithubHandle } from '@/data/site-owners'
 import { ViewNav } from './PersonaView'
+import CopyRowButton from './CopyRowButton'
 import {
   SiteData,
   loadSites,
@@ -11,6 +13,16 @@ import {
   healthBadge,
   healthCategory,
   cloudflareZoneUrl,
+  cloudflareDnsRecordsUrl,
+  dnsCheckerUrl,
+  pagesSettingsUrl,
+  newIssueUrl,
+  rowMarkdown,
+  migrationSteps,
+  sslBadge,
+  lighthouseBadge,
+  dataGeneratedAt,
+  dataIsStale,
 } from './sitesData'
 
 export const metadata: Metadata = {
@@ -98,12 +110,97 @@ function repoName(url: string): string {
   return url.replace('https://github.com/', '')
 }
 
+// Data source per column, surfaced as header tooltips and in the legend (#417).
+const COLUMN_SOURCE: Record<string, string> = {
+  Domain: 'WHMCS export (domain inventory)',
+  Repo: 'GitHub API',
+  'Last PR': 'GitHub API',
+  'Open PRs': 'GitHub API',
+  Health: 'HTTP health probe',
+  SSL: 'TLS probe (upstream pipeline)',
+  LH: 'Lighthouse CI (upstream pipeline)',
+  Owner: 'src/data/site-owners.ts in this repo',
+  Progress: 'Derived from Cloudflare, repo, server, and health fields',
+  Server: 'HTTP health probe / host detection',
+  Status: 'WHMCS export',
+  Notes: 'WHMCS export',
+}
+
+// Compact per-row quick-action links under the domain (#408, #410, #411, #423).
+function RowActions({ s, showRepoLink }: { s: SiteData; showRepoLink: boolean }) {
+  const action = (href: string, label: string, title: string) => (
+    <a
+      key={label}
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      title={title}
+      aria-label={title}
+      className="text-gray-500 hover:text-gray-800 hover:underline"
+    >
+      {label}
+    </a>
+  )
+  const cf = cloudflareZoneUrl(s)
+  const dnsRecords = cloudflareDnsRecordsUrl(s)
+  const actions = [
+    cf && action(cf, '☁ CF', `Open ${s.domain} in the Cloudflare dashboard`),
+    dnsRecords && action(dnsRecords, 'DNS', `Cloudflare DNS records for ${s.domain}`),
+    action(dnsCheckerUrl(s.domain), 'check', `DNS propagation check for ${s.domain}`),
+    showRepoLink &&
+      s.repoUrl &&
+      action(
+        s.repoUrl,
+        s.openPrs && s.openPrs !== '0' ? `repo (${s.openPrs} PRs)` : 'repo',
+        `GitHub repository: ${repoName(s.repoUrl)}`
+      ),
+    pagesSettingsUrl(s) &&
+      action(pagesSettingsUrl(s), 'pages', `GitHub Pages settings for ${s.domain}`),
+    action(newIssueUrl(s), '+issue', `Open a prefilled GitHub issue about ${s.domain}`),
+  ].filter(Boolean)
+  return (
+    <div className="mt-0.5 flex flex-wrap gap-x-2 gap-y-0.5 text-[11px] leading-4">
+      {actions}
+      <CopyRowButton text={rowMarkdown(s)} domain={s.domain} />
+    </div>
+  )
+}
+
+// 4-step migration progress dots, derived from existing fields (#424).
+function MigrationProgress({ s }: { s: SiteData }) {
+  const steps = migrationSteps(s)
+  const done = steps.filter((x) => x.done).length
+  return (
+    <span title={steps.map((x) => `${x.done ? '✓' : '○'} ${x.label}`).join('\n')}>
+      <span aria-hidden="true" className="tracking-widest text-ffc-teal-dark">
+        {steps.map((x) => (x.done ? '●' : '○')).join('')}
+      </span>
+      <span className="sr-only">{`${done} of ${steps.length} migration steps complete`}</span>
+      <span className="ml-1 text-[11px] text-gray-500 tabular-nums">{done}/4</span>
+    </span>
+  )
+}
+
 function TierTable({ sites, num }: { sites: SiteData[]; num: string }) {
   // Dev tiers (1, 2) lead with repo activity; other tiers hide those columns.
   const showRepoCols = num === '1' || num === '2'
-  const headers = showRepoCols
-    ? ['Domain', 'Repo', 'Last PR', 'Open PRs', 'Health', 'Server', 'Status', 'Notes']
-    : ['Domain', 'Health', 'Server', 'Status', 'Notes']
+  // Optional data-signal columns render only when the snapshot carries data.
+  const hasSsl = sites.some((s) => s.sslExpiry)
+  const hasLh = sites.some((s) => s.lighthouse)
+  const hasOwner = sites.some((s) => s.owner)
+  const showProgress = num === '3'
+  const headers = [
+    'Domain',
+    ...(showRepoCols ? ['Repo', 'Last PR', 'Open PRs'] : []),
+    'Health',
+    ...(hasSsl ? ['SSL'] : []),
+    ...(hasLh ? ['LH'] : []),
+    ...(hasOwner ? ['Owner'] : []),
+    ...(showProgress ? ['Progress'] : []),
+    'Server',
+    'Status',
+    'Notes',
+  ]
   const dash = <span className="text-gray-300">—</span>
   return (
     <div className="overflow-x-auto">
@@ -114,6 +211,7 @@ function TierTable({ sites, num }: { sites: SiteData[]; num: string }) {
               <th
                 key={h}
                 scope="col"
+                title={COLUMN_SOURCE[h] ? `Source: ${COLUMN_SOURCE[h]}` : undefined}
                 className="px-4 py-2 text-left text-xs font-bold uppercase tracking-wider text-gray-500"
               >
                 {h}
@@ -123,31 +221,37 @@ function TierTable({ sites, num }: { sites: SiteData[]; num: string }) {
         </thead>
         <tbody className="bg-white divide-y divide-gray-100">
           {sites.map((s) => {
-            const cfUrl = cloudflareZoneUrl(s)
             return (
               <tr key={`${num}-${s.domain}`} className="hover:bg-gray-50">
                 <td className="px-4 py-2 whitespace-nowrap font-medium">
-                  <a
-                    href={`https://${s.domain}`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-blue-600 hover:underline"
-                  >
-                    {s.domain}
-                  </a>
-                  {cfUrl && (
+                  <div className="flex items-center gap-1.5">
                     <a
-                      href={cfUrl}
+                      href={`https://${s.domain}`}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="ml-2 inline-flex items-center text-xs text-orange-600 hover:underline"
-                      aria-label={`Open ${s.domain} in the Cloudflare dashboard`}
-                      title={`Open ${s.domain} in the Cloudflare dashboard`}
+                      className="text-blue-600 hover:underline"
                     >
-                      <span aria-hidden="true">☁</span>
-                      <span className="ml-0.5">CF</span>
+                      {s.domain}
                     </a>
-                  )}
+                    {s.nsMatch.toLowerCase() === 'no' && (
+                      <span
+                        title="Live nameservers do not match Cloudflare"
+                        className="px-1.5 py-0.5 rounded text-[11px] font-semibold bg-red-100 text-red-700 border border-red-200"
+                      >
+                        <span aria-hidden="true">⚠ </span>NS
+                      </span>
+                    )}
+                    {s.changed && (
+                      <span
+                        title={s.changed}
+                        className="px-1.5 py-0.5 rounded text-[11px] font-semibold bg-purple-100 text-purple-700 border border-purple-200"
+                      >
+                        Δ
+                        <span className="sr-only">{` Changed since last refresh: ${s.changed}`}</span>
+                      </span>
+                    )}
+                  </div>
+                  <RowActions s={s} showRepoLink={!showRepoCols} />
                 </td>
                 {showRepoCols && (
                   <>
@@ -180,7 +284,68 @@ function TierTable({ sites, num }: { sites: SiteData[]; num: string }) {
                   >
                     {s.siteHealth || 'N/A'}
                   </span>
+                  {s.redirectTarget && (
+                    <p
+                      className="mt-0.5 text-[11px] text-gray-500 max-w-[12rem] truncate"
+                      title={`Redirects to ${s.redirectTarget}`}
+                    >
+                      → {s.redirectTarget}
+                    </p>
+                  )}
                 </td>
+                {hasSsl && (
+                  <td className="px-4 py-2 whitespace-nowrap text-xs">
+                    {s.sslExpiry ? (
+                      <span
+                        className={`px-2 py-0.5 rounded-full text-xs font-semibold border ${sslBadge(s.sslExpiry)}`}
+                        title={`TLS certificate expires ${s.sslExpiry}`}
+                      >
+                        {s.sslExpiry}
+                      </span>
+                    ) : (
+                      dash
+                    )}
+                  </td>
+                )}
+                {hasLh && (
+                  <td className="px-4 py-2 whitespace-nowrap text-xs">
+                    {s.lighthouse ? (
+                      <span
+                        className={`px-2 py-0.5 rounded-full text-xs font-semibold border ${lighthouseBadge(Number(s.lighthouse))}`}
+                        title={`Lighthouse score ${s.lighthouse}/100`}
+                      >
+                        {s.lighthouse}
+                      </span>
+                    ) : (
+                      dash
+                    )}
+                  </td>
+                )}
+                {hasOwner && (
+                  <td className="px-4 py-2 whitespace-nowrap text-xs">
+                    {s.owner ? (
+                      isGithubHandle(s.owner) ? (
+                        <a
+                          href={`https://github.com/${s.owner}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-indigo-600 hover:underline"
+                        >
+                          @{s.owner}
+                        </a>
+                      ) : (
+                        s.owner
+                      )
+                    ) : (
+                      dash
+                    )}
+                  </td>
+                )}
+                {showProgress && (
+                  <td className="px-4 py-2 whitespace-nowrap text-xs">
+                    <MigrationProgress s={s} />
+                  </td>
+                )}
                 <td className="px-4 py-2 whitespace-nowrap text-xs text-gray-700">
                   {s.serverInUse || dash}
                 </td>
@@ -237,6 +402,29 @@ export default function SitesListPage() {
 
       <div className="container mx-auto px-4 py-8">
         <ViewNav current="/sites-list" />
+
+        {/* Stale-data warning (#416): the snapshot can't be newer than the
+            newest GitHub activity it recorded, so an old max date means the
+            weekly sync likely failed. */}
+        {dataIsStale(sites) && (
+          <div
+            role="status"
+            className="mb-8 rounded-lg border border-amber-300 bg-amber-50 p-4 text-sm text-amber-900"
+          >
+            <span aria-hidden="true">⚠️ </span>
+            <strong>Site data may be stale.</strong> The newest activity in this snapshot is from{' '}
+            {dataGeneratedAt(sites)} ({relativeAge(dataGeneratedAt(sites))}). The weekly{' '}
+            <a
+              href="https://github.com/FreeForCharity/FFC-IN-ffcadmin.org/actions/workflows/update-sites-data.yml"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline hover:text-amber-700"
+            >
+              Sync Sites List Data
+            </a>{' '}
+            workflow may have failed.
+          </div>
+        )}
 
         {/* Volunteer guide */}
         <div className="bg-white p-6 rounded-lg shadow-md mb-8 border border-gray-200">
@@ -301,6 +489,48 @@ export default function SitesListPage() {
             </details>
           )
         })}
+
+        {/* Data provenance legend (#417) */}
+        <details className="mb-6 rounded-lg border border-gray-200 bg-white px-6 py-4 text-sm text-gray-700 shadow-md">
+          <summary className="cursor-pointer font-bold text-gray-900">
+            Where this data comes from
+          </summary>
+          <ul className="mt-3 space-y-1 list-disc pl-5">
+            <li>
+              <strong>WHMCS export</strong> — domain inventory, status, notes, expiry, recurring.
+            </li>
+            <li>
+              <strong>Cloudflare API</strong> — In Cloudflare, zone IPs (powers the ☁ CF and DNS
+              quick-links).
+            </li>
+            <li>
+              <strong>GitHub API</strong> — repo, last PR, open PRs, last commit, archived.
+            </li>
+            <li>
+              <strong>HTTP health probe</strong> — health badge, redirect detail, server detection.
+            </li>
+            <li>
+              <strong>Derived by the generator</strong> — work tiers, persona scores, migration
+              progress.
+            </li>
+            <li>
+              <strong>This repo</strong> — owners (<code>src/data/site-owners.ts</code>; PR a line
+              to claim a site).
+            </li>
+          </ul>
+          <p className="mt-3 text-xs text-gray-500">
+            Hover any column header for its source. Assembled weekly by the{' '}
+            <a
+              href="https://github.com/FreeForCharity/FFC-Cloudflare-Automation"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-600 underline hover:text-blue-800"
+            >
+              FFC-Cloudflare-Automation
+            </a>{' '}
+            generator; a Δ badge marks rows that changed since the previous refresh.
+          </p>
+        </details>
 
         {/* Supporting context */}
         <div className="mt-10">

--- a/src/app/sites-list/page.tsx
+++ b/src/app/sites-list/page.tsx
@@ -127,7 +127,7 @@ const COLUMN_SOURCE: Record<string, string> = {
 }
 
 // Compact per-row quick-action links under the domain (#408, #410, #411, #423).
-function RowActions({ s, showRepoLink }: { s: SiteData; showRepoLink: boolean }) {
+function RowActions({ s }: { s: SiteData }) {
   const action = (href: string, label: string, title: string) => (
     <a
       key={label}
@@ -147,8 +147,7 @@ function RowActions({ s, showRepoLink }: { s: SiteData; showRepoLink: boolean })
     cf && action(cf, '☁ CF', `Open ${s.domain} in the Cloudflare dashboard`),
     dnsRecords && action(dnsRecords, 'DNS', `Cloudflare DNS records for ${s.domain}`),
     action(dnsCheckerUrl(s.domain), 'check', `DNS propagation check for ${s.domain}`),
-    showRepoLink &&
-      s.repoUrl &&
+    s.repoUrl &&
       action(
         s.repoUrl,
         s.openPrs && s.openPrs !== '0' ? `repo (${s.openPrs} PRs)` : 'repo',
@@ -215,6 +214,9 @@ function TierTable({ sites, num }: { sites: SiteData[]; num: string }) {
                 className="px-4 py-2 text-left text-xs font-bold uppercase tracking-wider text-gray-500"
               >
                 {h}
+                {COLUMN_SOURCE[h] && (
+                  <span className="sr-only">{` (source: ${COLUMN_SOURCE[h]})`}</span>
+                )}
               </th>
             ))}
           </tr>
@@ -251,7 +253,7 @@ function TierTable({ sites, num }: { sites: SiteData[]; num: string }) {
                       </span>
                     )}
                   </div>
-                  <RowActions s={s} showRepoLink={!showRepoCols} />
+                  <RowActions s={s} />
                 </td>
                 {showRepoCols && (
                   <>

--- a/src/app/sites-list/sitesData.ts
+++ b/src/app/sites-list/sitesData.ts
@@ -2,6 +2,7 @@ import fs from 'fs'
 import path from 'path'
 import { parse } from 'csv-parse/sync'
 import { relativeAge } from '@/lib/dashboardData'
+import { SITE_OWNERS } from '@/data/site-owners'
 
 export interface SiteData {
   section: string
@@ -33,6 +34,16 @@ export interface SiteData {
   migrationScore: number
   maintenanceScore: number
   devScore: number
+  // Optional pipeline columns (#418–#421): empty until the upstream
+  // FFC-Cloudflare-Automation generator emits them; UI renders them
+  // only when present (see docs/data-contracts.md).
+  sslExpiry: string
+  nsMatch: string
+  redirectTarget: string
+  lighthouse: string
+  // Repo-maintained enrichment (#422) and refresh diff (#425).
+  owner: string
+  changed: string
 }
 
 export const HARD_DEAD = ['expired', 'cancelled', 'fraud', 'terminated']
@@ -82,14 +93,45 @@ export function coerceDeadTier(tier: string, r: Record<string, string>): string 
   return tier
 }
 
+function parseCsvFile(file: string): Record<string, string>[] {
+  const fileContent = fs.readFileSync(path.join(process.cwd(), 'docs', file), 'utf8')
+  return parse(fileContent, { columns: true, skip_empty_lines: true, trim: true })
+}
+
+// Previous snapshot, kept by update-sites-data.yml before each refresh (#425).
+// Returns null when no snapshot exists yet — diffing degrades to "no changes".
+function loadPrevSnapshot(): Map<string, Record<string, string>> | null {
+  try {
+    const records = parseCsvFile('sites_list.prev.csv')
+    return new Map(records.map((r) => [r['Domain'] || '', r]))
+  } catch {
+    return null
+  }
+}
+
+// Fields whose movement between refreshes the team cares about.
+const DIFF_FIELDS: [string, string][] = [
+  ['Site Health', 'Health'],
+  ['Status', 'Status'],
+  ['Work Tier', 'Tier'],
+  ['Server In Use', 'Server'],
+]
+
+/** Human summary of what changed for a domain since the previous snapshot, or ''. */
+export function diffSummary(
+  prev: Record<string, string> | undefined,
+  curr: Record<string, string>
+): string {
+  if (!prev) return 'New since last refresh'
+  const changes = DIFF_FIELDS.filter(([col]) => (prev[col] || '') !== (curr[col] || '')).map(
+    ([col, label]) => `${label}: ${prev[col] || '—'} → ${curr[col] || '—'}`
+  )
+  return changes.join('; ')
+}
+
 export function loadSites(): SiteData[] {
-  const filePath = path.join(process.cwd(), 'docs', 'sites_list.csv')
-  const fileContent = fs.readFileSync(filePath, 'utf8')
-  const records: Record<string, string>[] = parse(fileContent, {
-    columns: true,
-    skip_empty_lines: true,
-    trim: true,
-  })
+  const records = parseCsvFile('sites_list.csv')
+  const prev = loadPrevSnapshot()
   return records.map((r) => ({
     section: r['Section'] || '',
     domain: r['Domain'] || '',
@@ -119,6 +161,12 @@ export function loadSites(): SiteData[] {
     migrationScore: Number(r['Migration Score'] || 0),
     maintenanceScore: Number(r['Maintenance Score'] || 0),
     devScore: Number(r['Dev Score'] || 0),
+    sslExpiry: r['SSL Expiry'] || '',
+    nsMatch: r['NS Match'] || '',
+    redirectTarget: r['Redirect Target'] || '',
+    lighthouse: r['Lighthouse'] || '',
+    owner: SITE_OWNERS[(r['Domain'] || '').toLowerCase()] || '',
+    changed: prev ? diffSummary(prev.get(r['Domain'] || ''), r) : '',
   }))
 }
 
@@ -154,4 +202,132 @@ export function healthBadge(health: string): string {
     default:
       return 'text-gray-600 bg-gray-100 border-gray-200'
   }
+}
+
+// ---------------------------------------------------------------------------
+// Per-row quick-action links (#410, #411, #423)
+// ---------------------------------------------------------------------------
+
+/** Cloudflare DNS-records tab for the domain's zone, or '' when not in FFC Cloudflare. */
+export function cloudflareDnsRecordsUrl(s: Pick<SiteData, 'domain' | 'inCloudflare'>): string {
+  const zone = cloudflareZoneUrl(s)
+  return zone ? `${zone}/dns/records` : ''
+}
+
+/** Public DNS propagation checker for the domain's A record. */
+export function dnsCheckerUrl(domain: string): string {
+  const d = (domain || '').trim()
+  return d ? `https://dnschecker.org/#A/${encodeURIComponent(d)}` : ''
+}
+
+/** GitHub Pages settings for migrated sites — repo + served from GitHub Pages. */
+export function pagesSettingsUrl(s: Pick<SiteData, 'repoUrl' | 'serverInUse'>): string {
+  if (!s.repoUrl || !(s.serverInUse || '').toLowerCase().includes('github pages')) return ''
+  return `${s.repoUrl}/settings/pages`
+}
+
+const THIS_REPO = 'https://github.com/FreeForCharity/FFC-IN-ffcadmin.org'
+
+/** Prefilled new-issue link: the site's own repo when it has one, else this repo. */
+export function newIssueUrl(
+  s: Pick<SiteData, 'domain' | 'repoUrl' | 'workTier' | 'siteHealth' | 'serverInUse'>
+): string {
+  const repo = s.repoUrl || THIS_REPO
+  const title = encodeURIComponent(`[${s.domain}] `)
+  const body = encodeURIComponent(
+    `Domain: ${s.domain}\nWork tier: ${s.workTier}\nHealth: ${s.siteHealth || 'unknown'}\nServer: ${s.serverInUse || 'unknown'}\n\n(Filed from the FFC Sites List.)\n`
+  )
+  return `${repo}/issues/new?title=${title}&body=${body}`
+}
+
+/** Single-line Markdown summary of a row, for the copy quick-action (#409). */
+export function rowMarkdown(
+  s: Pick<SiteData, 'domain' | 'workTier' | 'siteHealth' | 'serverInUse' | 'repoUrl'>
+): string {
+  const parts = [
+    `**${s.domain}**`,
+    `tier: ${s.workTier}`,
+    `health: ${s.siteHealth || 'unknown'}`,
+    `server: ${s.serverInUse || 'unknown'}`,
+  ]
+  if (s.repoUrl) parts.push(`repo: ${s.repoUrl}`)
+  return parts.join(' — ')
+}
+
+// ---------------------------------------------------------------------------
+// Migration progress (#424) — derived entirely from existing CSV fields.
+// ---------------------------------------------------------------------------
+
+export interface MigrationStep {
+  label: string
+  done: boolean
+}
+
+export function migrationSteps(
+  s: Pick<SiteData, 'inCloudflare' | 'repoUrl' | 'serverInUse' | 'siteHealth'>
+): MigrationStep[] {
+  return [
+    { label: 'DNS in Cloudflare', done: (s.inCloudflare || '').toLowerCase() === 'yes' },
+    { label: 'GitHub repo created', done: Boolean(s.repoUrl) },
+    {
+      label: 'Served from GitHub Pages',
+      done: (s.serverInUse || '').toLowerCase().includes('github pages'),
+    },
+    { label: 'Site live', done: healthCategory(s.siteHealth) === 'live' },
+  ]
+}
+
+// ---------------------------------------------------------------------------
+// Optional data-signal badges (#418, #421)
+// ---------------------------------------------------------------------------
+
+/** Whole days until an ISO-ish date, or null when unparseable/empty. */
+export function daysUntil(dateStr: string): number | null {
+  if (!dateStr) return null
+  const t = Date.parse(dateStr)
+  if (Number.isNaN(t)) return null
+  return Math.floor((t - Date.now()) / 86_400_000)
+}
+
+/** Badge classes for an SSL-expiry date: red ≤ 14 days, amber ≤ 30, green beyond. */
+export function sslBadge(dateStr: string): string {
+  const days = daysUntil(dateStr)
+  if (days === null) return 'text-gray-600 bg-gray-100 border-gray-200'
+  if (days <= 14) return 'text-red-700 bg-red-100 border-red-200'
+  if (days <= 30) return 'text-yellow-700 bg-yellow-100 border-yellow-200'
+  return 'text-green-700 bg-green-100 border-green-200'
+}
+
+/** Badge classes for a 0–100 Lighthouse score (standard LH thresholds). */
+export function lighthouseBadge(score: number): string {
+  if (score >= 90) return 'text-green-700 bg-green-100 border-green-200'
+  if (score >= 50) return 'text-yellow-700 bg-yellow-100 border-yellow-200'
+  return 'text-red-700 bg-red-100 border-red-200'
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot freshness (#416). File mtime is useless in CI (fresh clone), so we
+// date the snapshot by the newest GitHub-activity timestamp the generator
+// captured — the data can't know about anything after it was generated.
+// ---------------------------------------------------------------------------
+
+export function dataGeneratedAt(sites: Pick<SiteData, 'lastCommit' | 'lastPrClosed'>[]): string {
+  let max = ''
+  for (const s of sites) {
+    for (const d of [s.lastCommit, s.lastPrClosed]) {
+      if (d && !Number.isNaN(Date.parse(d)) && d > max) max = d
+    }
+  }
+  return max
+}
+
+export const SNAPSHOT_STALE_DAYS = 8 // weekly sync cadence + 1 day of grace
+
+export function dataIsStale(
+  sites: Pick<SiteData, 'lastCommit' | 'lastPrClosed'>[],
+  maxDays: number = SNAPSHOT_STALE_DAYS
+): boolean {
+  const newest = dataGeneratedAt(sites)
+  if (!newest) return false // no signal — don't cry wolf
+  return Date.now() - Date.parse(newest) > maxDays * 86_400_000
 }

--- a/src/data/site-owners.ts
+++ b/src/data/site-owners.ts
@@ -1,0 +1,18 @@
+/**
+ * Owner / assignee mapping for FFC-managed sites (#422).
+ *
+ * Keyed by apex domain (exactly as it appears in docs/sites_list.csv).
+ * Values are GitHub usernames (preferred — rendered as a profile link)
+ * or a plain display name.
+ *
+ * To claim or assign a site, add a line here and open a PR.
+ */
+export const SITE_OWNERS: Record<string, string> = {
+  'ffcadmin.org': 'clarkemoyer',
+  'freeforcharity.org': 'clarkemoyer',
+}
+
+/** Looks like a GitHub handle (no spaces) — linkable to a profile. */
+export function isGithubHandle(owner: string): boolean {
+  return /^[A-Za-z0-9-]+$/.test(owner)
+}

--- a/src/data/site-owners.ts
+++ b/src/data/site-owners.ts
@@ -1,9 +1,9 @@
 /**
  * Owner / assignee mapping for FFC-managed sites (#422).
  *
- * Keyed by apex domain (exactly as it appears in docs/sites_list.csv).
- * Values are GitHub usernames (preferred — rendered as a profile link)
- * or a plain display name.
+ * Keyed by apex domain in lowercase (lookups lowercase the CSV domain,
+ * so a mixed-case key would never match). Values are GitHub usernames
+ * (preferred — rendered as a profile link) or a plain display name.
  *
  * To claim or assign a site, add a line here and open a PR.
  */


### PR DESCRIPTION
## Summary

Batch 1 of the Sites List improvement track (20 issues filed from #187): everything that enriches the **rows themselves**, all server-rendered.

**Quick-actions cluster** under every domain (all tiers + "Left FFC" table): ☁ CF zone, Cloudflare **DNS records**, public **DNS propagation check**, **repo** (with open-PR count on non-dev tiers), **GitHub Pages settings** (migrated sites only), prefilled **+issue**, and a client-side **⧉ copy** (row as one-line Markdown).

**Data signals:**
- ⚠ NS flag and Δ changed-since-last-refresh badge next to the domain; redirect rows show their destination under the health badge.
- Conditional **SSL**, **Lighthouse**, and **Owner** columns that appear only when data exists — SSL/NS/redirect/Lighthouse are optional pipeline columns (contract documented in `docs/data-contracts.md`); Owner comes from the new `src/data/site-owners.ts` (PR a line to claim a site).
- **Migration progress** ●●○○ (DNS in Cloudflare → repo → GitHub Pages → live), derived entirely from existing fields, on Tier 3 and the Migration persona view.
- **Stale-data banner** when the snapshot's newest recorded activity is > 8 days old (file mtime is meaningless in CI, so freshness is derived from the data itself).
- **Provenance**: every column header tooltips its data source; a "Where this data comes from" legend sits below the tables.

**Pipeline:** `update-sites-data.yml` now preserves the outgoing CSV as `docs/sites_list.prev.csv` so the build can diff refreshes.

Tests: 15 new helper tests (quick-links, markdown, migration steps, diff, badges, freshness). **420 passing**, type-check/lint/build clean.

Fixes #408. Fixes #409. Fixes #410. Fixes #411. Fixes #416. Fixes #417. Fixes #418. Fixes #419. Fixes #420. Fixes #421. Fixes #422. Fixes #423. Fixes #424. Fixes #425.

Refs #187.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X4omPQW2ErDyZsMtxypuMe)_