### PR TITLE
fix: accept-invitation guide — invitations do appear in GitHub notifications

### DIFF
--- a/__tests__/charity-onboarding.test.js
+++ b/__tests__/charity-onboarding.test.js
@@ -20,15 +20,14 @@ describe('Accept-invitation walkthrough page', () => {
     expect(page).toContain('invited you to collaborate')
   })
 
-  it('corrects the notifications-page misconception (the 2-hour problem)', () => {
+  it('documents github.com/notifications as a place to accept', () => {
     expect(page).toContain('github.com/notifications')
-    expect(page.toLowerCase()).toContain('does')
-    expect(page.toLowerCase()).toContain('not')
+    expect(page).toContain('Accept from your GitHub notifications')
   })
 
   it('documents all three acceptance routes', () => {
     expect(page).toContain('Accept from the email')
-    expect(page).toContain('Accept from your repository page')
+    expect(page).toContain('Accept from your GitHub notifications')
     expect(page).toContain('/invitations')
   })
 

--- a/src/app/site-owner/accept-invitation/page.tsx
+++ b/src/app/site-owner/accept-invitation/page.tsx
@@ -317,10 +317,10 @@ export default function AcceptInvitationPage() {
             https://github.com/{EXAMPLE_REPO}/invitations
           </p>
           <p className="text-sm text-gray-700">
-            Some repositories also show a green banner at the top of the main repo page (github.com/
-            {EXAMPLE_REPO}) — if you see it, its <strong>Accept invitation</strong> button does the
-            same thing. It doesn&apos;t always appear, which is why the{' '}
-            <strong>/invitations</strong> link above is the reliable one.
+            Some repositories also show a green banner at the top of the main repo page (
+            <span className="font-mono">{`github.com/${EXAMPLE_REPO}`}</span>) — if you see it, its{' '}
+            <strong>Accept invitation</strong> button does the same thing. It doesn&apos;t always
+            appear, which is why the <strong>/invitations</strong> link above is the reliable one.
           </p>
           <BannerMock />
         </Route>

--- a/src/app/site-owner/accept-invitation/page.tsx
+++ b/src/app/site-owner/accept-invitation/page.tsx
@@ -180,27 +180,28 @@ export default function AcceptInvitationPage() {
             The one thing to understand first
           </h2>
           <p className="text-sm text-blue-900/90 mb-2">
-            Your invitation shows up in <strong>two places at the same time</strong>, and you only
-            need to use <em>one</em> of them:
+            The same invitation shows up in more than one place, and you only need to use{' '}
+            <em>one</em> of them to accept:
           </p>
-          <ol className="text-sm text-blue-900/90 list-decimal pl-5 space-y-1">
+          <ul className="text-sm text-blue-900/90 list-disc pl-5 space-y-1">
             <li>An email from GitHub, and</li>
-            <li>A green banner on your repository&apos;s page when you&apos;re logged in.</li>
-          </ol>
+            <li>
+              Your GitHub notifications at{' '}
+              <a
+                href="https://github.com/notifications"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline"
+              >
+                github.com/notifications
+              </a>{' '}
+              when you&apos;re signed in.
+            </li>
+          </ul>
           <p className="text-sm text-blue-900/90 mt-2">
-            <strong>Important:</strong> a repository invitation usually does <strong>not</strong>{' '}
-            appear at{' '}
-            <a
-              href="https://github.com/notifications"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="underline"
-            >
-              github.com/notifications
-            </a>
-            . That bell is for other things. If you went there and it was empty, you weren&apos;t
-            doing anything wrong — you were just looking in the one spot it doesn&apos;t show. Use
-            Route&nbsp;A or Route&nbsp;B below instead.
+            There&apos;s also a direct accept link for your repository (Route&nbsp;C) that always
+            works. If a place looks empty, it&apos;s almost always because you&apos;re signed in as
+            the wrong account — check that first, below.
           </p>
         </section>
 
@@ -211,10 +212,11 @@ export default function AcceptInvitationPage() {
             person?
           </h2>
           <p className="text-sm text-amber-900/90 mb-3">
-            The #1 reason an invitation seems &ldquo;missing&rdquo; is being logged into a{' '}
-            <strong>different GitHub account</strong> than the username you gave FFC (for example,
-            an old personal account, or a second account on a shared computer). The invite was sent
-            to one specific username — you must be signed in as that exact person to see it.
+            The #1 reason an invitation seems &ldquo;missing&rdquo; — even in your notifications —
+            is being logged into a <strong>different GitHub account</strong> than the username you
+            gave FFC (for example, an old personal account, or a second account on a shared
+            computer). The invite was sent to one specific username, so you must be signed in as
+            that exact person to see it.
           </p>
           <p className="text-sm text-amber-900/90">
             Check it: open{' '}
@@ -277,55 +279,71 @@ export default function AcceptInvitationPage() {
 
         <Route
           letter="B"
-          title="Accept from your repository page"
-          subtitle="The most reliable way — works even if the email never arrives"
+          title="Accept from your GitHub notifications"
+          subtitle="Works even if you can’t find the email"
         >
           <p className="text-sm text-gray-700 mb-2">
-            FFC will give you your repository&apos;s web address. It looks like this (yours will
-            have your charity&apos;s name):
-          </p>
-          <p className="text-sm font-mono bg-gray-100 rounded p-2 mb-3 break-all">
-            https://github.com/{EXAMPLE_REPO}
-          </p>
-          <p className="text-sm text-gray-700 mb-1">
-            Make sure you&apos;re signed in (see the warning above), then open that address. At the
-            top of the page you&apos;ll see a banner inviting you to collaborate. Click the green{' '}
+            Signed in as the right account, open{' '}
+            <a
+              href="https://github.com/notifications"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-teal-700 underline hover:text-teal-900"
+            >
+              github.com/notifications
+            </a>{' '}
+            (or click the <strong>bell icon</strong> in the top-right of GitHub). Your repository
+            invitation appears in the list — open it and click the green{' '}
             <strong>Accept invitation</strong> button.
           </p>
-          <BannerMock />
           <p className="text-sm text-gray-700">
-            If the banner doesn&apos;t appear, add <strong>/invitations</strong> to the end of the
-            address and open{' '}
-            <span className="font-mono break-all">
-              https://github.com/{EXAMPLE_REPO}/invitations
-            </span>{' '}
-            — the accept button lives there too.
+            If the list looks empty: double-check the account (the warning above), and make sure the
+            filter at the top is on <strong>Inbox</strong> / <strong>All</strong> rather than a
+            narrower view.
           </p>
         </Route>
 
         <Route
           letter="C"
-          title="Let FFC walk you through it live"
-          subtitle="When you just want a human on the line"
+          title="Accept from the direct repository link"
+          subtitle="The surest way — a link that goes straight to the accept button"
         >
-          <p className="text-sm text-gray-700">
-            No shame in this — it takes two minutes together. Text <strong>Clarke Moyer</strong> at{' '}
-            <a href="sms:520-222-8104" className="text-teal-700 underline hover:text-teal-900">
-              (520)&nbsp;222-8104
-            </a>{' '}
-            and say you&apos;re ready to accept your repository invitation. He can re-send it and
-            stay on the phone while you click <strong>Accept</strong>.
+          <p className="text-sm text-gray-700 mb-2">
+            FFC will give you your repository&apos;s web address. Signed in, open it with{' '}
+            <strong>/invitations</strong> on the end — this goes straight to the accept button
+            (yours will have your charity&apos;s name):
           </p>
+          <p className="text-sm font-mono bg-gray-100 rounded p-2 mb-3 break-all">
+            https://github.com/{EXAMPLE_REPO}/invitations
+          </p>
+          <p className="text-sm text-gray-700">
+            Some repositories also show a green banner at the top of the main repo page (github.com/
+            {EXAMPLE_REPO}) — if you see it, its <strong>Accept invitation</strong> button does the
+            same thing. It doesn&apos;t always appear, which is why the{' '}
+            <strong>/invitations</strong> link above is the reliable one.
+          </p>
+          <BannerMock />
         </Route>
+
+        {/* Live help fallback */}
+        <div className="bg-teal-50 border border-teal-200 rounded-xl p-5 text-sm text-teal-900">
+          <strong>Still stuck? Do it live with FFC.</strong> No shame in this — it takes two minutes
+          together. Text <strong>Clarke Moyer</strong> at{' '}
+          <a href="sms:520-222-8104" className="text-teal-700 underline hover:text-teal-900">
+            (520)&nbsp;222-8104
+          </a>{' '}
+          and say you&apos;re ready to accept your repository invitation. He can re-send it and stay
+          on the phone while you click <strong>Accept</strong>.
+        </div>
 
         {/* What success looks like */}
         <section className="bg-green-50 border border-green-200 rounded-xl p-6">
           <h2 className="text-lg font-bold text-green-900 mb-2">How you know it worked</h2>
           <p className="text-sm text-green-900/90">
-            After you click <strong>Accept invitation</strong>, the banner disappears and you land
-            on your repository&apos;s normal page — a list of files and folders. That&apos;s it:
-            you&apos;re now a <strong>collaborator</strong> and you (and your AI assistant) can make
-            changes. You never have to accept again.
+            After you click <strong>Accept invitation</strong>, you land on your repository&apos;s
+            normal page — a list of files and folders, with no invitation prompt left. That&apos;s
+            it: you&apos;re now a <strong>collaborator</strong> and you (and your AI assistant) can
+            make changes. You never have to accept again.
           </p>
         </section>
 

--- a/src/app/site-owner/page.tsx
+++ b/src/app/site-owner/page.tsx
@@ -449,10 +449,10 @@ export default function SiteOwnerPage() {
                 <p className="text-sm text-gray-700">
                   Once FFC adds you, you become a <strong>collaborator</strong> on your
                   charity&apos;s repository — just your one repo, nothing else. The invitation
-                  arrives as an email from GitHub <em>and</em> as a green banner on your repository
-                  page. This is the step people get stuck on, so we wrote a separate, every-click
-                  walkthrough — what the email looks like, who it&apos;s from, where to find it if
-                  it&apos;s not in your inbox, and two other ways to accept.
+                  arrives as an email from GitHub <em>and</em> in your GitHub notifications. This is
+                  the step people get stuck on, so we wrote a separate, every-click walkthrough —
+                  what the email looks like, who it&apos;s from, where to find it if it&apos;s not
+                  in your inbox, and the direct link to accept.
                 </p>
                 <Link
                   href="/site-owner/accept-invitation"

--- a/src/data/setup-guides.ts
+++ b/src/data/setup-guides.ts
@@ -129,7 +129,7 @@ export const SETUP_GUIDES: SetupGuide[] = [
           'Send your **GitHub username** to FFC (text Clarke Moyer at (520) 222-8104) so you can be added to your charity’s repository as a writer. You’ll then get an invitation to accept.',
           'Accepting that invitation is the step most people get stuck on, so we wrote an every-click walkthrough: **https://ffcadmin.org/site-owner/accept-invitation** — what the email looks like, who it’s from, and three ways to accept it.',
         ],
-        tip: 'The invitation does NOT appear at https://github.com/notifications — look for the email from GitHub, or the green banner on your repository page. The walkthrough above shows both.',
+        tip: 'You can accept from the email, from your GitHub notifications (https://github.com/notifications), or from the direct repository invitations link — whichever you find first. The walkthrough shows all three.',
       },
     ],
     faqs: [


### PR DESCRIPTION
## Summary

Corrects a factual error in the accept-invitation walkthrough. The previous version claimed a repository invitation "usually does **not** appear at `github.com/notifications`." That's wrong — per the site owner's own verification today, the invitation **does** show in GitHub notifications. This PR fixes the guidance so we're not sending people away from a place the invite actually is.

### Changes
- **`/site-owner/accept-invitation`:**
  - "The one thing to understand first" now says the invite appears as an **email** *and* in your **GitHub notifications**, plus a direct accept link — no more "not in notifications" claim.
  - **Route B** is now **"Accept from your GitHub notifications"** (`github.com/notifications` / the bell), with a note to check the Inbox/All filter if the list looks empty.
  - **Route C** is now **"Accept from the direct repository link"** (`github.com/<repo>/invitations`) — the deterministic route. The repo banner is demoted to "some repositories also show a banner… it doesn't always appear" (the owner has never seen it), so we no longer present it as the primary/reliable path.
  - Live-help (text Clarke) moved to a fallback callout.
  - "How you know it worked" no longer assumes a banner disappears.
  - The "are you signed in as the right account?" check now explicitly covers "missing even in notifications," which is the most likely real cause of the original stuck case.
- **Site-owner landing** invite step + **GitHub-account guide** tip updated to match (email + notifications + direct link, not "banner").
- Test updated to assert notifications is a documented acceptance route.

445 tests passing; type-check/lint/build clean.

Thanks to @clarkemoyer for the correction from real-world verification.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X4omPQW2ErDyZsMtxypuMe)_