### PR TITLE
fix(intake): correct Key Vault secret names + dry-run, from live vault validation

### DIFF
--- a/.github/workflows/trigger-provisioning.yml
+++ b/.github/workflows/trigger-provisioning.yml
@@ -64,7 +64,7 @@ jobs:
           vault-name: ${{ vars.AZURE_KEY_VAULT_NAME }}
           # Export directly as GH_TOKEN so the dispatch step reads $GH_TOKEN at runtime.
           secrets: |
-            GH_TOKEN=${{ vars.KV_SECRET_GH_PAT || 'ffc-gh-pat' }}
+            GH_TOKEN=${{ vars.KV_SECRET_GH_PAT || 'read-all-cbm-github-pat' }}
 
       - name: Use GH PAT secret (fallback)
         if: steps.guard.outputs.enabled == 'true' && steps.guard.outputs.use_kv != 'true'

--- a/.github/workflows/verify-assignment.yml
+++ b/.github/workflows/verify-assignment.yml
@@ -59,7 +59,7 @@ jobs:
           vault-name: ${{ vars.AZURE_KEY_VAULT_NAME }}
           # Export directly as GH_TOKEN so the check step reads $GH_TOKEN at runtime.
           secrets: |
-            GH_TOKEN=${{ vars.KV_SECRET_GH_PAT || 'ffc-gh-pat' }}
+            GH_TOKEN=${{ vars.KV_SECRET_GH_PAT || 'read-all-cbm-github-pat' }}
 
       - name: Use GH PAT secret (fallback)
         if: steps.guard.outputs.enabled == 'true' && steps.guard.outputs.use_kv != 'true'

--- a/.github/workflows/whmcs-intake.yml
+++ b/.github/workflows/whmcs-intake.yml
@@ -11,6 +11,12 @@ name: WHMCS Intake (local)
 
 on:
   workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Print the applicant records to the log without creating issues'
+        required: false
+        type: boolean
+        default: false
   schedule:
     - cron: '0 8 * * *' # Once a day at 08:00 UTC (avoid over-polling WHMCS)
 
@@ -59,11 +65,12 @@ jobs:
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
           vault-name: ${{ vars.AZURE_KEY_VAULT_NAME }}
-          # Secret names default to the documented convention; override via vars.
+          # Defaults are the FFC vault's real secret names; override via vars.
+          # (WHMCS here authenticates with identifier + secret — there is no
+          # separate access-key secret.)
           secrets: |
-            WHMCS_API_IDENTIFIER=${{ vars.KV_SECRET_WHMCS_IDENTIFIER || 'whmcs-api-identifier' }}
-            WHMCS_API_SECRET=${{ vars.KV_SECRET_WHMCS_SECRET || 'whmcs-api-secret' }}
-            WHMCS_API_ACCESS_KEY=${{ vars.KV_SECRET_WHMCS_ACCESS_KEY || 'whmcs-api-access-key' }}
+            WHMCS_API_IDENTIFIER=${{ vars.KV_SECRET_WHMCS_IDENTIFIER || 'read-all-ffc-whmcs-api-identifier' }}
+            WHMCS_API_SECRET=${{ vars.KV_SECRET_WHMCS_SECRET || 'read-all-ffc-whmcs-api-secret' }}
 
       - name: Run WHMCS intake
         if: steps.guard.outputs.enabled == 'true'
@@ -72,7 +79,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           WHMCS_API_URL: ${{ vars.WHMCS_API_URL || 'https://freeforcharity.org/hub/includes/api.php' }}
-          # WHMCS_API_IDENTIFIER / _SECRET / _ACCESS_KEY come from Key Vault above.
+          # WHMCS_API_IDENTIFIER / _SECRET come from Key Vault above.
+          WHMCS_DRY_RUN: ${{ inputs.dry_run && '1' || '' }}
 
       - name: Create Pull Request (state file)
         if: steps.guard.outputs.enabled == 'true'

--- a/docs/azure-keyvault-setup.md
+++ b/docs/azure-keyvault-setup.md
@@ -92,7 +92,7 @@ steps:
       subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
       vault-name: ${{ vars.AZURE_KEY_VAULT_NAME }}
       secrets: |
-        WHMCS_API_SECRET=whmcs-api-secret
+        WHMCS_API_SECRET=read-all-ffc-whmcs-api-secret
   - run: node scripts/whmcs-applications.mjs # WHMCS_API_SECRET now in env
 ```
 

--- a/docs/azure-keyvault-setup.md
+++ b/docs/azure-keyvault-setup.md
@@ -17,6 +17,15 @@ before setup. A `secrets.GH_PAT` still works as a fallback for the latter two.
 
 ## What you configure (one time)
 
+> **Validated against the live `kv-ffc-admin-prod-cbm` vault** (2026-06-27). The
+> default secret names below are the real ones in that vault; a
+> `read-all-ffc-azure-kv-reader-client-id` reader identity already exists — use
+> its client ID for `AZURE_CLIENT_ID`. The WHMCS secret slots currently hold
+> `PLACEHOLDER-SET-VIA-AZURE-PORTAL`; populate them with the real values before
+> running. **Also note:** the WHMCS API IP-restricts — the runner's egress IP
+> must be on the WHMCS API allow-list, or calls fail with `Invalid IP` (verify
+> GitHub-hosted runner ranges are allowed, or use a self-hosted runner).
+
 ### 1. An Entra identity with a federated credential
 
 Create an Entra **app registration** (or user-assigned managed identity) and add
@@ -38,31 +47,30 @@ get/list **access policy** if the vault uses the legacy access-policy model.
 
 ### 3. Store the secrets in the vault
 
-| Default secret name    | Holds                                           |
-| ---------------------- | ----------------------------------------------- |
-| `whmcs-api-identifier` | WHMCS API identifier                            |
-| `whmcs-api-secret`     | WHMCS API secret                                |
-| `whmcs-api-access-key` | WHMCS API access key (optional)                 |
-| `ffc-gh-pat`           | Cross-repo PAT (`repo`, `workflow`, `read:org`) |
+| Default secret name                 | Holds                                           |
+| ----------------------------------- | ----------------------------------------------- |
+| `read-all-ffc-whmcs-api-identifier` | WHMCS API identifier                            |
+| `read-all-ffc-whmcs-api-secret`     | WHMCS API secret                                |
+| `read-all-cbm-github-pat`           | Cross-repo PAT (`repo`, `workflow`, `read:org`) |
 
+WHMCS authenticates with identifier + secret only (no separate access key).
 Names are overridable — see the `KV_SECRET_*` variables below.
 
 ### 4. Set GitHub Actions **variables** (repo → Settings → Variables)
 
 These are non-secret identifiers, so they are **variables**, not secrets:
 
-| Variable                     | Required | Example / default                  |
-| ---------------------------- | -------- | ---------------------------------- |
-| `AZURE_CLIENT_ID`            | yes      | Entra app/identity client ID       |
-| `AZURE_TENANT_ID`            | yes      | Entra tenant ID                    |
-| `AZURE_SUBSCRIPTION_ID`      | yes      | Azure subscription ID              |
-| `AZURE_KEY_VAULT_NAME`       | yes      | Vault name, e.g. `ffc-kv`          |
-| `WHMCS_API_URL`              | no       | defaults to the FFC WHMCS endpoint |
-| `WHMCS_ONBOARDING_PIDS`      | no       | defaults to `16,33`                |
-| `KV_SECRET_WHMCS_IDENTIFIER` | no       | defaults to `whmcs-api-identifier` |
-| `KV_SECRET_WHMCS_SECRET`     | no       | defaults to `whmcs-api-secret`     |
-| `KV_SECRET_WHMCS_ACCESS_KEY` | no       | defaults to `whmcs-api-access-key` |
-| `KV_SECRET_GH_PAT`           | no       | defaults to `ffc-gh-pat`           |
+| Variable                     | Required | Example / default                               |
+| ---------------------------- | -------- | ----------------------------------------------- |
+| `AZURE_CLIENT_ID`            | yes      | Entra app/identity client ID                    |
+| `AZURE_TENANT_ID`            | yes      | Entra tenant ID                                 |
+| `AZURE_SUBSCRIPTION_ID`      | yes      | Azure subscription ID                           |
+| `AZURE_KEY_VAULT_NAME`       | yes      | Vault name, e.g. `ffc-kv`                       |
+| `WHMCS_API_URL`              | no       | defaults to the FFC WHMCS endpoint              |
+| `WHMCS_ONBOARDING_PIDS`      | no       | defaults to `16,33`                             |
+| `KV_SECRET_WHMCS_IDENTIFIER` | no       | defaults to `read-all-ffc-whmcs-api-identifier` |
+| `KV_SECRET_WHMCS_SECRET`     | no       | defaults to `read-all-ffc-whmcs-api-secret`     |
+| `KV_SECRET_GH_PAT`           | no       | defaults to `read-all-cbm-github-pat`           |
 
 Setting `AZURE_CLIENT_ID` + `AZURE_KEY_VAULT_NAME` is what flips the guards from
 "skip" to "run".

--- a/scripts/whmcs-applications.mjs
+++ b/scripts/whmcs-applications.mjs
@@ -186,12 +186,19 @@ async function main() {
     console.warn('WHMCS credentials not set (expected from Azure Key Vault). Skipping.')
     return
   }
+  const applications = await collect()
+  console.log(`WHMCS intake: ${applications.length} applicant(s) found.`)
+  // Dry run: print the PII-safe records and stop — no GitHub issues created.
+  // Used for validating the WHMCS path before relying on it (and exposed as a
+  // workflow_dispatch input).
+  if (process.env.WHMCS_DRY_RUN) {
+    console.log(JSON.stringify(applications, null, 2))
+    return
+  }
   if (!token) {
     console.warn('No GITHUB_TOKEN; cannot create issues. Skipping.')
     return
   }
-  const applications = await collect()
-  console.log(`WHMCS intake: ${applications.length} applicant(s) found.`)
   await syncIntakeIssues({ applications, repo, token, stateFile: STATE_FILE, source: 'WHMCS' })
 }
 


### PR DESCRIPTION
## Summary

Fixes found by actually running the pipeline end-to-end against the **live `kv-ffc-admin-prod-cbm` vault** (Azure CLI device login) and the **live WHMCS endpoint**. The original #477 defaults were guesses; these are the real values.

## What the live test found & fixed

- **Real secret names** (the #477 defaults didn't exist): `read-all-ffc-whmcs-api-identifier`, `read-all-ffc-whmcs-api-secret`, `read-all-cbm-github-pat`. Updated the workflow defaults + doc.
- **No access-key secret** — WHMCS authenticates with identifier + secret only. The old workflow fetched `whmcs-api-access-key`, which **doesn't exist in the vault and would have failed the composite action**. Removed.
- **`dry_run` mode** — added a `workflow_dispatch` input + `WHMCS_DRY_RUN` env that prints the PII-safe records without creating issues, so the WHMCS path can be validated safely.
- **Doc notes** the live findings (below).

## What was validated ✅ vs. blocked ⛔

| Step | Result |
|------|--------|
| Azure CLI install + device auth | ✅ authenticated as `clarkemoyer@freeforcharity.org` |
| Key Vault discovery + secret read | ✅ found `kv-ffc-admin-prod-cbm`, read values |
| Real secret naming | ✅ captured; a `read-all-ffc-azure-kv-reader-client-id` reader identity already exists |
| WHMCS endpoint reachability | ✅ reachable; structured JSON error path exercised |
| WHMCS happy path (real applicants) | ⛔ blocked — see below |

**Two environmental blockers (not code):**
1. The WHMCS secret slots hold `PLACEHOLDER-SET-VIA-AZURE-PORTAL` — real creds aren't in the vault yet.
2. **WHMCS API IP-restricts.** A live call returned `{"result":"error","message":"Invalid IP 160.79.106.108"}` (this sandbox's egress IP). The runner's egress IP must be on the WHMCS API allow-list — worth confirming GitHub-hosted runner ranges are allowed, or using a self-hosted runner.

## To finish validation (needs your access)

1. Populate the three `read-all-ffc-whmcs-api-*` secrets with real values (Azure Portal).
2. Ensure the runner IP is allow-listed in WHMCS (or self-hosted runner).
3. Run `whmcs-intake.yml` with **`dry_run: true`** — it'll print the applicant records. I can read that run and confirm.

Verified locally: lint clean, **556/556 tests**, all YAML parses.

Refs docs/azure-keyvault-setup.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01PNahWrNd3XsoTQJ4Q9QsQ9)_