### PR TITLE
fix(intake): route WHMCS through FFC APIM gateway (static IP) + placeholder guard

### DIFF
--- a/.github/workflows/whmcs-intake.yml
+++ b/.github/workflows/whmcs-intake.yml
@@ -78,7 +78,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
-          WHMCS_API_URL: ${{ vars.WHMCS_API_URL || 'https://freeforcharity.org/hub/includes/api.php' }}
+          # Route through the FFC APIM gateway (static egress IP 20.231.116.111,
+          # the only IP WHMCS allow-lists). GitHub runner IPs are dynamic and
+          # would be rejected with "Invalid IP". See docs/whmcs-apim-routing.md in
+          # FFC-Cloudflare-Automation. Override via vars.WHMCS_API_URL if needed.
+          WHMCS_API_URL: ${{ vars.WHMCS_API_URL || 'https://apim-ffc-gateway-prod.azure-api.net/whmcs/api.php' }}
           # WHMCS_API_IDENTIFIER / _SECRET come from Key Vault above.
           WHMCS_DRY_RUN: ${{ inputs.dry_run && '1' || '' }}
 

--- a/docs/azure-keyvault-setup.md
+++ b/docs/azure-keyvault-setup.md
@@ -22,9 +22,13 @@ before setup. A `secrets.GH_PAT` still works as a fallback for the latter two.
 > `read-all-ffc-azure-kv-reader-client-id` reader identity already exists — use
 > its client ID for `AZURE_CLIENT_ID`. The WHMCS secret slots currently hold
 > `PLACEHOLDER-SET-VIA-AZURE-PORTAL`; populate them with the real values before
-> running. **Also note:** the WHMCS API IP-restricts — the runner's egress IP
-> must be on the WHMCS API allow-list, or calls fail with `Invalid IP` (verify
-> GitHub-hosted runner ranges are allowed, or use a self-hosted runner).
+> running. **WHMCS IP restriction:** GitHub runner IPs are dynamic and rejected
+> with `Invalid IP`, so `whmcs-intake.yml` routes WHMCS calls through the FFC
+> **APIM gateway** (`https://apim-ffc-gateway-prod.azure-api.net/whmcs/api.php`,
+> static egress IP `20.231.116.111` — the one IP WHMCS allow-lists). This mirrors
+> `FFC-Cloudflare-Automation`'s `docs/whmcs-apim-routing.md`; no per-repo IP work
+> is needed (it also requires WHMCS **Proxy IP Header = `CF-Connecting-IP`**,
+> configured once on the WHMCS side).
 
 ### 1. An Entra identity with a federated credential
 

--- a/docs/azure-keyvault-setup.md
+++ b/docs/azure-keyvault-setup.md
@@ -64,17 +64,17 @@ Names are overridable — see the `KV_SECRET_*` variables below.
 
 These are non-secret identifiers, so they are **variables**, not secrets:
 
-| Variable                     | Required | Example / default                               |
-| ---------------------------- | -------- | ----------------------------------------------- |
-| `AZURE_CLIENT_ID`            | yes      | Entra app/identity client ID                    |
-| `AZURE_TENANT_ID`            | yes      | Entra tenant ID                                 |
-| `AZURE_SUBSCRIPTION_ID`      | yes      | Azure subscription ID                           |
-| `AZURE_KEY_VAULT_NAME`       | yes      | Vault name, e.g. `ffc-kv`                       |
-| `WHMCS_API_URL`              | no       | defaults to the FFC WHMCS endpoint              |
-| `WHMCS_ONBOARDING_PIDS`      | no       | defaults to `16,33`                             |
-| `KV_SECRET_WHMCS_IDENTIFIER` | no       | defaults to `read-all-ffc-whmcs-api-identifier` |
-| `KV_SECRET_WHMCS_SECRET`     | no       | defaults to `read-all-ffc-whmcs-api-secret`     |
-| `KV_SECRET_GH_PAT`           | no       | defaults to `read-all-cbm-github-pat`           |
+| Variable                     | Required | Example / default                                    |
+| ---------------------------- | -------- | ---------------------------------------------------- |
+| `AZURE_CLIENT_ID`            | yes      | Entra app/identity client ID                         |
+| `AZURE_TENANT_ID`            | yes      | Entra tenant ID                                      |
+| `AZURE_SUBSCRIPTION_ID`      | yes      | Azure subscription ID                                |
+| `AZURE_KEY_VAULT_NAME`       | yes      | Vault name, e.g. `ffc-kv`                            |
+| `WHMCS_API_URL`              | no       | defaults to the FFC APIM gateway (`…/whmcs/api.php`) |
+| `WHMCS_ONBOARDING_PIDS`      | no       | defaults to `16,33`                                  |
+| `KV_SECRET_WHMCS_IDENTIFIER` | no       | defaults to `read-all-ffc-whmcs-api-identifier`      |
+| `KV_SECRET_WHMCS_SECRET`     | no       | defaults to `read-all-ffc-whmcs-api-secret`          |
+| `KV_SECRET_GH_PAT`           | no       | defaults to `read-all-cbm-github-pat`                |
 
 Setting `AZURE_CLIENT_ID` + `AZURE_KEY_VAULT_NAME` is what flips the guards from
 "skip" to "run".

--- a/scripts/whmcs-applications.mjs
+++ b/scripts/whmcs-applications.mjs
@@ -24,7 +24,12 @@ import { syncIntakeIssues, errMsg } from './lib/intake-issues.mjs'
 const moduleDir = dirname(fileURLToPath(import.meta.url))
 const STATE_FILE = join(moduleDir, '..', 'automation', 'applications-sync-state.json')
 
-const apiUrl = process.env.WHMCS_API_URL || 'https://freeforcharity.org/hub/includes/api.php'
+// Default to the FFC APIM gateway (static egress IP that WHMCS allow-lists);
+// GitHub runner IPs are dynamic and get rejected with "Invalid IP". See
+// docs/whmcs-apim-routing.md in FFC-Cloudflare-Automation.
+const apiUrl =
+  process.env.WHMCS_API_URL || 'https://apim-ffc-gateway-prod.azure-api.net/whmcs/api.php'
+const PLACEHOLDER = 'PLACEHOLDER-SET-VIA-AZURE-PORTAL'
 const identifier = process.env.WHMCS_API_IDENTIFIER
 const secret = process.env.WHMCS_API_SECRET
 const accessKey = process.env.WHMCS_API_ACCESS_KEY
@@ -184,6 +189,13 @@ async function collect() {
 async function main() {
   if (!identifier || !secret) {
     console.warn('WHMCS credentials not set (expected from Azure Key Vault). Skipping.')
+    return
+  }
+  if (identifier === PLACEHOLDER || secret === PLACEHOLDER) {
+    console.warn(
+      'WHMCS Key Vault secrets still hold the scaffolding placeholder; set the real ' +
+        'identifier/secret in the vault before running. Skipping.'
+    )
     return
   }
   const applications = await collect()


### PR DESCRIPTION
## Summary

Adopts the WHMCS capabilities `FFC-Cloudflare-Automation` shipped on 2026-06-28 so FFCadmin's local intake actually works from a GitHub runner.

**This corrects a real defect** in the prior intake workflow: it called WHMCS directly (`freeforcharity.org/hub/includes/api.php`), which a GitHub-hosted runner can't reach — WHMCS IP-restricts and runner IPs are dynamic, so every run would fail with `Invalid IP` (confirmed by live test). The CF repo solved this by routing through Azure APIM.

## Changes

- **`whmcs-intake.yml`** — `WHMCS_API_URL` now defaults to the **APIM gateway** `https://apim-ffc-gateway-prod.azure-api.net/whmcs/api.php`. APIM egresses from the static IP (`20.231.116.111`) that WHMCS allow-lists, so any runner works. (Backend-agnostic + keyless today, mirroring `docs/whmcs-apim-routing.md`.)
- **`whmcs-applications.mjs`** — same default; plus a guard that skips with a clear message when the KV secrets still hold `PLACEHOLDER-SET-VIA-AZURE-PORTAL` (matches the CF `whmcs-secrets-from-kv` behavior, avoids a confusing auth/IP error).
- **`docs/azure-keyvault-setup.md`** — replaces the earlier "verify runner ranges / use self-hosted" note with the APIM routing reality (and the required WHMCS-side `Proxy IP Header = CF-Connecting-IP`).

## Why this is the right approach
- It reuses FFC's existing, **already-validated** APIM `whmcs` API (the CF repo verified a live `GetProducts` returning `result: success` through it).
- No per-repo IP work, no self-hosted runner — the static IP is shared infrastructure.

## Verification
- `pnpm run lint` ✅ · `pnpm test` → **556/556** ✅ · YAML + `node --check` ✅

Note: still needs the real WHMCS secrets populated in the vault (placeholders today) before a live run; the new guard makes that state obvious.

Refs FFC-Cloudflare-Automation docs/whmcs-apim-routing.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01PNahWrNd3XsoTQJ4Q9QsQ9)_