### PR TITLE
feat(intake): collect desired domain and pass it to provisioning

### DIFF
--- a/.github/ISSUE_TEMPLATE/charity-intake.yml
+++ b/.github/ISSUE_TEMPLATE/charity-intake.yml
@@ -39,6 +39,14 @@ body:
       placeholder: 12-3456789
     validations:
       required: false
+  - type: input
+    id: desired-domain
+    attributes:
+      label: Desired domain name
+      description: If you already have — or want — a specific apex domain, enter it here (e.g. example.org). Leave blank if you're unsure; an FFC admin will help you choose one. Used to provision your site once a sponsoring admin is assigned.
+      placeholder: example.org
+    validations:
+      required: false
   - type: dropdown
     id: service
     attributes:

--- a/.github/workflows/trigger-provisioning.yml
+++ b/.github/workflows/trigger-provisioning.yml
@@ -55,13 +55,15 @@ jobs:
           set -uo pipefail
           # Extract the optional "Desired domain name" the applicant supplied, so
           # the Cloudflare provision workflow can read client_payload.domain.
-          # Issue-form bodies are "### Label\n\nvalue" blocks; pull the value
-          # under that heading, dropping the "_No response_" placeholder.
-          DOMAIN=$(printf '%s\n' "$BODY" \
-            | sed -n '/^### Desired domain name[[:space:]]*$/,/^### /p' \
-            | sed '1d;/^### /d' \
-            | grep -v '^[[:space:]]*$' | head -1 \
-            | tr -d '[:space:]')
+          # Issue-form bodies are "### Label\n\nvalue" blocks; an awk state
+          # machine starts capturing AFTER the heading and stops at the next one,
+          # printing the first non-empty value line.
+          DOMAIN=$(printf '%s\n' "$BODY" | awk '
+            /^### Desired domain name[[:space:]]*$/ { capture = 1; next }
+            /^### / { capture = 0 }
+            capture && NF { print; exit }
+          ' | tr -d '[:space:]')
+          # Drop the "_No response_" placeholder GitHub inserts for blank fields.
           if printf '%s' "$DOMAIN" | grep -qiE '^_no.?response_$'; then DOMAIN=""; fi
           gh api "repos/${TARGET_REPO}/dispatches" \
             -f "event_type=${EVENT_TYPE}" \

--- a/.github/workflows/trigger-provisioning.yml
+++ b/.github/workflows/trigger-provisioning.yml
@@ -50,13 +50,25 @@ jobs:
           ISSUE_URL: ${{ github.event.issue.html_url }}
           ASSIGNEE: ${{ github.event.issue.assignee.login }}
           REPO: ${{ github.repository }}
+          BODY: ${{ github.event.issue.body }}
         run: |
           set -uo pipefail
+          # Extract the optional "Desired domain name" the applicant supplied, so
+          # the Cloudflare provision workflow can read client_payload.domain.
+          # Issue-form bodies are "### Label\n\nvalue" blocks; pull the value
+          # under that heading, dropping the "_No response_" placeholder.
+          DOMAIN=$(printf '%s\n' "$BODY" \
+            | sed -n '/^### Desired domain name[[:space:]]*$/,/^### /p' \
+            | sed '1d;/^### /d' \
+            | grep -v '^[[:space:]]*$' | head -1 \
+            | tr -d '[:space:]')
+          if printf '%s' "$DOMAIN" | grep -qiE '^_no.?response_$'; then DOMAIN=""; fi
           gh api "repos/${TARGET_REPO}/dispatches" \
             -f "event_type=${EVENT_TYPE}" \
             -F "client_payload[ffcadmin_issue]=${ISSUE}" \
             -F "client_payload[charity_title]=${TITLE}" \
             -F "client_payload[issue_url]=${ISSUE_URL}" \
-            -F "client_payload[sponsor]=${ASSIGNEE}"
+            -F "client_payload[sponsor]=${ASSIGNEE}" \
+            -F "client_payload[domain]=${DOMAIN}"
           gh issue comment "$ISSUE" --repo "$REPO" --body \
             "✅ Verified assignment confirmed. Provisioning has been triggered in \`${TARGET_REPO}\`. This issue will update as the site is provisioned."

--- a/docs/migration-plan.md
+++ b/docs/migration-plan.md
@@ -20,6 +20,9 @@ verification:
   - `charity_title` — issue title (`[Intake] <charity name>`)
   - `issue_url` — link back to the FFCadmin issue
   - `sponsor` — assigned sponsoring admin's GitHub login
+  - `domain` — the applicant's desired apex domain from the intake form (may be
+    empty if left blank; the provision workflow should fall back to its `domain`
+    input / an admin prompt when empty)
 
 ## 2. Add the trigger to `15-website-provision.yml` (Cloudflare repo)
 


### PR DESCRIPTION
## Summary

Closes the domain gap flagged on the Cloudflare provisioning receiver (`FFC-Cloudflare-Automation#456`). That workflow keys on an apex **domain**, but the FFCadmin intake form never collected one — so a `repository_dispatch` had nothing to provision.

- **`charity-intake.yml`** — adds an optional **"Desired domain name"** field (placeholder `example.org`).
- **`trigger-provisioning.yml`** — extracts that field from the issue body and includes it as **`client_payload.domain`** in the dispatch.
- **`docs/migration-plan.md §1`** — documents `domain` in the payload contract.

`domain` is empty when the applicant leaves the field blank; the Cloudflare provision workflow falls back to its own `domain` input in that case, so this is non-breaking.

## Verification

- YAML parses (issue form + workflow) ✅
- `pnpm run lint` ✅ · `pnpm run build` ✅ · `pnpm test` → **553/553** ✅

## Pairs with

`FreeForCharity/FFC-Cloudflare-Automation#456` (the receiver) — once both land, the cross-repo provisioning chain carries the domain end-to-end. Still dormant until the `sponsoring-admins` team + `GH_PAT` exist (the guard skips otherwise).

Refs docs/migration-plan.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01PNahWrNd3XsoTQJ4Q9QsQ9)_