### PR TITLE
feat: audience-first mega-menu navigation + prominent Manage My Site CTA

### DIFF
--- a/__tests__/components/Navigation.test.tsx
+++ b/__tests__/components/Navigation.test.tsx
@@ -1,18 +1,19 @@
 /**
  * Navigation Component Tests
  *
- * These tests validate the Navigation component behavior and rendering.
+ * These tests validate the Navigation component behavior and rendering for the
+ * audience-first mega-menu structure: Home · Manage My Site · Volunteer ▾ ·
+ * Operate ▾ · For Charities ↗.
  */
 
 import '@testing-library/jest-dom'
 import { render, screen, fireEvent, act } from '@testing-library/react'
 import Navigation from '@/components/Navigation'
-import { trainingDropdown } from '@/data/navigation'
+import { volunteerMenu, menuItems } from '@/data/navigation'
 
 // Helper to render and flush the queueMicrotask from the pathname effect
 async function renderNavigation() {
   render(<Navigation />)
-  // Flush the queueMicrotask scheduled by the pathname change effect
   await act(async () => {})
 }
 
@@ -26,24 +27,21 @@ describe('Navigation Component', () => {
     it('should render the brand logo and name', async () => {
       await renderNavigation()
       expect(screen.getByAltText('Free For Charity Logo')).toBeInTheDocument()
-
       expect(screen.getByText('Admin Portal')).toBeInTheDocument()
     })
 
-    it('should render desktop navigation links and dropdown buttons', async () => {
+    it('should render the top-level links and the two mega-menu buttons', async () => {
       await renderNavigation()
       expect(screen.getByRole('link', { name: /home/i })).toBeInTheDocument()
-      expect(screen.getByRole('link', { name: /edit my site/i })).toBeInTheDocument()
+      // Both desktop and mobile render a Manage My Site link
+      expect(screen.getAllByRole('link', { name: /manage my site/i }).length).toBeGreaterThan(0)
       expect(screen.getByRole('button', { name: /volunteer/i })).toBeInTheDocument()
-      expect(screen.getByRole('button', { name: /training/i })).toBeInTheDocument()
       expect(screen.getByRole('button', { name: /operate/i })).toBeInTheDocument()
-      expect(screen.getByRole('button', { name: /resources/i })).toBeInTheDocument()
     })
 
     it('should render mobile menu button', async () => {
       await renderNavigation()
-      const menuButton = screen.getByRole('button', { name: /menu/i })
-      expect(menuButton).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /menu/i })).toBeInTheDocument()
     })
   })
 
@@ -51,26 +49,15 @@ describe('Navigation Component', () => {
     it('should toggle mobile menu when button is clicked', async () => {
       await renderNavigation()
       const menuButton = screen.getByRole('button', { name: /menu/i })
-
-      // Menu should be closed initially
-      expect(screen.queryByText(/close/i)).not.toBeInTheDocument()
-
-      // Open menu
       fireEvent.click(menuButton)
-
-      // Check if menu is open (aria-expanded should be true)
       expect(menuButton).toHaveAttribute('aria-expanded', 'true')
     })
 
     it('should close mobile menu when clicked twice', async () => {
       await renderNavigation()
       const menuButton = screen.getByRole('button', { name: /menu/i })
-
-      // Open menu
       fireEvent.click(menuButton)
       expect(menuButton).toHaveAttribute('aria-expanded', 'true')
-
-      // Close menu
       fireEvent.click(menuButton)
       expect(menuButton).toHaveAttribute('aria-expanded', 'false')
     })
@@ -79,76 +66,47 @@ describe('Navigation Component', () => {
   describe('Links', () => {
     it('should have correct href for home link', async () => {
       await renderNavigation()
-      const homeLink = screen.getByRole('link', { name: /home/i })
-      expect(homeLink).toHaveAttribute('href', '/')
+      expect(screen.getByRole('link', { name: /home/i })).toHaveAttribute('href', '/')
     })
 
-    it('should have correct href for edit my site link', async () => {
+    it('should point Manage My Site at the site-owner landing', async () => {
       await renderNavigation()
-      const link = screen.getByRole('link', { name: /edit my site/i })
-      expect(link).toHaveAttribute('href', '/site-owner')
+      const links = screen.getAllByRole('link', { name: /manage my site/i })
+      links.forEach((l) => expect(l).toHaveAttribute('href', '/site-owner'))
     })
 
-    it('should render volunteer dropdown items when opened', async () => {
+    it('should render volunteer mega-menu items (incl. nested training) when opened', async () => {
       await renderNavigation()
       fireEvent.click(screen.getByRole('button', { name: /volunteer/i }))
       expect(screen.getByRole('menuitem', { name: /get involved/i })).toHaveAttribute(
         'href',
         '/get-involved'
       )
-      expect(screen.getByRole('menuitem', { name: /recognition/i })).toHaveAttribute(
-        'href',
-        '/recognition'
-      )
-      expect(screen.getByRole('menuitem', { name: /continuing education/i })).toHaveAttribute(
-        'href',
-        '/continuing-education'
-      )
       expect(screen.getByRole('menuitem', { name: /contributor ladder/i })).toHaveAttribute(
         'href',
         '/contributor-ladder'
       )
-    })
-
-    it('should render training dropdown items when opened', async () => {
-      await renderNavigation()
-      const trainingBtn = screen.getByRole('button', { name: /training/i })
-      fireEvent.click(trainingBtn)
-      // Items have role="menuitem" which overrides the implicit link role
-      expect(screen.getByRole('menuitem', { name: /global admin/i })).toHaveAttribute(
+      // Training tracks now live under Volunteer
+      expect(screen.getByRole('menuitem', { name: /web developer/i })).toHaveAttribute(
         'href',
-        '/training-plan'
+        '/training/web-developer'
       )
       expect(screen.getByRole('menuitem', { name: /canva designer/i })).toHaveAttribute(
         'href',
         '/canva-designer-path'
       )
-      expect(screen.getByRole('menuitem', { name: /data & analytics/i })).toHaveAttribute(
-        'href',
-        '/training/data-analytics'
-      )
     })
 
-    it('should render operate dropdown items when opened', async () => {
+    it('should render operate mega-menu items (incl. nested resources) when opened', async () => {
       await renderNavigation()
       fireEvent.click(screen.getByRole('button', { name: /operate/i }))
       expect(screen.getByRole('menuitem', { name: /sites list/i })).toHaveAttribute(
         'href',
         '/sites-list'
       )
-      expect(screen.getByRole('menuitem', { name: /documentation/i })).toHaveAttribute(
-        'href',
-        '/documentation'
-      )
       expect(screen.getByRole('menuitem', { name: /testing/i })).toHaveAttribute('href', '/testing')
-    })
-
-    it('should render resources dropdown items when opened', async () => {
-      await renderNavigation()
-      const resourcesBtn = screen.getByRole('button', { name: /resources/i })
-      fireEvent.click(resourcesBtn)
+      // Resources now live under Operate
       expect(screen.getByRole('menuitem', { name: /guides/i })).toHaveAttribute('href', '/guides')
-      expect(screen.getByRole('menuitem', { name: /blog/i })).toHaveAttribute('href', '/blog')
       expect(screen.getByRole('menuitem', { name: /what ffc delivers/i })).toHaveAttribute(
         'href',
         '/what-ffc-delivers'
@@ -159,33 +117,33 @@ describe('Navigation Component', () => {
   describe('Dropdown Behavior', () => {
     it('should only have one dropdown open at a time', async () => {
       await renderNavigation()
-      const trainingBtn = screen.getByRole('button', { name: /training/i })
-      const resourcesBtn = screen.getByRole('button', { name: /resources/i })
+      const volunteerBtn = screen.getByRole('button', { name: /volunteer/i })
+      const operateBtn = screen.getByRole('button', { name: /operate/i })
 
-      fireEvent.click(trainingBtn)
-      expect(trainingBtn).toHaveAttribute('aria-expanded', 'true')
+      fireEvent.click(volunteerBtn)
+      expect(volunteerBtn).toHaveAttribute('aria-expanded', 'true')
 
-      fireEvent.click(resourcesBtn)
-      expect(resourcesBtn).toHaveAttribute('aria-expanded', 'true')
-      expect(trainingBtn).toHaveAttribute('aria-expanded', 'false')
+      fireEvent.click(operateBtn)
+      expect(operateBtn).toHaveAttribute('aria-expanded', 'true')
+      expect(volunteerBtn).toHaveAttribute('aria-expanded', 'false')
     })
 
     it('should close dropdown when clicking the same trigger again', async () => {
       await renderNavigation()
-      const trainingBtn = screen.getByRole('button', { name: /training/i })
-      fireEvent.click(trainingBtn)
-      expect(trainingBtn).toHaveAttribute('aria-expanded', 'true')
-      fireEvent.click(trainingBtn)
-      expect(trainingBtn).toHaveAttribute('aria-expanded', 'false')
+      const volunteerBtn = screen.getByRole('button', { name: /volunteer/i })
+      fireEvent.click(volunteerBtn)
+      expect(volunteerBtn).toHaveAttribute('aria-expanded', 'true')
+      fireEvent.click(volunteerBtn)
+      expect(volunteerBtn).toHaveAttribute('aria-expanded', 'false')
     })
 
     it('should close dropdown on Escape key', async () => {
       await renderNavigation()
-      const trainingBtn = screen.getByRole('button', { name: /training/i })
-      fireEvent.click(trainingBtn)
-      expect(trainingBtn).toHaveAttribute('aria-expanded', 'true')
+      const volunteerBtn = screen.getByRole('button', { name: /volunteer/i })
+      fireEvent.click(volunteerBtn)
+      expect(volunteerBtn).toHaveAttribute('aria-expanded', 'true')
       fireEvent.keyDown(document, { key: 'Escape' })
-      expect(trainingBtn).toHaveAttribute('aria-expanded', 'false')
+      expect(volunteerBtn).toHaveAttribute('aria-expanded', 'false')
     })
   })
 
@@ -199,11 +157,11 @@ describe('Navigation Component', () => {
 
     it('dropdown buttons should have aria-haspopup', async () => {
       await renderNavigation()
-      expect(screen.getByRole('button', { name: /training/i })).toHaveAttribute(
+      expect(screen.getByRole('button', { name: /volunteer/i })).toHaveAttribute(
         'aria-haspopup',
         'true'
       )
-      expect(screen.getByRole('button', { name: /resources/i })).toHaveAttribute(
+      expect(screen.getByRole('button', { name: /operate/i })).toHaveAttribute(
         'aria-haspopup',
         'true'
       )
@@ -211,15 +169,14 @@ describe('Navigation Component', () => {
 
     it('dropdown menus should have role="menu"', async () => {
       await renderNavigation()
-      fireEvent.click(screen.getByRole('button', { name: /training/i }))
+      fireEvent.click(screen.getByRole('button', { name: /volunteer/i }))
       expect(screen.getByRole('menu')).toBeInTheDocument()
     })
 
-    it('dropdown items should have role="menuitem"', async () => {
+    it('dropdown items should have role="menuitem" for every item across sections', async () => {
       await renderNavigation()
-      fireEvent.click(screen.getByRole('button', { name: /training/i }))
-      const menuItems = screen.getAllByRole('menuitem')
-      expect(menuItems.length).toBe(trainingDropdown.items.length)
+      fireEvent.click(screen.getByRole('button', { name: /volunteer/i }))
+      expect(screen.getAllByRole('menuitem').length).toBe(menuItems(volunteerMenu).length)
     })
   })
 })

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -11,45 +11,33 @@ test.describe('Smoke Tests', () => {
     await page.goto('/')
     const nav = page.locator('nav')
     await expect(nav.locator('a[href="/"]').first()).toBeVisible()
+    // Prominent charity-owner CTA button
     await expect(nav.locator('a[href*="/site-owner"]').first()).toBeVisible()
+    // Audience-first mega-menus: Volunteer + Operate (Training folds into
+    // Volunteer, Resources folds into Operate)
     await expect(nav.locator('button:has-text("Volunteer")')).toBeVisible()
-    await expect(nav.locator('button:has-text("Training")')).toBeVisible()
     await expect(nav.locator('button:has-text("Operate")')).toBeVisible()
-    await expect(nav.locator('button:has-text("Resources")')).toBeVisible()
   })
 
-  test('volunteer dropdown links are accessible', async ({ page }) => {
+  test('volunteer mega-menu links are accessible (incl. nested training)', async ({ page }) => {
     await page.goto('/')
-    await page.locator('nav button:has-text("Volunteer")').hover()
+    await page.locator('nav button:has-text("Volunteer")').first().hover()
     await expect(page.locator('nav a[href*="/get-involved"]').first()).toBeVisible()
-    await expect(page.locator('nav a[href*="/recognition"]').first()).toBeVisible()
-    await expect(page.locator('nav a[href*="/continuing-education"]').first()).toBeVisible()
     await expect(page.locator('nav a[href*="/contributor-ladder"]').first()).toBeVisible()
-  })
-
-  test('training dropdown links are accessible', async ({ page }) => {
-    await page.goto('/')
-    await page.locator('nav button:has-text("Training")').hover()
-    await expect(page.locator('nav a[href*="/training-plan"]').first()).toBeVisible()
-    await expect(page.locator('nav a[href*="/canva-designer-path"]').first()).toBeVisible()
+    await expect(page.locator('nav a[href*="/continuing-education"]').first()).toBeVisible()
+    // Training tracks now live under Volunteer
     await expect(page.locator('nav a[href*="/training/web-developer"]').first()).toBeVisible()
+    await expect(page.locator('nav a[href*="/canva-designer-path"]').first()).toBeVisible()
   })
 
-  test('operate dropdown links are accessible', async ({ page }) => {
+  test('operate mega-menu links are accessible (incl. nested resources)', async ({ page }) => {
     await page.goto('/')
-    await page.locator('nav button:has-text("Operate")').hover()
+    await page.locator('nav button:has-text("Operate")').first().hover()
     await expect(page.locator('nav a[href*="/sites-list"]').first()).toBeVisible()
-    await expect(page.locator('nav a[href*="/tech-stack"]').first()).toBeVisible()
     await expect(page.locator('nav a[href*="/documentation"]').first()).toBeVisible()
     await expect(page.locator('nav a[href*="/testing"]').first()).toBeVisible()
-  })
-
-  test('resources dropdown links are accessible', async ({ page }) => {
-    await page.goto('/')
-    await page.locator('nav button:has-text("Resources")').hover()
+    // Resources now live under Operate
     await expect(page.locator('nav a[href*="/guides"]').first()).toBeVisible()
-    await expect(page.locator('nav a[href*="/developer-environment-setup"]').first()).toBeVisible()
-    await expect(page.locator('nav a[href*="/blog"]').first()).toBeVisible()
     await expect(page.locator('nav a[href*="/what-ffc-delivers"]').first()).toBeVisible()
   })
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -31,7 +31,7 @@ export default function Home() {
                   href="/get-involved"
                   className="inline-flex items-center justify-center px-8 py-3 bg-white text-blue-600 rounded-lg font-semibold hover:bg-gray-50 transition-all shadow-lg hover:shadow-xl transform hover:-translate-y-0.5"
                 >
-                  Start Your Journey
+                  Volunteer With FFC
                   <svg
                     className="ml-2 w-5 h-5"
                     fill="none"

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -4,13 +4,7 @@ import Link from 'next/link'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { usePathname } from 'next/navigation'
 import { assetPath } from '@/lib/assetPath'
-import {
-  volunteerDropdown,
-  trainingDropdown,
-  operateDropdown,
-  resourcesDropdown,
-  type NavDropdown,
-} from '@/data/navigation'
+import { NAV_MENUS, menuItems, type NavMenu } from '@/data/navigation'
 
 export default function Navigation() {
   const [isMenuOpen, setIsMenuOpen] = useState(false)
@@ -25,8 +19,7 @@ export default function Navigation() {
     return pathname === href || pathname.startsWith(href + '/')
   }
 
-  const isDropdownActive = (dropdown: NavDropdown) =>
-    dropdown.items.some((item) => isActive(item.href))
+  const isDropdownActive = (menu: NavMenu) => menuItems(menu).some((item) => isActive(item.href))
 
   const linkClass = (href: string) =>
     isActive(href)
@@ -113,75 +106,93 @@ export default function Navigation() {
     </svg>
   )
 
-  const desktopDropdown = (dropdown: NavDropdown) => (
+  const desktopDropdown = (menu: NavMenu) => (
     <div
-      key={dropdown.id}
+      key={menu.id}
       className="relative"
-      onMouseEnter={() => handleDropdownMouseEnter(dropdown.id)}
+      onMouseEnter={() => handleDropdownMouseEnter(menu.id)}
       onMouseLeave={handleDropdownMouseLeave}
     >
       <button
         type="button"
-        id={`${dropdown.id}-dropdown-button`}
-        className={`${isDropdownActive(dropdown) ? 'text-blue-600 font-bold' : 'font-medium'} hover:text-blue-600 transition-colors inline-flex items-center whitespace-nowrap`}
-        aria-expanded={openDropdown === dropdown.id}
+        id={`${menu.id}-dropdown-button`}
+        className={`${isDropdownActive(menu) ? 'text-blue-600 font-bold' : 'font-medium'} hover:text-blue-600 transition-colors inline-flex items-center whitespace-nowrap`}
+        aria-expanded={openDropdown === menu.id}
         aria-haspopup="true"
-        aria-controls={`${dropdown.id}-dropdown-menu`}
-        onClick={() => setOpenDropdown(openDropdown === dropdown.id ? null : dropdown.id)}
+        aria-controls={`${menu.id}-dropdown-menu`}
+        onClick={() => setOpenDropdown(openDropdown === menu.id ? null : menu.id)}
       >
-        {dropdown.label}
-        {chevronSvg(openDropdown === dropdown.id)}
+        {menu.label}
+        {chevronSvg(openDropdown === menu.id)}
       </button>
-      {openDropdown === dropdown.id && (
+      {openDropdown === menu.id && (
         <div
-          id={`${dropdown.id}-dropdown-menu`}
+          id={`${menu.id}-dropdown-menu`}
           role="menu"
-          aria-labelledby={`${dropdown.id}-dropdown-button`}
-          className="absolute left-1/2 -translate-x-1/2 mt-2 w-80 bg-white rounded-lg shadow-xl border border-gray-200 py-2 z-50"
+          aria-labelledby={`${menu.id}-dropdown-button`}
+          className="absolute left-1/2 -translate-x-1/2 mt-2 w-[40rem] max-w-[calc(100vw-2rem)] bg-white rounded-lg shadow-xl border border-gray-200 p-4 z-50 grid grid-cols-2 gap-x-6 gap-y-1"
         >
-          {dropdown.items.map((item) => (
-            <Link
-              key={item.href}
-              href={item.href}
-              role="menuitem"
-              className="block px-4 py-3 hover:bg-blue-50 transition-colors"
-              onClick={() => setOpenDropdown(null)}
-            >
-              <p className="text-sm font-semibold text-gray-900">{item.label}</p>
-              <p className="text-xs text-gray-500 mt-0.5">{item.description}</p>
-            </Link>
+          {menu.sections.map((section) => (
+            <div key={section.heading} role="none">
+              <p className="px-3 pt-2 pb-1 text-xs font-bold uppercase tracking-wider text-gray-400">
+                {section.heading}
+              </p>
+              {section.items.map((item) => (
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  role="menuitem"
+                  aria-current={isActive(item.href) ? 'page' : undefined}
+                  className={`block rounded-md px-3 py-2 transition-colors hover:bg-blue-50 ${
+                    isActive(item.href) ? 'bg-blue-50' : ''
+                  }`}
+                  onClick={() => setOpenDropdown(null)}
+                >
+                  <p className="text-sm font-semibold text-gray-900">{item.label}</p>
+                  <p className="text-xs text-gray-500 mt-0.5">{item.description}</p>
+                </Link>
+              ))}
+            </div>
           ))}
         </div>
       )}
     </div>
   )
 
-  const mobileDropdown = (dropdown: NavDropdown) => (
-    <div key={dropdown.id}>
+  const mobileDropdown = (menu: NavMenu) => (
+    <div key={menu.id}>
       <button
         type="button"
-        className={`${isDropdownActive(dropdown) ? 'text-blue-600 font-bold bg-blue-50' : 'hover:bg-gray-50 hover:text-blue-600'} w-full text-left px-3 py-2 rounded-md transition-colors inline-flex items-center justify-between`}
-        onClick={() => toggleMobileAccordion(dropdown.id)}
-        aria-expanded={mobileAccordions.has(dropdown.id)}
-        aria-controls={`mobile-${dropdown.id}-panel`}
+        className={`${isDropdownActive(menu) ? 'text-blue-600 font-bold bg-blue-50' : 'hover:bg-gray-50 hover:text-blue-600'} w-full text-left px-3 py-2 rounded-md transition-colors inline-flex items-center justify-between`}
+        onClick={() => toggleMobileAccordion(menu.id)}
+        aria-expanded={mobileAccordions.has(menu.id)}
+        aria-controls={`mobile-${menu.id}-panel`}
       >
-        {dropdown.label}
-        {chevronSvg(mobileAccordions.has(dropdown.id))}
+        {menu.label}
+        {chevronSvg(mobileAccordions.has(menu.id))}
       </button>
-      {mobileAccordions.has(dropdown.id) && (
+      {mobileAccordions.has(menu.id) && (
         <div
-          id={`mobile-${dropdown.id}-panel`}
+          id={`mobile-${menu.id}-panel`}
           className="ml-4 mt-1 space-y-1 border-l-2 border-blue-100 pl-2"
         >
-          {dropdown.items.map((item) => (
-            <Link
-              key={item.href}
-              href={item.href}
-              className="block px-3 py-2 rounded-md text-sm hover:bg-gray-50 hover:text-blue-600 transition-colors"
-              onClick={() => setIsMenuOpen(false)}
-            >
-              {item.label}
-            </Link>
+          {menu.sections.map((section) => (
+            <div key={section.heading}>
+              <p className="px-3 pt-2 pb-0.5 text-xs font-bold uppercase tracking-wider text-gray-400">
+                {section.heading}
+              </p>
+              {section.items.map((item) => (
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  aria-current={isActive(item.href) ? 'page' : undefined}
+                  className="block px-3 py-2 rounded-md text-sm hover:bg-gray-50 hover:text-blue-600 transition-colors"
+                  onClick={() => setIsMenuOpen(false)}
+                >
+                  {item.label}
+                </Link>
+              ))}
+            </div>
           ))}
         </div>
       )}
@@ -215,8 +226,6 @@ export default function Navigation() {
               Home
             </Link>
 
-            {desktopDropdown(volunteerDropdown)}
-
             <Link
               href="/site-owner"
               aria-current={isActive('/site-owner') ? 'page' : undefined}
@@ -227,12 +236,10 @@ export default function Navigation() {
               <span aria-hidden="true" className="mr-1.5">
                 🌱
               </span>
-              Edit My Site
+              Manage My Site
             </Link>
 
-            {desktopDropdown(trainingDropdown)}
-            {desktopDropdown(operateDropdown)}
-            {desktopDropdown(resourcesDropdown)}
+            {NAV_MENUS.map((menu) => desktopDropdown(menu))}
 
             <a
               href="https://freeforcharity.org/"
@@ -299,20 +306,16 @@ export default function Navigation() {
               Home
             </Link>
 
-            {mobileDropdown(volunteerDropdown)}
-
             <Link
               href="/site-owner"
               aria-current={isActive('/site-owner') ? 'page' : undefined}
               className="block rounded-lg bg-gradient-to-r from-emerald-500 to-teal-600 px-3 py-2 my-1 text-center font-semibold text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-700 focus-visible:ring-offset-2"
               onClick={() => setIsMenuOpen(false)}
             >
-              <span aria-hidden="true">🌱 </span>Edit My Site
+              <span aria-hidden="true">🌱 </span>Manage My Site
             </Link>
 
-            {mobileDropdown(trainingDropdown)}
-            {mobileDropdown(operateDropdown)}
-            {mobileDropdown(resourcesDropdown)}
+            {NAV_MENUS.map((menu) => mobileDropdown(menu))}
 
             <a
               href="https://freeforcharity.org/"

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -133,8 +133,11 @@ export default function Navigation() {
           className="absolute left-1/2 -translate-x-1/2 mt-2 w-[40rem] max-w-[calc(100vw-2rem)] bg-white rounded-lg shadow-xl border border-gray-200 p-4 z-50 grid grid-cols-2 gap-x-6 gap-y-1"
         >
           {menu.sections.map((section) => (
-            <div key={section.heading} role="none">
-              <p className="px-3 pt-2 pb-1 text-xs font-bold uppercase tracking-wider text-gray-400">
+            <div key={section.heading} role="group" aria-label={section.heading}>
+              <p
+                aria-hidden="true"
+                className="px-3 pt-2 pb-1 text-xs font-bold uppercase tracking-wider text-gray-400"
+              >
                 {section.heading}
               </p>
               {section.items.map((item) => (

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -2,7 +2,7 @@
  * Shared navigation data used by the Navigation component.
  *
  * Audience-first mega-menu structure. Top level:
- *   Home · 🌱 Manage My Site (button) · Volunteer ▾ · Operate ▾ · For Charities ↗
+ *   Home · 🌱 Manage My Site (button) · Volunteer ▾ · Operate ▾ · For Charities & Donors ↗
  *
  * The two dropdowns are multi-section mega-menus:
  *   - Volunteer  → "Get involved" + "Training tracks"

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -1,9 +1,14 @@
 /**
  * Shared navigation data used by the Navigation component.
  *
- * Top level (audience-first): Home · Volunteer ▾ · Edit My Site · Training ▾ ·
- * Operate ▾ · Resources ▾ · For Charities & Donors ↗. Add new items here so
- * desktop and mobile menus stay in sync.
+ * Audience-first mega-menu structure. Top level:
+ *   Home · 🌱 Manage My Site (button) · Volunteer ▾ · Operate ▾ · For Charities ↗
+ *
+ * The two dropdowns are multi-section mega-menus:
+ *   - Volunteer  → "Get involved" + "Training tracks"
+ *   - Operate    → "Operations" + "Resources"
+ *
+ * Add new items to the relevant section so desktop and mobile menus stay in sync.
  */
 
 export interface NavDropdownItem {
@@ -12,158 +17,162 @@ export interface NavDropdownItem {
   description: string
 }
 
-export interface NavDropdown {
-  label: string
-  id: string
+export interface NavSection {
+  heading: string
   items: NavDropdownItem[]
 }
 
-/** Join & grow: the volunteer funnel and the designations you earn. */
-export const volunteerDropdown: NavDropdown = {
+export interface NavMenu {
+  label: string
+  id: string
+  sections: NavSection[]
+}
+
+/** Flattened items across all sections — used for active-state checks. */
+export function menuItems(menu: NavMenu): NavDropdownItem[] {
+  return menu.sections.flatMap((s) => s.items)
+}
+
+/** Join & grow: the volunteer funnel, the designations you earn, and training. */
+export const volunteerMenu: NavMenu = {
   label: 'Volunteer',
   id: 'volunteer',
-  items: [
+  sections: [
     {
-      label: 'Get Involved',
-      href: '/get-involved',
-      description: 'Ways to volunteer with FFC and how to start.',
+      heading: 'Get involved',
+      items: [
+        {
+          label: 'Get Involved',
+          href: '/get-involved',
+          description: 'Ways to volunteer with FFC and how to start.',
+        },
+        {
+          label: 'Volunteer Roles',
+          href: '/volunteer',
+          description: 'Web dev, Microsoft 365 / Google Workspace admin, data, design, military.',
+        },
+        {
+          label: 'Contributor Ladder',
+          href: '/contributor-ladder',
+          description: 'Progress from Contributor to Maintainer to Mentor.',
+        },
+        {
+          label: 'Recognition',
+          href: '/recognition',
+          description: 'Volunteer badges that map 1:1 to GitHub access roles.',
+        },
+        {
+          label: 'Continuing Education',
+          href: '/continuing-education',
+          description: 'Earn free CE credit (CPE/PDU/CEU) toward your certification.',
+        },
+        {
+          label: 'MOVSM',
+          href: '/movsm',
+          description: 'Military Outstanding Volunteer Service Medal pathway.',
+        },
+      ],
     },
     {
-      label: 'Volunteer Roles',
-      href: '/volunteer',
-      description: 'Web dev, Microsoft 365 / Google Workspace admin, data, design, military.',
-    },
-    {
-      label: 'Contributor Ladder',
-      href: '/contributor-ladder',
-      description: 'Progress from Contributor to Maintainer to Mentor.',
-    },
-    {
-      label: 'Recognition',
-      href: '/recognition',
-      description: 'Volunteer badges that map 1:1 to GitHub access roles.',
-    },
-    {
-      label: 'Continuing Education',
-      href: '/continuing-education',
-      description: 'Earn free CE credit (CPE/PDU/CEU) toward your certification.',
-    },
-    {
-      label: 'MOVSM',
-      href: '/movsm',
-      description: 'Military Outstanding Volunteer Service Medal pathway.',
-    },
-  ],
-}
-
-/** Role-based training tracks (modules × tiers). */
-export const trainingDropdown: NavDropdown = {
-  label: 'Training',
-  id: 'training',
-  items: [
-    {
-      label: 'All Training Tracks',
-      href: '/training',
-      description: 'Pick your role and see what you’re responsible for, by depth.',
-    },
-    {
-      label: 'Site Owner',
-      href: '/site-owner/training',
-      description: 'Operator-level training for editing your own charity site.',
-    },
-    {
-      label: 'Web Developer',
-      href: '/training/web-developer',
-      description: 'Build and maintain charity sites with an AI agent.',
-    },
-    {
-      label: 'Global Admin',
-      href: '/training-plan',
-      description: 'Microsoft 365 Global Administrator certification path.',
-    },
-    {
-      label: 'Google Workspace Admin',
-      href: '/training/google-workspace-admin',
-      description: 'Manage Google Workspace for charities, backed by certification.',
-    },
-    {
-      label: 'Data & Analytics',
-      href: '/training/data-analytics',
-      description: 'GA4, dashboards, and impact reporting for nonprofits.',
-    },
-    {
-      label: 'Canva Designer',
-      href: '/canva-designer-path',
-      description: 'Canva Designer certification path for nonprofits.',
+      heading: 'Training tracks',
+      items: [
+        {
+          label: 'All Training Tracks',
+          href: '/training',
+          description: 'Pick your role and see what you’re responsible for, by depth.',
+        },
+        {
+          label: 'Web Developer',
+          href: '/training/web-developer',
+          description: 'Build and maintain charity sites with an AI agent.',
+        },
+        {
+          label: 'Global Admin',
+          href: '/training-plan',
+          description: 'Microsoft 365 Global Administrator certification path.',
+        },
+        {
+          label: 'Google Workspace Admin',
+          href: '/training/google-workspace-admin',
+          description: 'Manage Google Workspace for charities, backed by certification.',
+        },
+        {
+          label: 'Data & Analytics',
+          href: '/training/data-analytics',
+          description: 'GA4, dashboards, and impact reporting for nonprofits.',
+        },
+        {
+          label: 'Canva Designer',
+          href: '/canva-designer-path',
+          description: 'Canva Designer certification path for nonprofits.',
+        },
+      ],
     },
   ],
 }
 
-/** Day-to-day operational tools for the FFC technical team. */
-export const operateDropdown: NavDropdown = {
+/** Run & reference: operational tools and supporting content for the team. */
+export const operateMenu: NavMenu = {
   label: 'Operate',
   id: 'operate',
-  items: [
+  sections: [
     {
-      label: 'Sites List',
-      href: '/sites-list',
-      description: 'All FFC-managed domains with health and migration status.',
+      heading: 'Operations',
+      items: [
+        {
+          label: 'Sites List',
+          href: '/sites-list',
+          description: 'All FFC-managed domains with health and migration status.',
+        },
+        {
+          label: 'Documentation',
+          href: '/documentation',
+          description: 'Project documentation and reference materials.',
+        },
+        {
+          label: 'Tech Stack',
+          href: '/tech-stack',
+          description: 'Technologies and tools used across FFC projects.',
+        },
+        {
+          label: 'Testing',
+          href: '/testing',
+          description: 'Testing strategy, live CI status, and best practices.',
+        },
+        {
+          label: 'Legacy WP Admin',
+          href: '/legacy-wordpress-administration',
+          description: 'WordPress-era operations, SOPs, and procedures for partner charities.',
+        },
+      ],
     },
     {
-      label: 'Documentation',
-      href: '/documentation',
-      description: 'Project documentation and reference materials.',
-    },
-    {
-      label: 'Tech Stack',
-      href: '/tech-stack',
-      description: 'Technologies and tools used across FFC projects.',
-    },
-    {
-      label: 'Testing',
-      href: '/testing',
-      description: 'Testing strategy, live CI status, and best practices.',
-    },
-    {
-      label: 'Legacy WP Admin',
-      href: '/legacy-wordpress-administration',
-      description: 'WordPress-era operations, SOPs, and procedures for partner charities.',
-    },
-  ],
-}
-
-/** Reference, how-to, and supporting content. */
-export const resourcesDropdown: NavDropdown = {
-  label: 'Resources',
-  id: 'resources',
-  items: [
-    {
-      label: 'Guides',
-      href: '/guides',
-      description: 'Step-by-step how-to guides for common tasks.',
-    },
-    {
-      label: 'Dev Environment Setup',
-      href: '/developer-environment-setup',
-      description: 'Start with your AI of choice — Claude, Codex, Gemini, or Copilot.',
-    },
-    {
-      label: 'Blog',
-      href: '/blog',
-      description: 'News, volunteer spotlights, and FFC stories.',
-    },
-    {
-      label: 'What FFC Delivers',
-      href: '/what-ffc-delivers',
-      description: 'What’s included when FFC builds a charity’s website.',
+      heading: 'Resources',
+      items: [
+        {
+          label: 'Guides',
+          href: '/guides',
+          description: 'Step-by-step how-to guides and account setup walkthroughs.',
+        },
+        {
+          label: 'Dev Environment Setup',
+          href: '/developer-environment-setup',
+          description: 'Start with your AI of choice — Claude, Codex, Gemini, or Copilot.',
+        },
+        {
+          label: 'Blog',
+          href: '/blog',
+          description: 'News, volunteer spotlights, and FFC stories.',
+        },
+        {
+          label: 'What FFC Delivers',
+          href: '/what-ffc-delivers',
+          description: 'What’s included when FFC builds a charity’s website.',
+        },
+      ],
     },
   ],
 }
 
 /** The dropdown menus rendered in the top bar, in order. */
-export const NAV_DROPDOWNS: NavDropdown[] = [
-  volunteerDropdown,
-  trainingDropdown,
-  operateDropdown,
-  resourcesDropdown,
-]
+export const NAV_MENUS: NavMenu[] = [volunteerMenu, operateMenu]


### PR DESCRIPTION
## Summary

The navigation simplification you approved: from five mixed dropdowns to an **audience-first mega-menu** with the charity-owner path as the standout CTA.

### Top bar: before → after
**Before:** Home · Volunteer ▾ · Edit My Site · Training ▾ · Operate ▾ · Resources ▾ · For Charities ↗ (5 dropdowns, audiences mixed with content-types)

**After:** Home · **🌱 Manage My Site** (button) · Volunteer ▾ · Operate ▾ · For Charities ↗ (**2 dropdowns + 1 button**)

### Mega-menus (multi-section panels with descriptions)
- **Volunteer ▾** → two columns: **Get involved** (Get Involved, Roles, Contributor Ladder, Recognition, CE, MOVSM) + **Training tracks** (All Training, Web Developer, Global Admin, Workspace Admin, Data & Analytics, Canva). Training folds in here, since training *is* the volunteer path.
- **Operate ▾** → **Operations** (Sites List, Documentation, Tech Stack, Testing, Legacy WP) + **Resources** (Guides, Dev Env Setup, Blog, What FFC Delivers). Resources folds in here.

No pages lost — every previous nav destination still has a home (verified by the navigation-coverage test). Each item keeps its one-line description in the panel, giving the cross-link depth you wanted; active items get `aria-current`.

### Disambiguation
- **"Manage My Site"** is the only filled CTA button in the bar — unambiguous about who it's for (renamed from "Edit My Site" to match how owners describe the task).
- **Homepage hero:** primary CTA relabeled **"Start Your Journey" → "Volunteer With FFC"**, so it stops competing with the charity-owner spotlight band; Contributor Ladder stays the secondary button.

### Data model
`src/data/navigation.ts` now exposes `NavMenu { sections: NavSection[] }` + `menuItems()` helper and a `NAV_MENUS` array; `Navigation.tsx` renders sectioned desktop panels (2-col grid) and grouped mobile accordions from it. Navigation tests rewritten for the new structure.

443 tests passing; type-check/lint/build clean.

Refs the onboarding-discoverability work in #450.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X4omPQW2ErDyZsMtxypuMe)_