### PR TITLE
feat: high-fidelity charity onboarding path + accept-invitation walkthrough

### DIFF
--- a/__tests__/charity-onboarding.test.js
+++ b/__tests__/charity-onboarding.test.js
@@ -1,0 +1,73 @@
+/**
+ * Charity onboarding journey (#site-owner): the high-fidelity invitation
+ * walkthrough and its discoverability across nav, footer, homepage, and the
+ * site-owner landing.
+ */
+const fs = require('fs')
+const path = require('path')
+
+const read = (p) => fs.readFileSync(path.join(__dirname, '..', p), 'utf8')
+
+describe('Accept-invitation walkthrough page', () => {
+  const page = read('src/app/site-owner/accept-invitation/page.tsx')
+
+  it('exists and is self-canonical', () => {
+    expect(page).toContain('https://ffcadmin.org/site-owner/accept-invitation/')
+  })
+
+  it('identifies who the email is from and its subject', () => {
+    expect(page).toContain('notifications@github.com')
+    expect(page).toContain('invited you to collaborate')
+  })
+
+  it('corrects the notifications-page misconception (the 2-hour problem)', () => {
+    expect(page).toContain('github.com/notifications')
+    expect(page.toLowerCase()).toContain('does')
+    expect(page.toLowerCase()).toContain('not')
+  })
+
+  it('documents all three acceptance routes', () => {
+    expect(page).toContain('Accept from the email')
+    expect(page).toContain('Accept from your repository page')
+    expect(page).toContain('/invitations')
+  })
+
+  it('warns about being signed in as the right account', () => {
+    expect(page.toLowerCase()).toContain('right')
+    expect(page.toLowerCase()).toContain('account')
+    expect(page).toContain('top-right')
+  })
+})
+
+describe('Onboarding discoverability', () => {
+  it('is a prominent nav button (desktop + mobile)', () => {
+    const nav = read('src/components/Navigation.tsx')
+    expect(nav).toContain('/site-owner')
+    // CTA button styling, not a plain text link
+    expect(nav).toContain('from-emerald-500 to-teal-600')
+  })
+
+  it('has a footer CTA linking the landing and the invitation walkthrough', () => {
+    const footer = read('src/components/Footer.tsx')
+    expect(footer).toContain('/site-owner/accept-invitation')
+    expect(footer).toContain('/site-owner')
+  })
+
+  it('is spotlighted on the homepage', () => {
+    const home = read('src/app/page.tsx')
+    expect(home).toContain('/site-owner/accept-invitation')
+  })
+
+  it('the site-owner landing shows the complete linear path and links the walkthrough', () => {
+    const landing = read('src/app/site-owner/page.tsx')
+    expect(landing).toContain('Your complete path, in order')
+    expect(landing).toContain('/site-owner/accept-invitation')
+    expect(landing).toContain('/guides/github-account')
+    expect(landing).toContain('/guides/multi-factor-authentication')
+  })
+
+  it('is registered in the sitemap', () => {
+    const sitemap = read('src/app/sitemap.ts')
+    expect(sitemap).toContain('/site-owner/accept-invitation/')
+  })
+})

--- a/__tests__/components/Footer.test.tsx
+++ b/__tests__/components/Footer.test.tsx
@@ -81,7 +81,7 @@ describe('Footer Component', () => {
   describe('Social Links', () => {
     it('should have GitHub icon link in social bar', () => {
       render(<Footer />)
-      const githubLink = screen.getByRole('link', { name: /github/i })
+      const githubLink = screen.getByRole('link', { name: /on GitHub/i })
       expect(githubLink).toHaveAttribute('href', 'https://github.com/FreeForCharity')
       expect(githubLink).toHaveAttribute('target', '_blank')
       expect(githubLink).toHaveAttribute('rel', 'noopener noreferrer')

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -106,7 +106,7 @@ export default function Home() {
               href="/site-owner"
               className="inline-flex items-center justify-center px-6 py-3 bg-white text-teal-700 rounded-lg font-semibold hover:bg-emerald-50 transition-colors shadow-lg"
             >
-              🌱 Edit My Site
+              <span aria-hidden="true">🌱&nbsp;</span>Edit My Site
               <svg
                 className="ml-2 w-5 h-5"
                 fill="none"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -85,6 +85,53 @@ export default function Home() {
         </div>
       </section>
 
+      {/* Charity site-owner spotlight — the most common visitor task */}
+      <section className="py-10 px-4 sm:px-6 lg:px-8 bg-gradient-to-r from-emerald-600 to-teal-700">
+        <div className="max-w-7xl mx-auto flex flex-col lg:flex-row lg:items-center lg:justify-between gap-6">
+          <div className="max-w-2xl">
+            <span className="inline-block bg-white/20 text-white text-xs font-semibold px-3 py-1 rounded-full mb-3">
+              Most charity owners start here
+            </span>
+            <h2 className="text-2xl md:text-3xl font-bold text-white mb-2">
+              FFC built your charity a website? Manage it yourself.
+            </h2>
+            <p className="text-emerald-50">
+              A complete, every-step path from creating your GitHub account to making your first
+              edit — in plain English, no coding. Includes the part everyone gets stuck on:{' '}
+              <strong>accepting your repository invitation</strong>.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-3 flex-shrink-0">
+            <Link
+              href="/site-owner"
+              className="inline-flex items-center justify-center px-6 py-3 bg-white text-teal-700 rounded-lg font-semibold hover:bg-emerald-50 transition-colors shadow-lg"
+            >
+              🌱 Edit My Site
+              <svg
+                className="ml-2 w-5 h-5"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M9 5l7 7-7 7"
+                />
+              </svg>
+            </Link>
+            <Link
+              href="/site-owner/accept-invitation"
+              className="inline-flex items-center justify-center px-6 py-3 border-2 border-white text-white rounded-lg font-semibold hover:bg-white/10 transition-colors"
+            >
+              Accept my GitHub invitation
+            </Link>
+          </div>
+        </div>
+      </section>
+
       {/* Persona router */}
       <section className="py-12 px-4 sm:px-6 lg:px-8 bg-white border-b border-gray-100">
         <div className="max-w-7xl mx-auto">

--- a/src/app/site-owner/accept-invitation/page.tsx
+++ b/src/app/site-owner/accept-invitation/page.tsx
@@ -1,0 +1,411 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import Breadcrumbs from '@/components/Breadcrumbs'
+
+export const metadata: Metadata = {
+  title: 'Accept Your GitHub Repository Invitation',
+  description:
+    'The exact, every-click walkthrough for accepting the GitHub invitation to your charity’s website repository: what the email looks like, who it’s from, where to find it if it’s not in your inbox, and the two other ways to accept it if the email never arrives.',
+  keywords:
+    'accept GitHub invitation, GitHub repository invite, collaborate invitation, github.com/notifications, accept invite GitHub charity, FreeForCharity onboarding',
+  alternates: { canonical: 'https://ffcadmin.org/site-owner/accept-invitation/' },
+}
+
+const EXAMPLE_REPO = 'FreeForCharity/FFC-EX-yourcharity.org'
+
+/** A faithful, illustration-only reproduction of the GitHub invitation email. */
+function EmailMock() {
+  return (
+    <figure className="my-4">
+      <div className="mx-auto max-w-xl rounded-xl border border-gray-300 shadow-sm overflow-hidden bg-white">
+        {/* Email header rows */}
+        <div className="border-b border-gray-200 p-4 text-sm">
+          <div className="flex items-start gap-3">
+            <div
+              className="flex-shrink-0 w-9 h-9 rounded-full bg-gray-900 text-white flex items-center justify-center font-bold"
+              aria-hidden="true"
+            >
+              <svg viewBox="0 0 24 24" fill="currentColor" className="w-5 h-5">
+                <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" />
+              </svg>
+            </div>
+            <div className="min-w-0">
+              <p className="font-semibold text-gray-900">GitHub</p>
+              <p className="text-gray-500 text-xs">
+                &lt;notifications@github.com&gt; <span className="text-gray-400">to you</span>
+              </p>
+            </div>
+          </div>
+          <p className="mt-3 font-bold text-gray-900">
+            [FreeForCharity] @clarkemoyer invited you to collaborate
+          </p>
+        </div>
+        {/* Email body */}
+        <div className="p-5 text-sm text-gray-700">
+          <p className="mb-4">
+            <strong>@clarkemoyer</strong> has invited you to collaborate on the{' '}
+            <strong>{EXAMPLE_REPO}</strong> repository.
+          </p>
+          <div className="text-center my-5">
+            <span className="inline-block bg-[#2da44e] text-white font-semibold text-sm px-4 py-2 rounded-md">
+              View invitation
+            </span>
+          </div>
+          <p className="text-xs text-gray-400">
+            You can also copy this URL: github.com/{EXAMPLE_REPO}/invitations
+          </p>
+        </div>
+      </div>
+      <figcaption className="text-center text-xs text-gray-400 mt-2">
+        Illustration of the email you&apos;ll receive — your repository name will be your
+        charity&apos;s.
+      </figcaption>
+    </figure>
+  )
+}
+
+/** A faithful, illustration-only reproduction of the on-repo invitation banner. */
+function BannerMock() {
+  return (
+    <figure className="my-4">
+      <div className="mx-auto max-w-2xl rounded-xl border border-gray-300 shadow-sm overflow-hidden">
+        {/* Fake browser address bar */}
+        <div className="bg-gray-100 border-b border-gray-200 px-3 py-2 flex items-center gap-2">
+          <span className="flex gap-1" aria-hidden="true">
+            <span className="w-2.5 h-2.5 rounded-full bg-red-400" />
+            <span className="w-2.5 h-2.5 rounded-full bg-yellow-400" />
+            <span className="w-2.5 h-2.5 rounded-full bg-green-400" />
+          </span>
+          <span className="ml-2 flex-1 truncate rounded bg-white border border-gray-200 px-2 py-0.5 text-xs text-gray-500">
+            github.com/{EXAMPLE_REPO}
+          </span>
+        </div>
+        {/* Invitation banner */}
+        <div className="bg-white p-5">
+          <div className="rounded-md border border-[#d0d7de] bg-[#ddf4ff] p-4 text-sm text-gray-800">
+            <p className="mb-3">
+              You&apos;ve been invited to collaborate on the <strong>{EXAMPLE_REPO}</strong>{' '}
+              repository.
+            </p>
+            <div className="flex gap-2">
+              <span className="inline-block bg-[#2da44e] text-white font-semibold text-xs px-3 py-1.5 rounded-md">
+                Accept invitation
+              </span>
+              <span className="inline-block bg-white border border-gray-300 text-gray-700 font-semibold text-xs px-3 py-1.5 rounded-md">
+                Decline
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+      <figcaption className="text-center text-xs text-gray-400 mt-2">
+        Illustration of the green banner at the top of your repository page.
+      </figcaption>
+    </figure>
+  )
+}
+
+function Route({
+  letter,
+  title,
+  subtitle,
+  children,
+}: {
+  letter: string
+  title: string
+  subtitle: string
+  children: React.ReactNode
+}) {
+  return (
+    <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
+      <div className="flex items-center gap-3 mb-3">
+        <span className="flex-shrink-0 w-9 h-9 rounded-full bg-teal-600 text-white flex items-center justify-center font-bold">
+          {letter}
+        </span>
+        <div>
+          <h3 className="text-lg font-bold text-gray-900">{title}</h3>
+          <p className="text-sm text-gray-500">{subtitle}</p>
+        </div>
+      </div>
+      {children}
+    </div>
+  )
+}
+
+export default function AcceptInvitationPage() {
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Breadcrumbs
+        items={[
+          { label: 'Home', href: '/' },
+          { label: 'Edit My Charity Website', href: '/site-owner' },
+          { label: 'Accept your repository invitation' },
+        ]}
+      />
+
+      {/* Hero */}
+      <div className="bg-gradient-to-r from-gray-800 to-gray-900 text-white py-14 px-4 sm:px-6 lg:px-8">
+        <div className="max-w-3xl mx-auto">
+          <div className="flex items-center gap-4 mb-3">
+            <span className="text-5xl" aria-hidden="true">
+              📨
+            </span>
+            <h1 className="text-3xl md:text-4xl font-bold">Accept your repository invitation</h1>
+          </div>
+          <p className="text-white/90">
+            This is the step that trips everyone up, so we&apos;re going to be extremely precise.
+            After you send FFC your GitHub username, we send you an invitation to your
+            charity&apos;s repository. You have to accept it once before you can edit anything. Here
+            is exactly what it looks like, who it&apos;s from, and three different ways to accept
+            it.
+          </p>
+        </div>
+      </div>
+
+      <main className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-12 space-y-8">
+        {/* Where you are */}
+        <p className="text-sm text-gray-500">
+          You are on <strong className="text-gray-700">step 4</strong> of the{' '}
+          <Link href="/site-owner" className="text-teal-700 underline hover:text-teal-900">
+            complete site-owner path
+          </Link>
+          : ① GitHub account → ② turn on MFA → ③ send FFC your username →{' '}
+          <strong className="text-gray-700">④ accept the invitation</strong> → ⑤ set up your
+          assistant.
+        </p>
+
+        {/* The big idea */}
+        <section className="bg-blue-50 border-l-4 border-blue-500 rounded p-5">
+          <h2 className="text-base font-bold text-blue-900 mb-2">
+            The one thing to understand first
+          </h2>
+          <p className="text-sm text-blue-900/90 mb-2">
+            Your invitation shows up in <strong>two places at the same time</strong>, and you only
+            need to use <em>one</em> of them:
+          </p>
+          <ol className="text-sm text-blue-900/90 list-decimal pl-5 space-y-1">
+            <li>An email from GitHub, and</li>
+            <li>A green banner on your repository&apos;s page when you&apos;re logged in.</li>
+          </ol>
+          <p className="text-sm text-blue-900/90 mt-2">
+            <strong>Important:</strong> a repository invitation usually does <strong>not</strong>{' '}
+            appear at{' '}
+            <a
+              href="https://github.com/notifications"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline"
+            >
+              github.com/notifications
+            </a>
+            . That bell is for other things. If you went there and it was empty, you weren&apos;t
+            doing anything wrong — you were just looking in the one spot it doesn&apos;t show. Use
+            Route&nbsp;A or Route&nbsp;B below instead.
+          </p>
+        </section>
+
+        {/* Step 0: right account */}
+        <section className="bg-amber-50 border border-amber-200 rounded-xl p-6">
+          <h2 className="text-lg font-bold text-amber-900 mb-2">
+            <span aria-hidden="true">⚠️ </span>Before anything else: are you signed in as the right
+            person?
+          </h2>
+          <p className="text-sm text-amber-900/90 mb-3">
+            The #1 reason an invitation seems &ldquo;missing&rdquo; is being logged into a{' '}
+            <strong>different GitHub account</strong> than the username you gave FFC (for example,
+            an old personal account, or a second account on a shared computer). The invite was sent
+            to one specific username — you must be signed in as that exact person to see it.
+          </p>
+          <p className="text-sm text-amber-900/90">
+            Check it: open{' '}
+            <a
+              href="https://github.com"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline"
+            >
+              github.com
+            </a>
+            , look at the <strong>circular profile picture in the very top-right corner</strong>,
+            and click it. The username shown at the top of that menu must match the one you sent
+            FFC. If it doesn&apos;t, sign out and sign back in as the correct account.
+          </p>
+        </section>
+
+        {/* Routes */}
+        <h2 className="text-2xl font-bold text-gray-900">Three ways to accept — pick any one</h2>
+
+        <Route
+          letter="A"
+          title="Accept from the email"
+          subtitle="The easiest way, if you can find the email"
+        >
+          <p className="text-sm text-gray-700 mb-1">Look for an email that looks like this:</p>
+          <ul className="text-sm text-gray-700 list-disc pl-5 mb-2 space-y-1">
+            <li>
+              <strong>From:</strong> GitHub &lt;notifications@github.com&gt; (the sender name is
+              just &ldquo;GitHub&rdquo;)
+            </li>
+            <li>
+              <strong>Subject:</strong> &ldquo;[FreeForCharity] @clarkemoyer invited you to
+              collaborate&rdquo;
+            </li>
+          </ul>
+          <EmailMock />
+          <div className="bg-amber-50 border border-amber-200 rounded p-3 text-sm text-amber-900 mb-3">
+            <strong>Can&apos;t find it?</strong> It is very often <strong>not</strong> in your main
+            inbox. Check these, in order:
+            <ul className="list-disc pl-5 mt-1 space-y-0.5">
+              <li>
+                Gmail: the <strong>Promotions</strong> and <strong>Updates</strong> tabs, then{' '}
+                <strong>Spam</strong>.
+              </li>
+              <li>
+                Outlook: the <strong>Other</strong> tab and the <strong>Junk</strong> folder.
+              </li>
+              <li>
+                Search your email for the word <strong>invited</strong> or <strong>github</strong>.
+              </li>
+            </ul>
+          </div>
+          <p className="text-sm text-gray-700">
+            When you find it, click the green <strong>View invitation</strong> button. It opens
+            GitHub in your browser and shows the green <strong>Accept invitation</strong> button —
+            click that. Done.
+          </p>
+        </Route>
+
+        <Route
+          letter="B"
+          title="Accept from your repository page"
+          subtitle="The most reliable way — works even if the email never arrives"
+        >
+          <p className="text-sm text-gray-700 mb-2">
+            FFC will give you your repository&apos;s web address. It looks like this (yours will
+            have your charity&apos;s name):
+          </p>
+          <p className="text-sm font-mono bg-gray-100 rounded p-2 mb-3 break-all">
+            https://github.com/{EXAMPLE_REPO}
+          </p>
+          <p className="text-sm text-gray-700 mb-1">
+            Make sure you&apos;re signed in (see the warning above), then open that address. At the
+            top of the page you&apos;ll see a banner inviting you to collaborate. Click the green{' '}
+            <strong>Accept invitation</strong> button.
+          </p>
+          <BannerMock />
+          <p className="text-sm text-gray-700">
+            If the banner doesn&apos;t appear, add <strong>/invitations</strong> to the end of the
+            address and open{' '}
+            <span className="font-mono break-all">
+              https://github.com/{EXAMPLE_REPO}/invitations
+            </span>{' '}
+            — the accept button lives there too.
+          </p>
+        </Route>
+
+        <Route
+          letter="C"
+          title="Let FFC walk you through it live"
+          subtitle="When you just want a human on the line"
+        >
+          <p className="text-sm text-gray-700">
+            No shame in this — it takes two minutes together. Text <strong>Clarke Moyer</strong> at{' '}
+            <a href="sms:520-222-8104" className="text-teal-700 underline hover:text-teal-900">
+              (520)&nbsp;222-8104
+            </a>{' '}
+            and say you&apos;re ready to accept your repository invitation. He can re-send it and
+            stay on the phone while you click <strong>Accept</strong>.
+          </p>
+        </Route>
+
+        {/* What success looks like */}
+        <section className="bg-green-50 border border-green-200 rounded-xl p-6">
+          <h2 className="text-lg font-bold text-green-900 mb-2">How you know it worked</h2>
+          <p className="text-sm text-green-900/90">
+            After you click <strong>Accept invitation</strong>, the banner disappears and you land
+            on your repository&apos;s normal page — a list of files and folders. That&apos;s it:
+            you&apos;re now a <strong>collaborator</strong> and you (and your AI assistant) can make
+            changes. You never have to accept again.
+          </p>
+        </section>
+
+        {/* Troubleshooting */}
+        <section className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
+          <h2 className="text-xl font-bold text-gray-900 mb-4">
+            If something still isn&apos;t right
+          </h2>
+          <dl className="space-y-4 text-sm">
+            <div className="border-l-4 border-gray-200 pl-4">
+              <dt className="font-bold text-gray-900">
+                &ldquo;This invitation has expired&rdquo; or the link does nothing
+              </dt>
+              <dd className="text-gray-700">
+                Invitations expire after 7 days. Text Clarke at (520)&nbsp;222-8104 and ask him to
+                re-send the invitation to your GitHub username — it arrives again within minutes.
+              </dd>
+            </div>
+            <div className="border-l-4 border-gray-200 pl-4">
+              <dt className="font-bold text-gray-900">I clicked Decline by accident</dt>
+              <dd className="text-gray-700">
+                No problem and nothing is broken — the invitation just needs to be sent again. Text
+                Clarke and he&apos;ll re-send it.
+              </dd>
+            </div>
+            <div className="border-l-4 border-gray-200 pl-4">
+              <dt className="font-bold text-gray-900">
+                The repository page says &ldquo;404&rdquo; / &ldquo;not found&rdquo;
+              </dt>
+              <dd className="text-gray-700">
+                That almost always means you&apos;re signed out or signed in as the wrong account
+                (the repo is private until you accept). Re-check the top-right profile picture, then
+                reload the page.
+              </dd>
+            </div>
+            <div className="border-l-4 border-gray-200 pl-4">
+              <dt className="font-bold text-gray-900">I never gave FFC my username</dt>
+              <dd className="text-gray-700">
+                That&apos;s step 3 — no invitation can be sent until you do. Text Clarke your{' '}
+                <strong>GitHub username</strong> (the name under your top-right profile picture) and
+                your charity&apos;s name, and the invite will follow.
+              </dd>
+            </div>
+          </dl>
+        </section>
+
+        {/* Next */}
+        <section className="bg-gradient-to-br from-gray-50 to-teal-50 rounded-xl border border-gray-200 p-6">
+          <h2 className="text-lg font-bold text-gray-900 mb-2">
+            You&apos;re in — what&apos;s next
+          </h2>
+          <p className="text-sm text-gray-700 mb-4">
+            Now set up the AI assistant that actually makes your edits, then make your first change.
+          </p>
+          <div className="flex flex-wrap gap-3">
+            <Link
+              href="/site-owner#before-you-start"
+              className="inline-flex items-center justify-center px-5 py-2.5 bg-gradient-to-r from-emerald-500 to-teal-600 text-white rounded-lg font-semibold hover:opacity-90 transition-opacity text-sm"
+            >
+              Next: set up your assistant →
+            </Link>
+            <Link
+              href="/site-owner"
+              className="inline-flex items-center justify-center px-5 py-2.5 bg-white border border-gray-300 text-gray-700 rounded-lg font-semibold hover:bg-gray-50 transition-colors text-sm"
+            >
+              Back to the full path
+            </Link>
+          </div>
+        </section>
+
+        {/* Support */}
+        <p className="text-sm text-gray-600">
+          Stuck on any step? Text Clarke Moyer at{' '}
+          <a href="sms:520-222-8104" className="text-teal-700 underline hover:text-teal-900">
+            (520)&nbsp;222-8104
+          </a>
+          . This step is genuinely the hardest part of the whole process — once you&apos;re past it,
+          editing your site is easy.
+        </p>
+      </main>
+    </div>
+  )
+}

--- a/src/app/site-owner/page.tsx
+++ b/src/app/site-owner/page.tsx
@@ -138,6 +138,89 @@ export default function SiteOwnerPage() {
           </p>
         </div>
 
+        {/* Complete linear path */}
+        <section className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8 border-2 border-teal-200">
+          <div className="flex items-center mb-2">
+            <span className="text-4xl mr-4" aria-hidden="true">
+              🧭
+            </span>
+            <div>
+              <h2 className="text-2xl font-bold text-gray-900">Your complete path, in order</h2>
+              <p className="text-gray-600">
+                Brand new? Do these in sequence. Each one links to a spell-it-all-out guide.
+              </p>
+            </div>
+          </div>
+          <ol className="mt-4 space-y-3">
+            {[
+              {
+                n: '1',
+                title: 'Create your GitHub account',
+                body: 'A free account in your own name — this is the login that owns your access.',
+                href: '/guides/github-account',
+                cta: 'Open the GitHub account guide',
+              },
+              {
+                n: '2',
+                title: 'Turn on multi-factor authentication (MFA)',
+                body: 'A second step at login so a stolen password alone can’t get in. Required.',
+                href: '/guides/multi-factor-authentication',
+                cta: 'Open the MFA guide',
+              },
+              {
+                n: '3',
+                title: 'Send FFC your GitHub username',
+                body: 'Text Clarke your username + charity name so we can invite you. (Copy-paste message in step 2 below.)',
+                href: '#before-you-start',
+                cta: 'See the message to send',
+              },
+              {
+                n: '4',
+                title: 'Accept your repository invitation',
+                body: 'The step most people get stuck on — what the email looks like, who it’s from, and three ways to accept.',
+                href: '/site-owner/accept-invitation',
+                cta: 'Open the accept-invitation walkthrough',
+                highlight: true,
+              },
+              {
+                n: '5',
+                title: 'Install your AI assistant & connect it once',
+                body: 'Download Claude, sign in, and connect it to GitHub a single time.',
+                href: '#before-you-start',
+                cta: 'Jump to setup',
+              },
+              {
+                n: '6',
+                title: 'Make your first edit',
+                body: 'Describe a small change in plain English, read it, approve it — it’s live.',
+                href: '#first-edit',
+                cta: 'Jump to your first edit',
+              },
+            ].map((s) => (
+              <li
+                key={s.n}
+                className={`flex items-start gap-4 rounded-lg border p-4 ${
+                  s.highlight ? 'border-teal-300 bg-teal-50' : 'border-gray-200 bg-gray-50'
+                }`}
+              >
+                <span className="flex-shrink-0 w-8 h-8 bg-teal-600 text-white rounded-full flex items-center justify-center font-bold">
+                  {s.n}
+                </span>
+                <div className="min-w-0">
+                  <h3 className="font-bold text-gray-900">{s.title}</h3>
+                  <p className="text-sm text-gray-700 mb-1">{s.body}</p>
+                  <Link
+                    href={s.href}
+                    className="text-sm font-semibold text-teal-700 underline hover:text-teal-900"
+                  >
+                    {s.cta} →
+                  </Link>
+                </div>
+              </li>
+            ))}
+          </ol>
+        </section>
+
         {/* What to expect */}
         <section className="bg-white rounded-xl shadow-lg p-6 md:p-8 mb-8">
           <div className="flex items-center mb-4">
@@ -365,12 +448,22 @@ export default function SiteOwnerPage() {
                 </h3>
                 <p className="text-sm text-gray-700">
                   Once FFC adds you, you become a <strong>collaborator</strong> on your
-                  charity&apos;s repository — just your one repo, nothing else. You&apos;ll get an
-                  email titled something like “[your charity] invited you to collaborate” and a
-                  notification on GitHub. Open it and click <strong>Accept invitation</strong>.
-                  That&apos;s what gives you (and your assistant) permission to make changes.
+                  charity&apos;s repository — just your one repo, nothing else. The invitation
+                  arrives as an email from GitHub <em>and</em> as a green banner on your repository
+                  page. This is the step people get stuck on, so we wrote a separate, every-click
+                  walkthrough — what the email looks like, who it&apos;s from, where to find it if
+                  it&apos;s not in your inbox, and two other ways to accept.
                 </p>
-                <div className="mt-2 bg-amber-50 border-l-4 border-amber-400 p-3 rounded text-xs text-amber-900">
+                <Link
+                  href="/site-owner/accept-invitation"
+                  className="mt-3 inline-flex items-center justify-center px-5 py-2.5 bg-gradient-to-r from-gray-800 to-gray-900 text-white rounded-lg font-semibold hover:opacity-90 transition-opacity text-sm"
+                >
+                  <span aria-hidden="true" className="mr-2">
+                    📨
+                  </span>
+                  Open the &ldquo;Accept your invitation&rdquo; walkthrough →
+                </Link>
+                <div className="mt-3 bg-amber-50 border-l-4 border-amber-400 p-3 rounded text-xs text-amber-900">
                   Didn&apos;t get an invite within a day, or the link expired? Text Clarke again at
                   (520)&nbsp;222-8104 and ask to re-send the writer invitation to your GitHub
                   username.
@@ -729,6 +822,27 @@ export default function SiteOwnerPage() {
         <div className="bg-gradient-to-br from-gray-50 to-teal-50 rounded-xl shadow-lg p-6 md:p-8 border border-gray-200">
           <h2 className="text-xl font-bold text-gray-900 mb-4">Where to next</h2>
           <ul className="space-y-2 text-sm text-gray-700">
+            <li>
+              <Link
+                href="/site-owner/accept-invitation"
+                className="text-teal-700 underline hover:text-teal-900"
+              >
+                Accept your repository invitation
+              </Link>
+              <span className="text-gray-500">
+                {' '}
+                &mdash; the every-click walkthrough for the step people get stuck on
+              </span>
+            </li>
+            <li>
+              <Link href="/guides" className="text-teal-700 underline hover:text-teal-900">
+                Account &amp; tool setup guides
+              </Link>
+              <span className="text-gray-500">
+                {' '}
+                &mdash; GitHub, MFA, charity email, password manager &amp; more
+              </span>
+            </li>
             <li>
               <Link
                 href="/site-owner/training"

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -101,6 +101,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.9,
     },
     {
+      url: `${SITE_URL}/site-owner/accept-invitation/`,
+      lastModified: now,
+      changeFrequency: 'monthly',
+      priority: 0.85,
+    },
+    {
       url: `${SITE_URL}/site-owner/common-edits/`,
       lastModified: now,
       changeFrequency: 'monthly',

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -29,7 +29,7 @@ export default function Footer() {
               href="/site-owner"
               className="inline-flex items-center justify-center rounded-lg bg-white px-5 py-2.5 text-sm font-semibold text-teal-700 hover:bg-emerald-50 transition-colors"
             >
-              🌱 Edit My Site
+              <span aria-hidden="true">🌱&nbsp;</span>Edit My Site
             </Link>
             <Link
               href="/site-owner/accept-invitation"

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -16,6 +16,30 @@ export default function Footer() {
   return (
     <footer className="bg-black text-white mt-auto">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        {/* Charity site-owner CTA band */}
+        <div className="mb-10 rounded-xl bg-gradient-to-r from-emerald-600 to-teal-700 p-6 md:p-8 flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+          <div>
+            <h3 className="text-xl font-bold text-white">Run a charity FFC built a site for?</h3>
+            <p className="text-sm text-emerald-50">
+              Follow the complete, every-step path to start editing your own website — no coding.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-3">
+            <Link
+              href="/site-owner"
+              className="inline-flex items-center justify-center rounded-lg bg-white px-5 py-2.5 text-sm font-semibold text-teal-700 hover:bg-emerald-50 transition-colors"
+            >
+              🌱 Edit My Site
+            </Link>
+            <Link
+              href="/site-owner/accept-invitation"
+              className="inline-flex items-center justify-center rounded-lg border border-white/70 px-5 py-2.5 text-sm font-semibold text-white hover:bg-white/10 transition-colors"
+            >
+              Accept my GitHub invitation →
+            </Link>
+          </div>
+        </div>
+
         {/* Top Section with 7 columns */}
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-7 gap-8 mb-8">
           {/* Endorsements */}

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -219,7 +219,10 @@ export default function Navigation() {
 
             <Link
               href="/site-owner"
-              className="inline-flex items-center whitespace-nowrap rounded-lg bg-gradient-to-r from-emerald-500 to-teal-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:opacity-90 transition-opacity"
+              aria-current={isActive('/site-owner') ? 'page' : undefined}
+              className={`inline-flex items-center whitespace-nowrap rounded-lg bg-gradient-to-r from-emerald-500 to-teal-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:opacity-90 transition-opacity focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-700 focus-visible:ring-offset-2 ${
+                isActive('/site-owner') ? 'ring-2 ring-emerald-700 ring-offset-2' : ''
+              }`}
             >
               <span aria-hidden="true" className="mr-1.5">
                 🌱
@@ -300,10 +303,11 @@ export default function Navigation() {
 
             <Link
               href="/site-owner"
-              className="block rounded-lg bg-gradient-to-r from-emerald-500 to-teal-600 px-3 py-2 my-1 text-center font-semibold text-white"
+              aria-current={isActive('/site-owner') ? 'page' : undefined}
+              className="block rounded-lg bg-gradient-to-r from-emerald-500 to-teal-600 px-3 py-2 my-1 text-center font-semibold text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-700 focus-visible:ring-offset-2"
               onClick={() => setIsMenuOpen(false)}
             >
-              🌱 Edit My Site
+              <span aria-hidden="true">🌱 </span>Edit My Site
             </Link>
 
             {mobileDropdown(trainingDropdown)}

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -217,7 +217,13 @@ export default function Navigation() {
 
             {desktopDropdown(volunteerDropdown)}
 
-            <Link href="/site-owner" className={`${linkClass('/site-owner')} whitespace-nowrap`}>
+            <Link
+              href="/site-owner"
+              className="inline-flex items-center whitespace-nowrap rounded-lg bg-gradient-to-r from-emerald-500 to-teal-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:opacity-90 transition-opacity"
+            >
+              <span aria-hidden="true" className="mr-1.5">
+                🌱
+              </span>
               Edit My Site
             </Link>
 
@@ -294,10 +300,10 @@ export default function Navigation() {
 
             <Link
               href="/site-owner"
-              className={mobileLinkClass('/site-owner')}
+              className="block rounded-lg bg-gradient-to-r from-emerald-500 to-teal-600 px-3 py-2 my-1 text-center font-semibold text-white"
               onClick={() => setIsMenuOpen(false)}
             >
-              Edit My Site
+              🌱 Edit My Site
             </Link>
 
             {mobileDropdown(trainingDropdown)}

--- a/src/data/setup-guides.ts
+++ b/src/data/setup-guides.ts
@@ -126,8 +126,10 @@ export const SETUP_GUIDES: SetupGuide[] = [
       {
         title: 'Tell FFC your username',
         body: [
-          'Send your **GitHub username** to FFC (text Clarke Moyer at (520) 222-8104) so you can be added to your charity’s repository as a writer. You’ll get an email invitation — open it and click **Accept invitation**.',
+          'Send your **GitHub username** to FFC (text Clarke Moyer at (520) 222-8104) so you can be added to your charity’s repository as a writer. You’ll then get an invitation to accept.',
+          'Accepting that invitation is the step most people get stuck on, so we wrote an every-click walkthrough: **ffcadmin.org/site-owner/accept-invitation** — what the email looks like, who it’s from, and three ways to accept it.',
         ],
+        tip: 'The invitation does NOT appear at github.com/notifications — look for the email from GitHub, or the green banner on your repository page. The walkthrough above shows both.',
       },
     ],
     faqs: [

--- a/src/data/setup-guides.ts
+++ b/src/data/setup-guides.ts
@@ -127,9 +127,9 @@ export const SETUP_GUIDES: SetupGuide[] = [
         title: 'Tell FFC your username',
         body: [
           'Send your **GitHub username** to FFC (text Clarke Moyer at (520) 222-8104) so you can be added to your charity’s repository as a writer. You’ll then get an invitation to accept.',
-          'Accepting that invitation is the step most people get stuck on, so we wrote an every-click walkthrough: **ffcadmin.org/site-owner/accept-invitation** — what the email looks like, who it’s from, and three ways to accept it.',
+          'Accepting that invitation is the step most people get stuck on, so we wrote an every-click walkthrough: **https://ffcadmin.org/site-owner/accept-invitation** — what the email looks like, who it’s from, and three ways to accept it.',
         ],
-        tip: 'The invitation does NOT appear at github.com/notifications — look for the email from GitHub, or the green banner on your repository page. The walkthrough above shows both.',
+        tip: 'The invitation does NOT appear at https://github.com/notifications — look for the email from GitHub, or the green banner on your repository page. The walkthrough above shows both.',
       },
     ],
     faqs: [


### PR DESCRIPTION
## Summary

Addresses the 2-hour onboarding call: makes the charity site-owner path **prominent and easy to find**, and adds a **high-fidelity, every-click walkthrough** for the step everyone gets stuck on — accepting the GitHub repository invitation.

### New page: `/site-owner/accept-invitation`
The precise walkthrough we were missing. It includes:
- **Styled, faithful reproductions** (illustrations, no binary assets) of the actual **GitHub invitation email** (sender `GitHub <notifications@github.com>`, the real subject line, green "View invitation" button) and the **repo invitation banner** in a browser frame.
- The key correction that caused the 2 hours: **a repo invite does NOT appear at `github.com/notifications`** — it's an email *and* a banner on the repo page. Stated plainly so people stop looking in the wrong place.
- **"Are you signed in as the right account?"** check (the #1 cause of "missing" invites) with where to look (top-right avatar).
- **Three acceptance routes**: (A) from the email — incl. where Gmail/Outlook hide it (Promotions/Updates/Spam/Junk); (B) from the repo URL banner + the `/invitations` URL; (C) live with Clarke.
- "How you know it worked" + a troubleshooting list (expired, declined by accident, 404/wrong account, never sent username).

### Discoverability (the "not well linked / hard to find" fix)
- **Nav:** "Edit My Site" is now a **filled CTA button** (🌱, emerald→teal) on desktop and mobile, visually distinct from the dropdowns so it's unambiguous next to Volunteer/Training.
- **Homepage:** a full-width **charity-owner spotlight band** right under the hero ("Most charity owners start here") with **Edit My Site** + **Accept my GitHub invitation** buttons.
- **Footer:** a prominent CTA band linking the landing and the invitation walkthrough.
- **Site-owner landing:** a new **"Your complete path, in order"** 6-step stepper (GitHub account → MFA → send username → accept invite → set up assistant → first edit), each linking its guide; the thin invite paragraph now links the new walkthrough; "Where to next" links the account-setup guides.
- **Cross-link:** the `/guides/github-account` final step now points to the walkthrough and warns about the `/notifications` misconception.

Tests: new `charity-onboarding.test.js` (page content + discoverability across nav/footer/homepage/landing/sitemap); tightened one Footer test that assumed a single "github" link. **445 passing**, type-check/lint/build clean. Sitemap updated.

## Follow-up (not in this PR)
You asked for an "overall look at navigation" toward a simpler **mega-menu** with deep cross-linking. That's a larger IA change worth reviewing on its own; I'll propose a concrete structure next rather than fold a full nav rebuild in here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X4omPQW2ErDyZsMtxypuMe)_