### PR TITLE
feat(roadmap): richer applicant cards from WHMCS (status, mission, Candid, EIN)

### DIFF
--- a/__tests__/whmcs-applications.test.js
+++ b/__tests__/whmcs-applications.test.js
@@ -7,16 +7,28 @@
  * 501c3 tier mapping, mission truncation, and the sort order.
  */
 
-let buildApplicationRecords, TIER_BY_PID, MISSION_MAX_LENGTH
+let buildApplicationRecords, TIER_BY_PID, MISSION_MAX_LENGTH, sanitizeCandidUrl, sanitizeEin
 
 beforeAll(async () => {
   const mod = await import('../scripts/whmcs-applications.mjs')
   buildApplicationRecords = mod.buildApplicationRecords
   TIER_BY_PID = mod.TIER_BY_PID
   MISSION_MAX_LENGTH = mod.MISSION_MAX_LENGTH
+  sanitizeCandidUrl = mod.sanitizeCandidUrl
+  sanitizeEin = mod.sanitizeEin
 })
 
-const ALLOWED_KEYS = ['id', 'charityName', 'serviceTier', 'missionExcerpt', 'submittedAt']
+const ALLOWED_KEYS = [
+  'id',
+  'charityName',
+  'charityStage',
+  'charityStatusOption',
+  'serviceTier',
+  'missionExcerpt',
+  'candidUrl',
+  'ein',
+  'submittedAt',
+]
 
 describe('buildApplicationRecords', () => {
   it('emits only the PII-safe allowlist and gates on a public org name', () => {
@@ -75,6 +87,25 @@ describe('buildApplicationRecords', () => {
     expect(app.missionExcerpt).toBe('Health & hope for "all"')
   })
 
+  it('sanitizes Candid/GuideStar URLs (unwrap HTML, reject placeholders)', () => {
+    expect(sanitizeCandidUrl('<a href="https://app.candid.org/profile/123/x">x</a>')).toBe(
+      'https://app.candid.org/profile/123/x'
+    )
+    expect(sanitizeCandidUrl('https://www.guidestar.org/profile/12-3456789')).toBe(
+      'https://www.guidestar.org/profile/12-3456789'
+    )
+    expect(sanitizeCandidUrl('https://none.org')).toBe('')
+    expect(sanitizeCandidUrl('not a url')).toBe('')
+    expect(sanitizeCandidUrl('')).toBe('')
+  })
+
+  it('validates EIN format', () => {
+    expect(sanitizeEin('41-3950250')).toBe('41-3950250')
+    expect(sanitizeEin('413950250')).toBe('41-3950250')
+    expect(sanitizeEin('none')).toBe('')
+    expect(sanitizeEin('')).toBe('')
+  })
+
   it('keeps angle brackets entity-encoded (no markup injection)', () => {
     const byClient = new Map([
       [
@@ -100,6 +131,34 @@ describe('buildApplicationRecords', () => {
     const [app] = buildApplicationRecords(byClient)
     expect(app.missionExcerpt.length).toBeLessThanOrEqual(MISSION_MAX_LENGTH)
     expect(app.missionExcerpt.endsWith('…')).toBe(true)
+  })
+
+  it('carries accurate stage/status and validated Candid URL + EIN', () => {
+    const byClient = new Map([
+      [
+        '90',
+        {
+          clientId: '90',
+          pid: '33',
+          company: 'Wenatchee Valley Islamic Center',
+          candidUrl: 'https://app.candid.org/profile/16302238/x',
+          ein: '12-3456789',
+        },
+      ],
+      ['91', { clientId: '91', pid: '16', company: 'Pre Org' }],
+    ])
+    const apps = buildApplicationRecords(byClient)
+    const c501 = apps.find((a) => a.id === 'ffc-90')
+    expect(c501).toMatchObject({
+      charityStage: '501c3',
+      charityStatusOption: 'Approved 501(c)(3)',
+      candidUrl: 'https://app.candid.org/profile/16302238/x',
+      ein: '12-3456789',
+    })
+    const pre = apps.find((a) => a.id === 'ffc-91')
+    expect(pre.charityStage).toBe('pre-501c3')
+    expect(pre).not.toHaveProperty('candidUrl')
+    expect(pre).not.toHaveProperty('ein')
   })
 
   it('sorts by submission date then name', () => {

--- a/scripts/generate-roadmap-data.ts
+++ b/scripts/generate-roadmap-data.ts
@@ -24,7 +24,7 @@ import { dirname, join } from 'path'
 import { parse as parseCsv } from 'csv-parse/sync'
 import { computeReadiness } from '../src/lib/readiness/scoring'
 import { emptyIntake } from '../src/lib/readiness/defaults'
-import { parseIntakeIssue } from '../src/lib/readiness/parseIntake'
+import { parseIntakeIssue, parseIssueForm } from '../src/lib/readiness/parseIntake'
 import type {
   RoadmapData,
   RoadmapEntry,
@@ -113,6 +113,31 @@ function liveUrlFrom(body: string | null): string | undefined {
   return match ? match[1] : undefined
 }
 
+/** Public Candid/GuideStar profile URL only (HTML-unwrapped, placeholders dropped). */
+function cleanCandidUrl(raw?: string): string | undefined {
+  if (!raw) return undefined
+  const href = /href=["']([^"']+)["']/i.exec(raw)
+  const candidate = (href ? href[1] : raw).trim()
+  try {
+    const u = new URL(candidate)
+    if (
+      (u.protocol === 'https:' || u.protocol === 'http:') &&
+      /(^|\.)(candid\.org|guidestar\.org)$/i.test(u.hostname)
+    ) {
+      return u.toString()
+    }
+  } catch {
+    /* not a URL */
+  }
+  return undefined
+}
+
+/** Validate a US EIN (NN-NNNNNNN); public for registered charities. */
+function cleanEin(raw?: string): string | undefined {
+  const m = /\b(\d{2})-?(\d{7})\b/.exec(raw ?? '')
+  return m ? `${m[1]}-${m[2]}` : undefined
+}
+
 function toEntry(issue: GhIssue): RoadmapEntry {
   const parsed = parseIntakeIssue(issue.body ?? '')
   const readiness = computeReadiness(parsed.intake)
@@ -128,6 +153,9 @@ function toEntry(issue: GhIssue): RoadmapEntry {
   // labelled status:live), so the portfolio dedup below can suppress the
   // matching domain even before the issue is flipped to live.
   const liveUrl = liveUrlFrom(issue.body)
+  const form = parseIssueForm(issue.body ?? '')
+  const candidUrl = cleanCandidUrl(form.get('candid / guidestar profile url'))
+  const ein = cleanEin(form.get('ein'))
   return {
     issueNumber: issue.number,
     charityName: parsed.charityName || issue.title,
@@ -144,6 +172,8 @@ function toEntry(issue: GhIssue): RoadmapEntry {
     plusOne: issue.reactions?.['+1'] ?? 0,
     issueUrl: issue.html_url,
     ...(liveUrl ? { liveUrl } : {}),
+    ...(candidUrl ? { candidUrl } : {}),
+    ...(ein ? { ein } : {}),
   }
 }
 

--- a/scripts/generate-roadmap-data.ts
+++ b/scripts/generate-roadmap-data.ts
@@ -113,11 +113,28 @@ function liveUrlFrom(body: string | null): string | undefined {
   return match ? match[1] : undefined
 }
 
+/**
+ * Decode the HTML entities WHMCS/GitHub commonly store in a URL so the parsed
+ * value matches `whmcs-applications.mjs`. `&amp;` query separators (and the
+ * double-encoded `&amp;amp;`) would otherwise survive into `new URL()` and the
+ * link would point at a mangled query string. Angle brackets are intentionally
+ * left encoded (anti-injection); a URL never legitimately contains a raw `<`/`>`.
+ */
+function decodeUrlEntities(s: string): string {
+  let out = s
+  for (let i = 0; i < 3 && out.includes('&'); i++) {
+    const next = out.replace(/&amp;/gi, '&').replace(/&#0*38;/g, '&')
+    if (next === out) break
+    out = next
+  }
+  return out
+}
+
 /** Public Candid/GuideStar profile URL only (HTML-unwrapped, placeholders dropped). */
 function cleanCandidUrl(raw?: string): string | undefined {
   if (!raw) return undefined
   const href = /href=["']([^"']+)["']/i.exec(raw)
-  const candidate = (href ? href[1] : raw).trim()
+  const candidate = decodeUrlEntities((href ? href[1] : raw).trim())
   try {
     const u = new URL(candidate)
     if (

--- a/scripts/lib/intake-issues.mjs
+++ b/scripts/lib/intake-issues.mjs
@@ -132,7 +132,8 @@ export async function syncIntakeIssues({ applications, repo, token, stateFile, s
   }
   const gh = makeGh(token)
   const state = loadState(stateFile)
-  const seen = new Set(state.seenApplicationIds || [])
+  const knownIds = new Set(state.seenApplicationIds || [])
+  const seen = new Set(knownIds)
 
   const findIssueForId = async (id) => {
     const q = encodeURIComponent(
@@ -175,10 +176,19 @@ export async function syncIntakeIssues({ applications, repo, token, stateFile, s
     }
   }
 
+  // Persist when issues changed OR when the dedup state drifted from reality —
+  // e.g. the state file was reset/lost but the matching issues already exist, so
+  // `seen` grew without a create/update. Without this the recovered ids would be
+  // re-searched on every run and never written back.
+  const stateDrifted = seen.size !== knownIds.size || [...seen].some((id) => !knownIds.has(id))
   const changed = created > 0 || updated > 0
-  if (changed) {
+  if (changed || stateDrifted) {
     writeState(stateFile, seen)
-    console.log(`Intake sync: ${created} created, ${updated} updated; state updated.`)
+    console.log(
+      `Intake sync: ${created} created, ${updated} updated; state ${
+        changed ? 'updated' : 'reconciled'
+      }.`
+    )
   } else {
     console.log('Intake sync: no changes.')
   }

--- a/scripts/lib/intake-issues.mjs
+++ b/scripts/lib/intake-issues.mjs
@@ -71,24 +71,50 @@ export function makeGh(token) {
   }
 }
 
-function stubBody(app, repo, source) {
+/**
+ * Build the stub issue body. The leading block is a human-facing welcome plus
+ * the dedup marker; the issue-form parser drops that preamble (it has no `###`
+ * heading) and reads the structured fields below. Pre-filling the fields we know
+ * from the application makes the readiness engine + roadmap card show an
+ * accurate charity status, mission, and tier instead of empty defaults.
+ */
+export function stubBody(app, repo) {
   const name = app.charityName || 'your charity'
   const tier = app.serviceTier ? `\n\n**Service requested:** ${app.serviceTier}` : ''
-  const origin = source
-    ? `_Auto-created from an FFC ${source} application for **${name}**._${tier}`
-    : `_Auto-created from an FFC application for **${name}**._${tier}`
-  return [
-    origin,
+  const lines = [
+    `_Auto-created from an FFC application for **${name}**._${tier}`,
     '',
-    'Welcome to Free For Charity! Please complete your structured intake by editing this issue',
-    `with the [charity intake form](https://github.com/${repo}/issues/new?template=charity-intake.yml),`,
+    'Welcome to Free For Charity! Complete or correct your structured intake with the',
+    `[charity intake form](https://github.com/${repo}/issues/new?template=charity-intake.yml),`,
     'or reply here and an FFC admin will help. Your charity already appears on the',
     '[public roadmap](https://ffcadmin.org/roadmap) — completing intake raises your readiness score.',
     '',
     'Not comfortable with GitHub? Text **520-222-8104**.',
     '',
     `<!-- ${ID_MARKER}: ${app.id} -->`,
-  ].join('\n')
+    '',
+  ]
+  const field = (label, value) => {
+    const v = String(value ?? '').trim()
+    if (v) lines.push(`### ${label}`, '', v, '')
+  }
+  field('Charity name', app.charityName)
+  field('Charity status', app.charityStatusOption)
+  field('Brief mission', app.missionExcerpt)
+  field('EIN', app.ein)
+  field('Candid / GuideStar profile URL', app.candidUrl)
+  return `${lines.join('\n').trimEnd()}\n`
+}
+
+/** A bot-created stub we may safely refresh (vs. an issue a human has edited). */
+function isRefreshableStub(issue) {
+  const login = issue?.user?.login || ''
+  return (
+    (login === 'github-actions' || login === 'github-actions[bot]') &&
+    typeof issue.body === 'string' &&
+    issue.body.includes(ID_MARKER) &&
+    issue.body.includes('Auto-created from an FFC')
+  )
 }
 
 /**
@@ -108,46 +134,53 @@ export async function syncIntakeIssues({ applications, repo, token, stateFile, s
   const state = loadState(stateFile)
   const seen = new Set(state.seenApplicationIds || [])
 
-  const issueExistsForId = async (id) => {
+  const findIssueForId = async (id) => {
     const q = encodeURIComponent(
       `repo:${repo} is:issue label:kind:intake in:body "${ID_MARKER}: ${id}"`
     )
     const result = await gh(`/search/issues?q=${q}`)
-    return (result.total_count ?? 0) > 0
+    return result.items?.[0] ?? null
   }
 
   let created = 0
-  let changed = false
+  let updated = 0
   for (const app of applications) {
     const id = String(app.id ?? '').trim()
-    if (!id || seen.has(id)) continue
+    if (!id) continue
     try {
-      if (await issueExistsForId(id)) {
+      const title = `[Intake] ${app.charityName || id}`
+      const body = stubBody(app, repo)
+      const existing = await findIssueForId(id)
+      if (existing) {
+        // Refresh the body when our application data has changed, but never
+        // clobber an issue a human (or the applicant) has edited.
+        if (isRefreshableStub(existing) && (existing.body !== body || existing.title !== title)) {
+          await gh(`/repos/${repo}/issues/${existing.number}`, {
+            method: 'PATCH',
+            body: JSON.stringify({ title, body }),
+          })
+          updated++
+        }
         seen.add(id)
-        changed = true
         continue
       }
       await gh(`/repos/${repo}/issues`, {
         method: 'POST',
-        body: JSON.stringify({
-          title: `[Intake] ${app.charityName || id}`,
-          body: stubBody(app, repo, source),
-          labels: labelsFor(app),
-        }),
+        body: JSON.stringify({ title, body, labels: labelsFor(app) }),
       })
       seen.add(id)
-      changed = true
       created++
     } catch (err) {
       console.warn(`Skipping application ${id}: ${errMsg(err)}`)
     }
   }
 
+  const changed = created > 0 || updated > 0
   if (changed) {
     writeState(stateFile, seen)
-    console.log(`Intake sync: ${created} stub issue(s) created; state updated.`)
+    console.log(`Intake sync: ${created} created, ${updated} updated; state updated.`)
   } else {
-    console.log('Intake sync: no new applications; state unchanged.')
+    console.log('Intake sync: no changes.')
   }
-  return { created, changed }
+  return { created, updated, changed }
 }

--- a/scripts/whmcs-applications.mjs
+++ b/scripts/whmcs-applications.mjs
@@ -9,8 +9,10 @@
  * pre-501c3 = pid 16, 501c3 = pid 33 (override via WHMCS_ONBOARDING_PIDS).
  * Donors hold no such product, so gating on these pids excludes them by
  * construction. Only non-PII fields are derived (an allowlist): an opaque id,
- * the public org name, the service tier, an optional truncated mission, and a
- * date. Emails/phones/addresses/board/EIN are never read into the record.
+ * the public org name, charity status, service tier, an optional truncated
+ * mission, a Candid/GuideStar profile link, EIN (public for registered
+ * charities), and a date. Personal contact info — emails, phones, addresses,
+ * board members — is never matched or read into the record.
  *
  * Read-only against WHMCS (GetClientsProducts + GetClientsDetails). Graceful:
  * missing creds or a WHMCS error is a no-op, leaving state unchanged.

--- a/scripts/whmcs-applications.mjs
+++ b/scripts/whmcs-applications.mjs
@@ -57,6 +57,51 @@ export const TIER_BY_PID = {
   16: 'Tier 1 — Application & verification (pre-501(c)(3))',
   33: 'Tier 1 — Application & verification (501(c)(3))',
 }
+// pid -> the "Charity status" intake-form option string (so the stub issue parses
+// to the right charityStage and scores accurately). pid is authoritative.
+export const STATUS_OPTION_BY_PID = {
+  16: 'Pre-501(c)(3) (actively pursuing)',
+  33: 'Approved 501(c)(3)',
+}
+
+/** First populated custom-field value whose NAME matches `re` (decoded, trimmed). */
+function fieldValue(product, re) {
+  const nodes = product?.customfields?.customfield
+  if (!nodes) return ''
+  for (const f of [].concat(nodes)) {
+    if (re.test(String(f?.name || ''))) {
+      const v = decodeEntities(String(f?.value || '')).trim()
+      if (v) return v
+    }
+  }
+  return ''
+}
+
+/**
+ * Pull a clean Candid/GuideStar profile URL: WHMCS stores it HTML-wrapped
+ * (`<a href="URL">…</a>`) and many are placeholders ("none.org"). Return a real
+ * candid.org / guidestar.org URL only, else ''.
+ */
+export function sanitizeCandidUrl(raw) {
+  if (!raw) return ''
+  const href = /href=["']([^"']+)["']/i.exec(raw)
+  const candidate = decodeEntities(href ? href[1] : raw).trim()
+  let u
+  try {
+    u = new URL(candidate)
+  } catch {
+    return ''
+  }
+  if (u.protocol !== 'https:' && u.protocol !== 'http:') return ''
+  if (!/(^|\.)(candid\.org|guidestar\.org)$/i.test(u.hostname)) return ''
+  return u.toString()
+}
+
+/** Validate a US EIN (NN-NNNNNNN). EINs are public for registered charities. */
+export function sanitizeEin(raw) {
+  const m = /\b(\d{2})-?(\d{7})\b/.exec(String(raw || ''))
+  return m ? `${m[1]}-${m[2]}` : ''
+}
 
 // The WHMCS host's Imunify360 bot-protection intermittently challenges GitHub
 // runner IPs; retry just those transient signatures (mirrors the repo's
@@ -174,8 +219,13 @@ export function buildApplicationRecords(byClient) {
     apps.push({
       id: `ffc-${rec.clientId}`,
       charityName: company,
+      // pid -> stage/status so the stub parses to an accurate charityStage.
+      charityStage: rec.pid === '33' ? '501c3' : 'pre-501c3',
+      charityStatusOption: STATUS_OPTION_BY_PID[rec.pid] || STATUS_OPTION_BY_PID[16],
       serviceTier: TIER_BY_PID[rec.pid] || 'Tier 1 — Application & verification',
       ...(mission ? { missionExcerpt: mission } : {}),
+      ...(rec.candidUrl ? { candidUrl: rec.candidUrl } : {}),
+      ...(rec.ein ? { ein: rec.ein } : {}),
       ...(rec.regIso ? { submittedAt: rec.regIso } : {}),
     })
   }
@@ -210,13 +260,27 @@ async function collect() {
       if (!clientId) continue
       const regIso = isoDate(p?.regdate)
       const mission = missionFromProduct(p)
+      // Non-PII transparency fields (allowlisted by field name; board/contact
+      // fields are never matched). Candid link + EIN help donors evaluate.
+      const candidUrl = sanitizeCandidUrl(fieldValue(p, /guidestar|candid/i))
+      const ein = sanitizeEin(fieldValue(p, /\bEIN\b|tax id/i))
       const existing = byClient.get(clientId)
       if (existing) {
         if (pid === '33') existing.pid = pid
         if (!existing.mission && mission) existing.mission = mission
         if (!existing.regIso && regIso) existing.regIso = regIso
+        if (!existing.candidUrl && candidUrl) existing.candidUrl = candidUrl
+        if (!existing.ein && ein) existing.ein = ein
       } else {
-        byClient.set(clientId, { clientId, pid, mission, regIso, company: undefined })
+        byClient.set(clientId, {
+          clientId,
+          pid,
+          mission,
+          regIso,
+          candidUrl,
+          ein,
+          company: undefined,
+        })
       }
     }
   }

--- a/src/app/roadmap/RoadmapCard.tsx
+++ b/src/app/roadmap/RoadmapCard.tsx
@@ -85,6 +85,27 @@ export default function RoadmapCard({ entry, section }: RoadmapCardProps) {
           <dt className="font-medium text-gray-600">Seeking:</dt>
           <dd>{entry.serviceTier}</dd>
         </div>
+        {entry.ein && (
+          <div className="flex gap-1">
+            <dt className="font-medium text-gray-600">EIN:</dt>
+            <dd>{entry.ein}</dd>
+          </div>
+        )}
+        {entry.candidUrl && (
+          <div className="flex gap-1">
+            <dt className="font-medium text-gray-600">Transparency:</dt>
+            <dd>
+              <a
+                href={entry.candidUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-medium text-blue-700 hover:text-blue-900"
+              >
+                Candid / GuideStar profile ↗
+              </a>
+            </dd>
+          </div>
+        )}
         {section === 'review' && entry.submittedAt && (
           <div className="flex gap-1">
             <dt className="font-medium text-gray-600">Submitted:</dt>

--- a/src/app/roadmap/roadmapData.ts
+++ b/src/app/roadmap/roadmapData.ts
@@ -48,6 +48,10 @@ export interface RoadmapEntry {
   plusOne: number
   issueUrl: string
   liveUrl?: string
+  /** Public Candid/GuideStar profile URL (donor transparency), when supplied. */
+  candidUrl?: string
+  /** EIN (public for registered charities), when supplied. */
+  ein?: string
 }
 
 export interface RoadmapData {


### PR DESCRIPTION
## Summary

The WHMCS intake stubs were near-empty, so roadmap cards showed inaccurate defaults (*Nonprofit project / General mission / Just getting started*) with nothing to help someone evaluate the charity. This pulls the **non-PII application data** WHMCS already holds and renders it.

## What changed
- **`whmcs-applications.mjs`** — extract an allowlist of non-PII fields: charity status (→ `charityStage`/`charityStatusOption`, from the onboarding `pid`), **Candid/GuideStar profile URL** (HTML-unwrapped, placeholders like `none.org` dropped, host-restricted to candid.org/guidestar.org), **EIN** (validated `NN-NNNNNNN`; the intake form already treats EIN as public). Board/contact custom fields (emails, phones, LinkedIn) are **never matched**.
- **`lib/intake-issues.mjs`** — the stub issue is now a **partial intake form** (welcome preamble the parser skips + pre-filled `### Charity status / Brief mission / EIN / Candid …` fields). So the existing readiness engine + card light up with an accurate status, mission, and **real readiness tier**. Existing bot stubs are **refreshed in place** when the data changes; human-edited issues are never clobbered.
- **`generate-roadmap-data.ts` + `roadmapData.ts`** — thread `candidUrl` + `ein` onto `RoadmapEntry` (re-sanitized, so human-entered forms are safe too).
- **`RoadmapCard.tsx`** — show **EIN** and a **“Candid / GuideStar profile ↗”** verification link.

## Live validation (dry-run via APIM)
23 pending applicants → **17 pre-501(c)(3) / 6 501(c)(3)**, **14 EINs**, **8 real Candid links** (e.g. `app.candid.org/profile/9983753/…`). Cards now show accurate status + mission + tier + transparency link instead of generic defaults.

## Tests
`pnpm type-check` ✅ · `lint` ✅ · `build` ✅ · **561 tests** ✅ (added URL/EIN sanitizer + record tests).

## Note on mission category
Essential/General/Niche is an **editorial** classification (it carries a scoring bonus) and isn't in the WHMCS application, so it's left for admin review rather than guessed. The card now leads with accurate **legal status + mission text + transparency link**, which is the decision-relevant info.

## After merge
Re-running `whmcs-intake.yml` refreshes the existing 23 issues in place with the rich bodies; `build-roadmap-data.yml` then regenerates `roadmap.json`. I'll trigger both.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PNahWrNd3XsoTQJ4Q9QsQ9)_