### PR TITLE
chore(deps): pin undici >=7.28.0 to clear transitive advisories

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "typescript": "^5.9.3"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=20.18.1"
   },
   "packageManager": "pnpm@9.0.0",
   "pnpm": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
   "pnpm": {
     "overrides": {
       "postcss@<8.5.10": ">=8.5.10",
-      "eslint-plugin-react-hooks": "7.0.1"
+      "eslint-plugin-react-hooks": "7.0.1",
+      "undici@>=7.0.0 <7.28.0": ">=7.28.0 <8.0.0"
     }
   },
   "lint-staged": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   postcss@<8.5.10: '>=8.5.10'
   eslint-plugin-react-hooks: 7.0.1
+  undici@>=7.0.0 <7.28.0: '>=7.28.0 <8.0.0'
 
 importers:
 
@@ -3815,8 +3816,8 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
-  undici@7.27.1:
-    resolution: {integrity: sha512-UDdpiex+mzigiyrXrGbiUaF4HzTNhKbh2vRNFaTMzcqmLIPrZxaCtwo/1TMSuWoM1Xz3WiTo9KdgI3kRqYzJGg==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   unrs-resolver@1.12.2:
@@ -7229,7 +7230,7 @@ snapshots:
       meow: 14.1.0
       mime: 4.1.0
       srcset: 5.0.3
-      undici: 7.27.1
+      undici: 7.28.0
 
   lint-staged@17.0.7:
     dependencies:
@@ -8145,7 +8146,7 @@ snapshots:
 
   undici-types@7.24.6: {}
 
-  undici@7.27.1: {}
+  undici@7.28.0: {}
 
   unrs-resolver@1.12.2:
     dependencies:


### PR DESCRIPTION
## Summary

Clears all **8 `undici` Dependabot advisories** (`GHSA-pr7r-676h-xcf6` and related — 3 high / 3 moderate / 2 low). They came in transitively via the dev-only `linkinator@7.6.1 > undici@7.27.1`.

Fix is a single `pnpm.overrides` rule: `"undici@>=7.0.0 <7.28.0": ">=7.28.0 <8.0.0"`. The replacement range is **intentionally the patched 7.x line, not a hard 7.28.x pin** — it admits future 7.x patch releases while staying within the major `linkinator` (used by the CI link checks) is built against. It currently resolves to `7.28.0`.

`engines.node` is raised `>=20.0.0` → **`>=20.18.1`** to match undici 7.28's declared floor, so contributors on early 20.x get a clear signal instead of a confusing transitive engine warning. CI already runs Node 20 latest.

## Verification

- `pnpm audit`: 8 undici advisories → **0**
- `pnpm run lint` ✅ · `pnpm run build` ✅ · `pnpm test` → **553/553** ✅
- `undici` resolves to `7.28.0`

## Remaining audit item (intentionally not fixed)

One moderate remains: `js-yaml@3.14.2`, pulled **dev-only, test-time** by jest's coverage tooling (`@istanbuljs/load-nyc-config`, unmaintained, uses js-yaml v3's `safeLoad`). The only patch (`>=4.2.0`) is a breaking major that removed `safeLoad`, so a global override would break coverage. Our own direct `js-yaml` is already `^4.2.0`. Left as-is; it only parses trusted jest coverage config.
