### PR TITLE
feat: add Site Owner to the Volunteer training tracks menu

### DIFF
--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -82,6 +82,11 @@ export const volunteerMenu: NavMenu = {
           description: 'Pick your role and see what you’re responsible for, by depth.',
         },
         {
+          label: 'Site Owner',
+          href: '/site-owner/training',
+          description: 'Operator-level training for editing your own charity site.',
+        },
+        {
           label: 'Web Developer',
           href: '/training/web-developer',
           description: 'Build and maintain charity sites with an AI agent.',


### PR DESCRIPTION
## Summary

Adds **Site Owner** to the **Volunteer → Training tracks** column in the nav mega-menu (→ `/site-owner/training`). Site Owner is a distinct training track/path, so it now appears alongside the other tracks (All Training Tracks, Web Developer, Microsoft 365 Administrator, Google Workspace Administrator, Data & Analytics, Canva Designer) for discoverability — in addition to the prominent "Manage My Site" button.

One-line data addition to `src/data/navigation.ts`. The Navigation test counts menu items dynamically, so it stays green automatically.

444 jest tests pass; **e2e smoke run locally (12 passed)**; type-check/lint/build clean.

Refs #452, #454.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X4omPQW2ErDyZsMtxypuMe)_