### PR TITLE
feat: real charity examples on invite guide + clarify training role names

### DIFF
--- a/__tests__/charity-onboarding.test.js
+++ b/__tests__/charity-onboarding.test.js
@@ -31,6 +31,18 @@ describe('Accept-invitation walkthrough page', () => {
     expect(page).toContain('/invitations')
   })
 
+  it('shows real, clickable charity examples of the FFC-EX- repo pattern', () => {
+    for (const domain of [
+      'mitchellnchistory.org',
+      'americanlegionpost64.org',
+      'savewatersaveplanet.org',
+    ]) {
+      expect(page).toContain(domain)
+      expect(page).toContain(`FreeForCharity/FFC-EX-${domain}`)
+    }
+    expect(page).toContain('FFC-EX-')
+  })
+
   it('warns about being signed in as the right account', () => {
     expect(page.toLowerCase()).toContain('right')
     expect(page.toLowerCase()).toContain('account')

--- a/__tests__/charity-onboarding.test.js
+++ b/__tests__/charity-onboarding.test.js
@@ -38,9 +38,10 @@ describe('Accept-invitation walkthrough page', () => {
       'savewatersaveplanet.org',
     ]) {
       expect(page).toContain(domain)
-      expect(page).toContain(`FreeForCharity/FFC-EX-${domain}`)
     }
-    expect(page).toContain('FFC-EX-')
+    // Repos are derived from the domain via repoForDomain() to avoid drift.
+    expect(page).toContain('FreeForCharity/FFC-EX-')
+    expect(page).toContain('repoForDomain')
   })
 
   it('warns about being signed in as the right account', () => {

--- a/__tests__/components/ContributorLadderPage.test.tsx
+++ b/__tests__/components/ContributorLadderPage.test.tsx
@@ -130,7 +130,9 @@ describe('Contributor Ladder Page', () => {
 
     it('should have links to training programs', () => {
       render(<ContributorLadderPage />)
-      const globalAdminLinks = screen.getAllByRole('link', { name: /Global Admin Track/i })
+      const globalAdminLinks = screen.getAllByRole('link', {
+        name: /Microsoft 365 Administrator Track/i,
+      })
       const canvaDesignerLinks = screen.getAllByRole('link', { name: /Canva Designer Track/i })
 
       expect(globalAdminLinks.length).toBeGreaterThan(0)
@@ -139,7 +141,9 @@ describe('Contributor Ladder Page', () => {
 
     it('should have correct URLs for training program links', () => {
       render(<ContributorLadderPage />)
-      const globalAdminLinks = screen.getAllByRole('link', { name: /Global Admin Track/i })
+      const globalAdminLinks = screen.getAllByRole('link', {
+        name: /Microsoft 365 Administrator Track/i,
+      })
       const canvaDesignerLinks = screen.getAllByRole('link', { name: /Canva Designer Track/i })
 
       expect(globalAdminLinks[0]).toHaveAttribute('href', '/training-plan')

--- a/__tests__/components/ContributorLadderPage.test.tsx
+++ b/__tests__/components/ContributorLadderPage.test.tsx
@@ -130,23 +130,23 @@ describe('Contributor Ladder Page', () => {
 
     it('should have links to training programs', () => {
       render(<ContributorLadderPage />)
-      const globalAdminLinks = screen.getAllByRole('link', {
+      const m365AdminLinks = screen.getAllByRole('link', {
         name: /Microsoft 365 Administrator Track/i,
       })
       const canvaDesignerLinks = screen.getAllByRole('link', { name: /Canva Designer Track/i })
 
-      expect(globalAdminLinks.length).toBeGreaterThan(0)
+      expect(m365AdminLinks.length).toBeGreaterThan(0)
       expect(canvaDesignerLinks.length).toBeGreaterThan(0)
     })
 
     it('should have correct URLs for training program links', () => {
       render(<ContributorLadderPage />)
-      const globalAdminLinks = screen.getAllByRole('link', {
+      const m365AdminLinks = screen.getAllByRole('link', {
         name: /Microsoft 365 Administrator Track/i,
       })
       const canvaDesignerLinks = screen.getAllByRole('link', { name: /Canva Designer Track/i })
 
-      expect(globalAdminLinks[0]).toHaveAttribute('href', '/training-plan')
+      expect(m365AdminLinks[0]).toHaveAttribute('href', '/training-plan')
       expect(canvaDesignerLinks[0]).toHaveAttribute('href', '/canva-designer-path')
     })
   })

--- a/src/app/contributor-ladder/page.tsx
+++ b/src/app/contributor-ladder/page.tsx
@@ -426,7 +426,7 @@ export default function ContributorLadder() {
               href="/training-plan"
               className="inline-flex items-center justify-center px-8 py-4 bg-gradient-to-r from-blue-600 to-indigo-600 text-white rounded-lg font-semibold hover:from-blue-700 hover:to-indigo-700 transition-all shadow-lg hover:shadow-xl"
             >
-              Global Admin Track
+              Microsoft 365 Administrator Track
               <svg
                 className="ml-2 w-5 h-5"
                 fill="none"

--- a/src/app/get-involved/page.tsx
+++ b/src/app/get-involved/page.tsx
@@ -5,7 +5,7 @@ import NonprofitCallout from '@/components/NonprofitCallout'
 export const metadata: Metadata = {
   title: 'Get Involved',
   description:
-    'Join Free For Charity as a volunteer. Choose your track: Web Developer, Global Administrator, Google Workspace Admin, Data & Analytics, or Canva Designer — or just edit your own charity’s FFC website. Start building and make an impact.',
+    'Join Free For Charity as a volunteer. Choose your track: Web Developer, Microsoft 365 Administrator, Google Workspace Admin, Data & Analytics, or Canva Designer — or just edit your own charity’s FFC website. Start building and make an impact.',
 }
 
 const roles = [

--- a/src/app/get-involved/page.tsx
+++ b/src/app/get-involved/page.tsx
@@ -34,7 +34,7 @@ const roles = [
     estimate: 'flexible',
   },
   {
-    title: 'Global Administrator',
+    title: 'Microsoft 365 Administrator',
     subtitle: 'Manage Infrastructure & Security',
     description:
       'Become a dual-hatted admin for Microsoft 365 and GitHub. Manage DNS, email, security policies, and deployments for all FFC charity sites.',

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -16,7 +16,7 @@ export const metadata: Metadata = {
     template: '%s | Free For Charity Admin',
   },
   description:
-    'Volunteer training hub for Free For Charity. Complete Global Administrator or Canva Designer certification paths, learn our tech stack, and join the contributor ladder to build free websites for nonprofits.',
+    'Volunteer training hub for Free For Charity. Complete Microsoft 365 Administrator or Canva Designer certification paths, learn our tech stack, and join the contributor ladder to build free websites for nonprofits.',
   metadataBase: new URL(SITE_URL),
   alternates: {
     canonical: `${SITE_URL}/`,
@@ -38,13 +38,13 @@ export const metadata: Metadata = {
     siteName: 'Free For Charity Admin',
     title: 'Free For Charity Admin | Volunteer & Admin Training Hub',
     description:
-      'Training hub for Free For Charity volunteers. Explore Global Administrator and Canva Designer certification paths while helping nonprofits.',
+      'Training hub for Free For Charity volunteers. Explore Microsoft 365 Administrator and Canva Designer certification paths while helping nonprofits.',
   },
   twitter: {
     card: 'summary_large_image',
     title: 'Free For Charity Admin | Volunteer & Admin Training Hub',
     description:
-      'Training hub for Free For Charity volunteers. Explore Global Administrator and Canva Designer certification paths while helping nonprofits.',
+      'Training hub for Free For Charity volunteers. Explore Microsoft 365 Administrator and Canva Designer certification paths while helping nonprofits.',
   },
   icons: {
     icon: assetPath('/Svgs/ffc-logo.svg'),
@@ -83,7 +83,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
               url: 'https://ffcadmin.org',
               logo: `${SITE_URL}${assetPath('/Images/hero-logo.png')}`,
               description:
-                'Free For Charity trains volunteers through Global Administrator and Canva Designer certification paths to build and manage free websites for 501(c)(3) nonprofits.',
+                'Free For Charity trains volunteers through Microsoft 365 Administrator and Canva Designer certification paths to build and manage free websites for 501(c)(3) nonprofits.',
               foundingDate: '2013',
               areaServed: 'US',
               nonprofitStatus: '501c3',

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -540,239 +540,110 @@ export default function Home() {
         </div>
       </section>
 
-      {/* Learning Paths Section */}
+      {/* Volunteer training tracks — all roles */}
       <section className="py-16 px-4 sm:px-6 lg:px-8 bg-gray-50">
         <div className="max-w-7xl mx-auto">
           <div className="text-center mb-12">
             <h2 className="text-3xl md:text-4xl font-bold text-gray-900 mb-4">
-              Specialized Training Paths
+              Volunteer Training Tracks
             </h2>
             <p className="text-lg text-gray-600 max-w-3xl mx-auto">
-              We train volunteers in two distinct tracks, each with comprehensive certification
-              programs and hands-on project work
+              We split volunteering into focused roles, each with its own self-paced curriculum and
+              certification. Pick the one that fits you — or browse them all.
             </p>
           </div>
 
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
-            {/* Global Admin Path */}
-            <div className="bg-white rounded-xl shadow-xl p-8 hover:shadow-2xl transition-all">
-              <div className="flex items-start mb-6">
-                <div className="w-16 h-16 rounded-lg flex items-center justify-center flex-shrink-0 mr-4 bg-ffc-gradient-teal">
-                  <svg
-                    className="w-8 h-8 text-white"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                    aria-hidden="true"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"
-                    />
-                  </svg>
-                </div>
-                <div>
-                  <h3 className="text-2xl font-bold text-gray-900 mb-2">
-                    Global Administrator Track
-                  </h3>
-                  <p className="font-semibold" style={{ color: 'var(--color-ffc-teal-dark)' }}>
-                    Technical Infrastructure & Security
-                  </p>
-                </div>
-              </div>
-              <p className="text-gray-700 mb-6">
-                Comprehensive training in Microsoft 365, GitHub, and modern development practices.
-                Gain dual-hatted authority over nonprofit technology infrastructure with MS-900 and
-                GitHub Foundations certifications.
-              </p>
-              <ul className="space-y-2 mb-6">
-                <li className="flex items-start">
-                  <svg
-                    className="w-5 h-5 text-green-500 mt-0.5 mr-2 flex-shrink-0"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                    aria-hidden="true"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M5 13l4 4L19 7"
-                    />
-                  </svg>
-                  <span className="text-gray-700">Microsoft 365 administration & security</span>
-                </li>
-                <li className="flex items-start">
-                  <svg
-                    className="w-5 h-5 text-green-500 mt-0.5 mr-2 flex-shrink-0"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                    aria-hidden="true"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M5 13l4 4L19 7"
-                    />
-                  </svg>
-                  <span className="text-gray-700">
-                    GitHub repository management & AI-assisted development
-                  </span>
-                </li>
-                <li className="flex items-start">
-                  <svg
-                    className="w-5 h-5 text-green-500 mt-0.5 mr-2 flex-shrink-0"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                    aria-hidden="true"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M5 13l4 4L19 7"
-                    />
-                  </svg>
-                  <span className="text-gray-700">CI/CD pipelines & automated deployments</span>
-                </li>
-              </ul>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+            {[
+              {
+                title: 'Microsoft 365 Administrator',
+                blurb:
+                  'Run email, identity, MFA, and security for charities. Earn MS-900 + GitHub Foundations.',
+                href: '/training-plan',
+                icon: '🛡️',
+                cert: 'MS-900 · GitHub Foundations',
+              },
+              {
+                title: 'Google Workspace Administrator',
+                blurb:
+                  'Manage accounts, groups, shared drives, and security for charities that run on Google.',
+                href: '/training/google-workspace-admin',
+                icon: '🗂️',
+                cert: 'Google Workspace Administrator',
+              },
+              {
+                title: 'Web Developer',
+                blurb:
+                  'Build and maintain charity sites with an AI agent — Issue → PR → merge, no heavy setup.',
+                href: '/training/web-developer',
+                icon: '💻',
+                cert: 'Self-paced, project-based',
+              },
+              {
+                title: 'Data & Analytics',
+                blurb:
+                  'Set up GA4, build impact dashboards, and turn charity data into clear reporting.',
+                href: '/training/data-analytics',
+                icon: '📈',
+                cert: 'Google Analytics certification',
+              },
+              {
+                title: 'Canva Designer',
+                blurb:
+                  'Design brand kits, social templates, and marketing materials with Canva Pro.',
+                href: '/canva-designer-path',
+                icon: '🎨',
+                cert: 'Canva Design School',
+              },
+              {
+                title: 'See all training tracks',
+                blurb:
+                  'Compare every role by depth (Operator → Practitioner → Administrator) in one place.',
+                href: '/training',
+                icon: '🧭',
+                cert: 'Overview of all roles',
+              },
+            ].map((track) => (
               <Link
-                href="/training-plan"
-                className="inline-flex items-center justify-center w-full px-6 py-3 text-white rounded-lg font-semibold hover:opacity-90 transition-all shadow-lg bg-ffc-gradient-teal"
+                key={track.href}
+                href={track.href}
+                className="group block bg-white rounded-xl shadow-lg p-6 hover:shadow-xl transition-all transform hover:-translate-y-1"
               >
-                View Training Plan
-                <svg
-                  className="ml-2 w-5 h-5"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                  aria-hidden="true"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M13 7l5 5m0 0l-5 5m5-5H6"
-                  />
-                </svg>
+                <span className="text-3xl" aria-hidden="true">
+                  {track.icon}
+                </span>
+                <h3 className="text-lg font-bold text-gray-900 mt-3 mb-1 group-hover:text-blue-700">
+                  {track.title}
+                </h3>
+                <p className="text-sm text-gray-600 mb-3">{track.blurb}</p>
+                <p className="text-xs font-semibold uppercase tracking-wide text-gray-400">
+                  {track.cert}
+                </p>
               </Link>
-            </div>
+            ))}
+          </div>
 
-            {/* Canva Designer Path */}
-            <div className="bg-white rounded-xl shadow-xl p-8 hover:shadow-2xl transition-all">
-              <div className="flex items-start mb-6">
-                <div className="w-16 h-16 rounded-lg flex items-center justify-center flex-shrink-0 mr-4 bg-ffc-gradient-orange">
-                  <svg
-                    className="w-8 h-8 text-white"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                    aria-hidden="true"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M7 21a4 4 0 01-4-4V5a2 2 0 012-2h4a2 2 0 012 2v12a4 4 0 01-4 4zm0 0h12a2 2 0 002-2v-4a2 2 0 00-2-2h-2.343M11 7.343l1.657-1.657a2 2 0 012.828 0l2.829 2.829a2 2 0 010 2.828l-8.486 8.485M7 17h.01"
-                    />
-                  </svg>
-                </div>
-                <div>
-                  <h3 className="text-2xl font-bold text-gray-900 mb-2">Canva Designer Track</h3>
-                  <p className="font-semibold" style={{ color: 'var(--color-ffc-orange-dark)' }}>
-                    Professional Visual Design
-                  </p>
-                </div>
-              </div>
-              <p className="text-gray-700 mb-6">
-                Master Canva Pro to create professional brand identities and marketing materials.
-                Complete official Canva Design School courses and build comprehensive template
-                libraries for nonprofits.
-              </p>
-              <ul className="space-y-2 mb-6">
-                <li className="flex items-start">
-                  <svg
-                    className="w-5 h-5 text-green-500 mt-0.5 mr-2 flex-shrink-0"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                    aria-hidden="true"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M5 13l4 4L19 7"
-                    />
-                  </svg>
-                  <span className="text-gray-700">
-                    Complete brand kit development & style guides
-                  </span>
-                </li>
-                <li className="flex items-start">
-                  <svg
-                    className="w-5 h-5 text-green-500 mt-0.5 mr-2 flex-shrink-0"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                    aria-hidden="true"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M5 13l4 4L19 7"
-                    />
-                  </svg>
-                  <span className="text-gray-700">
-                    Social media templates for all major platforms
-                  </span>
-                </li>
-                <li className="flex items-start">
-                  <svg
-                    className="w-5 h-5 text-green-500 mt-0.5 mr-2 flex-shrink-0"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                    aria-hidden="true"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M5 13l4 4L19 7"
-                    />
-                  </svg>
-                  <span className="text-gray-700">Email marketing & print stationery designs</span>
-                </li>
-              </ul>
-              <Link
-                href="/canva-designer-path"
-                className="inline-flex items-center justify-center w-full px-6 py-3 text-white rounded-lg font-semibold hover:opacity-90 transition-all shadow-lg bg-ffc-gradient-orange"
+          <div className="text-center mt-10">
+            <Link
+              href="/get-involved"
+              className="inline-flex items-center justify-center px-6 py-3 bg-ffc-gradient-teal text-white rounded-lg font-semibold hover:opacity-90 transition-opacity shadow-lg"
+            >
+              Compare roles &amp; get involved
+              <svg
+                className="ml-2 w-5 h-5"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
               >
-                View Designer Path
-                <svg
-                  className="ml-2 w-5 h-5"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                  aria-hidden="true"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M13 7l5 5m0 0l-5 5m5-5H6"
-                  />
-                </svg>
-              </Link>
-            </div>
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M13 7l5 5m0 0l-5 5m5-5H6"
+                />
+              </svg>
+            </Link>
           </div>
         </div>
       </section>

--- a/src/app/site-owner/accept-invitation/page.tsx
+++ b/src/app/site-owner/accept-invitation/page.tsx
@@ -11,7 +11,29 @@ export const metadata: Metadata = {
   alternates: { canonical: 'https://ffcadmin.org/site-owner/accept-invitation/' },
 }
 
-const EXAMPLE_REPO = 'FreeForCharity/FFC-EX-yourcharity.org'
+// A real, live FFC charity site used as the running example so the repo name is
+// recognizable and clickable. The repo name is always FFC-EX- + the domain.
+const EXAMPLE_DOMAIN = 'mitchellnchistory.org'
+const EXAMPLE_REPO = `FreeForCharity/FFC-EX-${EXAMPLE_DOMAIN}`
+
+// Three deliberately different kinds of charity, to show the same pattern holds.
+const PATTERN_EXAMPLES = [
+  {
+    kind: 'History museum',
+    domain: 'mitchellnchistory.org',
+    repo: 'FreeForCharity/FFC-EX-mitchellnchistory.org',
+  },
+  {
+    kind: 'Veterans post',
+    domain: 'americanlegionpost64.org',
+    repo: 'FreeForCharity/FFC-EX-americanlegionpost64.org',
+  },
+  {
+    kind: 'Environmental nonprofit',
+    domain: 'savewatersaveplanet.org',
+    repo: 'FreeForCharity/FFC-EX-savewatersaveplanet.org',
+  },
+]
 
 /** A faithful, illustration-only reproduction of the GitHub invitation email. */
 function EmailMock() {
@@ -57,8 +79,8 @@ function EmailMock() {
         </div>
       </div>
       <figcaption className="text-center text-xs text-gray-400 mt-2">
-        Illustration of the email you&apos;ll receive — your repository name will be your
-        charity&apos;s.
+        Real example: the Mitchell County NC history museum at <strong>{EXAMPLE_DOMAIN}</strong>.
+        Yours will show your charity&apos;s own domain.
       </figcaption>
     </figure>
   )
@@ -202,6 +224,51 @@ export default function AcceptInvitationPage() {
             There&apos;s also a direct accept link for your repository (Route&nbsp;C) that always
             works. If a place looks empty, it&apos;s almost always because you&apos;re signed in as
             the wrong account — check that first, below.
+          </p>
+        </section>
+
+        {/* The naming pattern, shown with real charities */}
+        <section className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
+          <h2 className="text-lg font-bold text-gray-900 mb-1">
+            What your repository is called (the pattern)
+          </h2>
+          <p className="text-sm text-gray-700 mb-4">
+            Every FFC charity site lives in a repository named{' '}
+            <span className="font-mono">FFC-EX-</span>
+            <em>your-domain</em> inside the <strong>FreeForCharity</strong> organization. Once you
+            know your charity&apos;s website address, you know your repository address. These are
+            three real, live FFC charities — open any one to see a finished site and the repository
+            behind it:
+          </p>
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+            {PATTERN_EXAMPLES.map((ex) => (
+              <div key={ex.domain} className="rounded-lg border border-gray-200 bg-gray-50 p-3">
+                <p className="text-xs font-semibold uppercase tracking-wide text-gray-400 mb-1">
+                  {ex.kind}
+                </p>
+                <a
+                  href={`https://${ex.domain}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="block text-sm font-semibold text-blue-600 hover:underline break-all"
+                >
+                  {ex.domain}
+                </a>
+                <a
+                  href={`https://github.com/${ex.repo}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="mt-1 block text-xs font-mono text-indigo-600 hover:underline break-all"
+                >
+                  github.com/{ex.repo}
+                </a>
+              </div>
+            ))}
+          </div>
+          <p className="text-xs text-gray-500 mt-3">
+            See how each repository name is just <span className="font-mono">FFC-EX-</span> followed
+            by that charity&apos;s domain? Yours follows the same rule. (These are real examples —
+            you&apos;ll only ever be invited to your own.)
           </p>
         </section>
 

--- a/src/app/site-owner/accept-invitation/page.tsx
+++ b/src/app/site-owner/accept-invitation/page.tsx
@@ -11,28 +11,20 @@ export const metadata: Metadata = {
   alternates: { canonical: 'https://ffcadmin.org/site-owner/accept-invitation/' },
 }
 
+// The repo name is always FFC-EX- + the domain, inside the FreeForCharity org.
+const repoForDomain = (domain: string) => `FreeForCharity/FFC-EX-${domain}`
+
 // A real, live FFC charity site used as the running example so the repo name is
-// recognizable and clickable. The repo name is always FFC-EX- + the domain.
+// recognizable and clickable.
 const EXAMPLE_DOMAIN = 'mitchellnchistory.org'
-const EXAMPLE_REPO = `FreeForCharity/FFC-EX-${EXAMPLE_DOMAIN}`
+const EXAMPLE_REPO = repoForDomain(EXAMPLE_DOMAIN)
 
 // Three deliberately different kinds of charity, to show the same pattern holds.
+// Repos are derived from the domain so they can never drift out of sync.
 const PATTERN_EXAMPLES = [
-  {
-    kind: 'History museum',
-    domain: 'mitchellnchistory.org',
-    repo: 'FreeForCharity/FFC-EX-mitchellnchistory.org',
-  },
-  {
-    kind: 'Veterans post',
-    domain: 'americanlegionpost64.org',
-    repo: 'FreeForCharity/FFC-EX-americanlegionpost64.org',
-  },
-  {
-    kind: 'Environmental nonprofit',
-    domain: 'savewatersaveplanet.org',
-    repo: 'FreeForCharity/FFC-EX-savewatersaveplanet.org',
-  },
+  { kind: 'History museum', domain: EXAMPLE_DOMAIN },
+  { kind: 'Veterans post', domain: 'americanlegionpost64.org' },
+  { kind: 'Environmental nonprofit', domain: 'savewatersaveplanet.org' },
 ]
 
 /** A faithful, illustration-only reproduction of the GitHub invitation email. */
@@ -255,12 +247,12 @@ export default function AcceptInvitationPage() {
                   {ex.domain}
                 </a>
                 <a
-                  href={`https://github.com/${ex.repo}`}
+                  href={`https://github.com/${repoForDomain(ex.domain)}`}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="mt-1 block text-xs font-mono text-indigo-600 hover:underline break-all"
                 >
-                  github.com/{ex.repo}
+                  github.com/{repoForDomain(ex.domain)}
                 </a>
               </div>
             ))}

--- a/src/app/training-plan/layout.tsx
+++ b/src/app/training-plan/layout.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
-  title: 'Global Admin Training Plan',
+  title: 'Microsoft 365 Administrator Training Plan',
   description:
-    'Operation Digital Sovereignty - Global Administrator certification program covering Microsoft 365 and GitHub administration for Free For Charity volunteers.',
+    'Operation Digital Sovereignty - the Microsoft 365 Administrator certification program (covering Microsoft 365 Global Administrator duties and GitHub administration) for Free For Charity volunteers.',
 }
 
 export default function TrainingPlanLayout({ children }: { children: React.ReactNode }) {

--- a/src/app/training-plan/page.tsx
+++ b/src/app/training-plan/page.tsx
@@ -58,7 +58,9 @@ export default function TrainingPlan() {
                 d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"
               />
             </svg>
-            <h1 className="text-3xl md:text-4xl font-bold">Global Admin Training Plan</h1>
+            <h1 className="text-3xl md:text-4xl font-bold">
+              Microsoft 365 Administrator Training Plan
+            </h1>
           </div>
           <p className="text-blue-100 text-lg">
             Operation Digital Sovereignty - Forge a dual-hatted leader with Global Administrator and

--- a/src/app/training/page.tsx
+++ b/src/app/training/page.tsx
@@ -12,9 +12,9 @@ import {
 export const metadata: Metadata = {
   title: 'Training Tracks',
   description:
-    'Free For Charity training is organized as responsibility modules at three depths — Operator, Practitioner, and Administrator. Pick your role (Site Owner, Web Developer, Global Administrator, or Canva Designer) and see exactly what you’re responsible for.',
+    'Free For Charity training is organized as responsibility modules at three depths — Operator, Practitioner, and Administrator. Pick your role (Site Owner, Web Developer, Microsoft 365 Administrator, or Canva Designer) and see exactly what you’re responsible for.',
   keywords:
-    'FFC training tracks, site owner training, web developer training, global administrator, Canva designer, nonprofit technology training, Free For Charity',
+    'FFC training tracks, site owner training, web developer training, Microsoft 365 administrator, Google Workspace administrator, Canva designer, nonprofit technology training, Free For Charity',
   alternates: {
     canonical: 'https://ffcadmin.org/training/',
   },

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -262,11 +262,40 @@ export default function Footer() {
                 </Link>
               </li>
               <li>
+                <Link href="/training" className="text-gray-400 hover:text-white transition-colors">
+                  All Training Tracks
+                </Link>
+              </li>
+              <li>
                 <Link
                   href="/training-plan"
                   className="text-gray-400 hover:text-white transition-colors"
                 >
-                  Global Administrator
+                  Microsoft 365 Administrator
+                </Link>
+              </li>
+              <li>
+                <Link
+                  href="/training/google-workspace-admin"
+                  className="text-gray-400 hover:text-white transition-colors"
+                >
+                  Google Workspace Administrator
+                </Link>
+              </li>
+              <li>
+                <Link
+                  href="/training/web-developer"
+                  className="text-gray-400 hover:text-white transition-colors"
+                >
+                  Web Developer
+                </Link>
+              </li>
+              <li>
+                <Link
+                  href="/training/data-analytics"
+                  className="text-gray-400 hover:text-white transition-colors"
+                >
+                  Data &amp; Analytics
                 </Link>
               </li>
               <li>

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -87,12 +87,12 @@ export const volunteerMenu: NavMenu = {
           description: 'Build and maintain charity sites with an AI agent.',
         },
         {
-          label: 'Global Admin',
+          label: 'Microsoft 365 Administrator',
           href: '/training-plan',
-          description: 'Microsoft 365 Global Administrator certification path.',
+          description: 'Run M365 email, identity & security — MS-900 + GitHub Foundations.',
         },
         {
-          label: 'Google Workspace Admin',
+          label: 'Google Workspace Administrator',
           href: '/training/google-workspace-admin',
           description: 'Manage Google Workspace for charities, backed by certification.',
         },

--- a/src/data/training-modules.ts
+++ b/src/data/training-modules.ts
@@ -786,7 +786,7 @@ export const LEARNING_PATHS: LearningPath[] = [
   },
   {
     id: 'global-admin',
-    title: 'Global Administrator',
+    title: 'Microsoft 365 Administrator',
     persona: 'You manage Microsoft 365, GitHub, and infrastructure for all FFC charities.',
     intro:
       'The administrator path: full depth across every module, backed by the MS-900 and GitHub Foundations certifications. This is the complete "Operation Digital Sovereignty" program.',

--- a/src/data/volunteer-roles.ts
+++ b/src/data/volunteer-roles.ts
@@ -56,7 +56,7 @@ export const VOLUNTEER_ROLES: VolunteerRole[] = [
       'Earn MS-900 (FFC sponsors the exam)',
     ],
     startHref: '/training-plan',
-    startLabel: 'Start the Global Admin track',
+    startLabel: 'Start the Microsoft 365 Administrator track',
     gradient: 'from-teal-500 to-emerald-600',
     icon: '🛡️',
   },


### PR DESCRIPTION
## Summary

Two requested improvements.

### 1. Real, clickable charity examples on the accept-invitation guide
- The running example is now a **real live FFC site** — the Mitchell County NC history museum (`mitchellnchistory.org` → `FreeForCharity/FFC-EX-mitchellnchistory.org`) — so the email/banner mocks look authentic, with the domain named nearby so owners see the correlation.
- Added a **"What your repository is called (the pattern)"** section with **three deliberately different charity types**, each linking the live site *and* its repo (all verified 200):
  - 🏛️ History museum — `mitchellnchistory.org`
  - 🎖️ Veterans post — `americanlegionpost64.org`
  - 🌎 Environmental nonprofit — `savewatersaveplanet.org`
- It spells out the rule: **repo = `FFC-EX-` + your domain**, inside the FreeForCharity org — so once an owner knows their website address, they know their repo address.

### 2. Clarify the training roles and expose them everywhere
The path formerly called **"Global Admin"** is now consistently **"Microsoft 365 Administrator"**, so it reads as a peer of Google Workspace Administrator, Web Developer, Data & Analytics, and Canva Designer (the role split that already exists in the data was not reflected in the discovery surfaces). Renamed in: top-nav mega-menu, footer, homepage, get-involved, contributor-ladder, the `/training-plan` H1 + metadata, and the training-track data. *(Curriculum text that refers to the actual Microsoft 365 "Global Administrator" tenant role is intentionally left as-is — that's the correct product term.)*

Training is now surfaced in more places:
- **Homepage:** the old "two distinct tracks" section is replaced with a **6-card grid of all tracks** (Microsoft 365 Admin, Google Workspace Admin, Web Developer, Data & Analytics, Canva Designer, + "See all training tracks") and a "Compare roles & get involved" CTA.
- **Footer Learning Paths:** now lists All Training Tracks, Microsoft 365 Administrator, Google Workspace Administrator, Web Developer, Data & Analytics, Canva Designer.
- **Nav** Volunteer → Training tracks and **get-involved** already enumerate every role; labels are now consistent.

## Verification
- All example repo + live URLs return **200** (checked).
- 444 jest tests pass; **e2e smoke run locally (12 passed)** — ran Playwright before pushing this time, since nav labels + homepage changed. Type-check/lint/build clean. Updated the contributor-ladder test for the renamed link.

Refs #450, #452.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X4omPQW2ErDyZsMtxypuMe)_