### PR TITLE
fix(ci): align KV login to azure/login@v3 with allow-no-subscriptions

### DIFF
--- a/.github/actions/azure-kv-secrets/action.yml
+++ b/.github/actions/azure-kv-secrets/action.yml
@@ -29,14 +29,25 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Azure login (OIDC)
+    # Two conditional logins so an empty subscription-id is genuinely omitted
+    # rather than passed as "" (which azure/login could treat as a real value).
+    # allow-no-subscriptions lets a KV-reader identity with only vault data-plane
+    # access (no subscription RBAC) log in successfully.
+    - name: Azure login (OIDC, with subscription)
+      if: inputs.subscription-id != ''
       uses: azure/login@v3
       with:
         client-id: ${{ inputs.client-id }}
         tenant-id: ${{ inputs.tenant-id }}
         subscription-id: ${{ inputs.subscription-id }}
-        # The KV-reader identity may lack subscription RBAC (data-plane access to
-        # the vault is enough), so don't fail login on no accessible subscription.
+        allow-no-subscriptions: true
+
+    - name: Azure login (OIDC, no subscription)
+      if: inputs.subscription-id == ''
+      uses: azure/login@v3
+      with:
+        client-id: ${{ inputs.client-id }}
+        tenant-id: ${{ inputs.tenant-id }}
         allow-no-subscriptions: true
 
     - name: Load secrets from Key Vault

--- a/.github/actions/azure-kv-secrets/action.yml
+++ b/.github/actions/azure-kv-secrets/action.yml
@@ -11,8 +11,12 @@ inputs:
     description: 'Entra tenant ID.'
     required: true
   subscription-id:
-    description: 'Azure subscription ID.'
-    required: true
+    description: >-
+      Azure subscription ID (optional). The KV-reader identity often has only
+      data-plane access to the vault and no subscription RBAC, so login uses
+      allow-no-subscriptions and does not require this.
+    required: false
+    default: ''
   vault-name:
     description: 'Key Vault name (not the full URL).'
     required: true
@@ -26,11 +30,14 @@ runs:
   using: composite
   steps:
     - name: Azure login (OIDC)
-      uses: azure/login@v2
+      uses: azure/login@v3
       with:
         client-id: ${{ inputs.client-id }}
         tenant-id: ${{ inputs.tenant-id }}
         subscription-id: ${{ inputs.subscription-id }}
+        # The KV-reader identity may lack subscription RBAC (data-plane access to
+        # the vault is enough), so don't fail login on no accessible subscription.
+        allow-no-subscriptions: true
 
     - name: Load secrets from Key Vault
       shell: bash


### PR DESCRIPTION
## Summary

De-risks the Azure OIDC login in the reusable `azure-kv-secrets` composite action by matching the **validated** pattern in `FFC-Cloudflare-Automation`'s `whmcs-secrets-from-kv`:

- `azure/login@v2` → **`@v3`**
- add **`allow-no-subscriptions: true`**
- make `subscription-id` **optional**

**Why:** the shared FFC **KV-reader identity** (`read-all-ffc-azure-kv-reader-client-id`) has vault *data-plane* access but not necessarily subscription RBAC. The previous step required a subscription, which could fail the OIDC login with that identity. CF's working WHMCS workflows use `allow-no-subscriptions: true` for exactly this reason — this brings FFCadmin in line.

No caller change needed: the workflows still pass `vars.AZURE_SUBSCRIPTION_ID` (now optional/ignored if the identity lacks access).

## Verification
- action YAML parses ✅ · `pnpm run lint` ✅ (no app code touched)

Discovered while validating activation against the live Azure tenant.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PNahWrNd3XsoTQJ4Q9QsQ9)_