### PR TITLE
feat(roadmap): favor basic-needs > veterans > general missions

### DIFF
--- a/.github/ISSUE_TEMPLATE/charity-intake.yml
+++ b/.github/ISSUE_TEMPLATE/charity-intake.yml
@@ -74,11 +74,11 @@ body:
     id: mission-category
     attributes:
       label: Mission category
-      description: 'Essential = food, water, shelter, emergency response, disaster relief, mental-health crisis, veterans, domestic violence. See /intake-help/mission-statement.'
+      description: 'FFC favors basic-needs causes (food, water, shelter) first, then veterans/military, then all other missions. See /intake-help/mission-statement.'
       options:
-        - Essential
+        - Basic needs (food, water, shelter)
+        - Veterans / military
         - General
-        - Niche
     validations:
       required: true
   - type: dropdown

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -36,15 +36,15 @@
   description: Graduated to financial self-sustainability
 
 # Mission tier
-- name: 'mission:essential'
+- name: 'mission:basic-needs'
   color: 'e99695'
-  description: Essential mission (food, shelter, emergency, veterans, DV, etc.)
+  description: Basic-needs mission (food, water, shelter) — favored first
+- name: 'mission:veterans'
+  color: 'c5def5'
+  description: Veterans / military mission — favored second
 - name: 'mission:general'
   color: 'd4c5f9'
-  description: General-mission 501(c)(3)
-- name: 'mission:niche'
-  color: 'bfd4f2'
-  description: Niche mission
+  description: General mission — neutral baseline
 
 # Affiliation
 - name: 'affiliation:franchise'

--- a/__tests__/parse-intake.test.ts
+++ b/__tests__/parse-intake.test.ts
@@ -19,7 +19,7 @@ Approved 501(c)(3)
 
 ### Mission category
 
-Essential
+Basic needs (food, water, shelter)
 
 ### Affiliation
 
@@ -76,7 +76,7 @@ describe('parseIntakeIssue', () => {
     expect(charityName).toBe('Helping Hands Shelter')
     expect(missionExcerpt).toContain('emergency shelter')
     expect(intake.charityStage).toBe('501c3')
-    expect(intake.missionCategory).toBe('essential')
+    expect(intake.missionCategory).toBe('basic-needs')
     expect(intake.candid.seal).toBe('gold')
     expect(intake.candid.profileUrl).toBe(true)
     expect(intake.existingWebsite).toBe('functional')
@@ -88,7 +88,7 @@ describe('parseIntakeIssue', () => {
   it('produces a positive, scoreable result for the sample charity', () => {
     const { intake } = parseIntakeIssue(SAMPLE)
     const result = computeReadiness(intake)
-    // Essential mission (+50) + 501(c)(3) (+20) + Gold seal cluster alone clears Foundational.
+    // Basic-needs mission (+50) + 501(c)(3) (+20) + Gold seal cluster alone clears Foundational.
     expect(result.score).toBeGreaterThan(0)
   })
 
@@ -96,6 +96,30 @@ describe('parseIntakeIssue', () => {
     const { intake, charityName } = parseIntakeIssue('')
     expect(charityName).toBe('')
     expect(intake.charityStage).toBe('non-pursuing')
+  })
+
+  it('auto-classifies the mission tier from text when no category dropdown is set', () => {
+    // WHMCS-sourced stubs carry a Brief mission but no Mission category field.
+    const basicNeeds = parseIntakeIssue(
+      '### Brief mission\n\nWe run a food pantry for hungry families.\n'
+    ).intake
+    expect(basicNeeds.missionCategory).toBe('basic-needs')
+
+    const vets = parseIntakeIssue(
+      '### Brief mission\n\nPeer support for military veterans returning home.\n'
+    ).intake
+    expect(vets.missionCategory).toBe('veterans')
+
+    const general = parseIntakeIssue(
+      '### Brief mission\n\nAfter-school robotics club for local students.\n'
+    ).intake
+    expect(general.missionCategory).toBe('general')
+
+    // An explicit dropdown always overrides the text classifier.
+    const explicit = parseIntakeIssue(
+      '### Brief mission\n\nWe run a food pantry.\n\n### Mission category\n\nGeneral\n'
+    ).intake
+    expect(explicit.missionCategory).toBe('general')
   })
 
   it('parses documents, application progress, partnership, and operations fields', () => {

--- a/__tests__/readiness-scoring.test.ts
+++ b/__tests__/readiness-scoring.test.ts
@@ -42,10 +42,13 @@ describe('computeReadiness — floors and gates', () => {
     expect(independent.score - corporate.score).toBe(40)
   })
 
-  it('gives the essential mission a +50 bonus over general (§15 #13)', () => {
+  it('favors basic-needs (+50) and veterans (+30) over a general mission', () => {
     const general = computeReadiness(emptyIntake({ missionCategory: 'general' }))
-    const essential = computeReadiness(emptyIntake({ missionCategory: 'essential' }))
-    expect(essential.score - general.score).toBe(50)
+    const basicNeeds = computeReadiness(emptyIntake({ missionCategory: 'basic-needs' }))
+    const veterans = computeReadiness(emptyIntake({ missionCategory: 'veterans' }))
+    expect(basicNeeds.score - general.score).toBe(50)
+    expect(veterans.score - general.score).toBe(30)
+    expect(basicNeeds.score).toBeGreaterThan(veterans.score)
   })
 
   it('does not double-count duplicate integrations or policy pages', () => {
@@ -100,13 +103,13 @@ describe('per-person phone/email caps (§15 #14)', () => {
 
 describe('time-in-status decay (§15 #17)', () => {
   it('subtracts 2 points per stalled month, capped at recoverable points', () => {
-    const result = computeReadiness(emptyIntake({ missionCategory: 'essential' }))
+    const result = computeReadiness(emptyIntake({ missionCategory: 'basic-needs' }))
     const decayed = applyTimeInStatusDecay(result, 3, 100)
     expect(decayed.score).toBe(result.score - 6)
   })
 
   it('keeps the category breakdown summing to the decayed score', () => {
-    const result = computeReadiness(emptyIntake({ missionCategory: 'essential' }))
+    const result = computeReadiness(emptyIntake({ missionCategory: 'basic-needs' }))
     const decayed = applyTimeInStatusDecay(result, 3, 100)
     const sum = decayed.categories.reduce((total, c) => total + c.points, 0)
     expect(sum).toBe(decayed.score)
@@ -114,7 +117,7 @@ describe('time-in-status decay (§15 #17)', () => {
   })
 
   it('never decays more than the recoverable points', () => {
-    const result = computeReadiness(emptyIntake({ missionCategory: 'essential' }))
+    const result = computeReadiness(emptyIntake({ missionCategory: 'basic-needs' }))
     const decayed = applyTimeInStatusDecay(result, 12, 5)
     expect(decayed.score).toBe(result.score - 5)
   })
@@ -125,8 +128,8 @@ describe('time-in-status decay (§15 #17)', () => {
   })
 })
 
-/** A maximally-prepared, essential-mission 501(c)(3). Program plan: "~375". */
-function maximalEssential501c3(): IntakeData {
+/** A maximally-prepared, basic-needs-mission 501(c)(3). Program plan: "~375". */
+function maximalBasicNeeds501c3(): IntakeData {
   const orgSpecific = {
     present: true,
     phoneType: 'org-specific' as const,
@@ -134,7 +137,7 @@ function maximalEssential501c3(): IntakeData {
   }
   const linkedinSeat = { present: true, named: true, linkedin: true }
   return emptyIntake({
-    missionCategory: 'essential',
+    missionCategory: 'basic-needs',
     charityStage: '501c3',
     affiliation: 'independent',
     revenueForm: '990-n',
@@ -170,8 +173,8 @@ function maximalEssential501c3(): IntakeData {
 }
 
 describe('reference fixtures', () => {
-  it('scores a maximal essential 501(c)(3) in the Mature band (~375)', () => {
-    const result = computeReadiness(maximalEssential501c3())
+  it('scores a maximal basic-needs 501(c)(3) in the Mature band (~375)', () => {
+    const result = computeReadiness(maximalBasicNeeds501c3())
     expect(result.tier).toBe('Mature')
     expect(result.score).toBeGreaterThanOrEqual(360)
     expect(result.score).toBeLessThanOrEqual(410)

--- a/__tests__/roadmap-data.test.ts
+++ b/__tests__/roadmap-data.test.ts
@@ -30,10 +30,10 @@ function entry(overrides: Partial<RoadmapEntry>): RoadmapEntry {
 }
 
 describe('sortNeedsAdmin (§9)', () => {
-  it('ranks essential mission ahead of a higher-scoring general charity', () => {
-    const essential = entry({
-      charityName: 'Essential',
-      missionCategory: 'essential',
+  it('ranks basic-needs ahead of a higher-scoring general charity', () => {
+    const basicNeeds = entry({
+      charityName: 'BasicNeeds',
+      missionCategory: 'basic-needs',
       readinessScore: 50,
     })
     const general = entry({
@@ -41,8 +41,17 @@ describe('sortNeedsAdmin (§9)', () => {
       missionCategory: 'general',
       readinessScore: 250,
     })
-    const sorted = sortNeedsAdmin([general, essential])
-    expect(sorted[0].charityName).toBe('Essential')
+    const sorted = sortNeedsAdmin([general, basicNeeds])
+    expect(sorted[0].charityName).toBe('BasicNeeds')
+  })
+
+  it('ranks basic-needs ahead of veterans ahead of general', () => {
+    const sorted = sortNeedsAdmin([
+      entry({ charityName: 'Gen', missionCategory: 'general', readinessScore: 300 }),
+      entry({ charityName: 'Vet', missionCategory: 'veterans', readinessScore: 10 }),
+      entry({ charityName: 'Basic', missionCategory: 'basic-needs', readinessScore: 0 }),
+    ])
+    expect(sorted.map((e) => e.charityName)).toEqual(['Basic', 'Vet', 'Gen'])
   })
 
   it('breaks mission ties by readiness score, then +1 votes, then oldest first', () => {

--- a/src/app/intake-help/mission-statement/page.tsx
+++ b/src/app/intake-help/mission-statement/page.tsx
@@ -26,9 +26,10 @@ export default function MissionStatementPage() {
         wellness.”
       </p>
       <p>
-        Your mission also drives your readiness sort order: FFC categorizes missions as essential,
-        general, or niche. A clear statement helps us categorize accurately. Fuller guidance,
-        examples, and a worksheet are forthcoming.
+        Your mission also drives your readiness sort order: FFC favors basic-needs causes (food,
+        water, shelter) first, then veterans/military, then all other missions at a neutral
+        baseline. A clear statement helps us categorize accurately — and the tier only affects sort
+        order, never eligibility. Fuller guidance, examples, and a worksheet are forthcoming.
       </p>
     </IntakeHelpShell>
   )

--- a/src/app/roadmap/RoadmapCard.tsx
+++ b/src/app/roadmap/RoadmapCard.tsx
@@ -10,9 +10,9 @@ const TIER_BADGE: Record<TierLabel, string> = {
 }
 
 const MISSION_BADGE: Record<MissionCategory, { label: string; className: string }> = {
-  essential: { label: 'Essential mission', className: 'bg-orange-100 text-orange-800' },
+  'basic-needs': { label: 'Basic needs', className: 'bg-orange-100 text-orange-800' },
+  veterans: { label: 'Veterans / military', className: 'bg-indigo-100 text-indigo-800' },
   general: { label: 'General mission', className: 'bg-gray-100 text-gray-700' },
-  niche: { label: 'Niche mission', className: 'bg-slate-100 text-slate-700' },
 }
 
 const STAGE_BADGE: Record<CharityStage, { label: string; className: string }> = {
@@ -54,7 +54,7 @@ interface RoadmapCardProps {
 export default function RoadmapCard({ entry, section }: RoadmapCardProps) {
   const mission = MISSION_BADGE[entry.missionCategory]
   const stage = STAGE_BADGE[entry.charityStage]
-  const accent = entry.missionCategory === 'essential' ? 'border-orange-300' : 'border-gray-200'
+  const accent = entry.missionCategory === 'basic-needs' ? 'border-orange-300' : 'border-gray-200'
 
   return (
     <article className={`flex flex-col rounded-xl border ${accent} bg-white p-5 shadow-sm`}>

--- a/src/app/roadmap/methodology/page.tsx
+++ b/src/app/roadmap/methodology/page.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link'
 import Breadcrumbs from '@/components/Breadcrumbs'
 import {
   MISSION_POINTS,
+  MISSION_LABELS,
   CHARITY_STAGE_POINTS,
   AFFILIATION_POINTS,
   REVENUE_FORM_POINTS,
@@ -149,12 +150,9 @@ export default function MethodologyPage() {
             title="Mission category"
             improve="Basic-needs missions (food, water, shelter) carry the largest bonus; veterans/military are favored next. All other missions are welcome at the neutral baseline — the tier only affects sort order, never eligibility."
             rows={[
-              {
-                label: 'Basic needs (food, water, shelter)',
-                points: MISSION_POINTS['basic-needs'],
-              },
-              { label: 'Veterans / military', points: MISSION_POINTS.veterans },
-              { label: 'General', points: MISSION_POINTS.general },
+              { label: MISSION_LABELS['basic-needs'], points: MISSION_POINTS['basic-needs'] },
+              { label: MISSION_LABELS.veterans, points: MISSION_POINTS.veterans },
+              { label: MISSION_LABELS.general, points: MISSION_POINTS.general },
             ]}
           />
           <Category

--- a/src/app/roadmap/methodology/page.tsx
+++ b/src/app/roadmap/methodology/page.tsx
@@ -110,8 +110,9 @@ export default function MethodologyPage() {
           <h2 className="text-xl font-bold text-gray-900">How the queue is sorted</h2>
           <ol className="mt-2 list-decimal space-y-1 pl-5 text-gray-700">
             <li>
-              <strong>Mission tier</strong> — essential-mission charities carry a large bonus and
-              sort first.
+              <strong>Mission tier</strong> — FFC favors basic-needs charities (food, water,
+              shelter) first, then veterans/military; both carry a bonus and sort ahead of general
+              missions.
             </li>
             <li>
               <strong>Readiness score</strong> — higher scores sort higher within a mission tier.
@@ -146,11 +147,14 @@ export default function MethodologyPage() {
         <div className="grid gap-5 md:grid-cols-2">
           <Category
             title="Mission category"
-            improve="Essential missions (food, water, shelter, emergency response, disaster relief, mental-health crisis, veterans, domestic violence) carry the largest bonus."
+            improve="Basic-needs missions (food, water, shelter) carry the largest bonus; veterans/military are favored next. All other missions are welcome at the neutral baseline — the tier only affects sort order, never eligibility."
             rows={[
-              { label: 'Essential', points: MISSION_POINTS.essential },
+              {
+                label: 'Basic needs (food, water, shelter)',
+                points: MISSION_POINTS['basic-needs'],
+              },
+              { label: 'Veterans / military', points: MISSION_POINTS.veterans },
               { label: 'General', points: MISSION_POINTS.general },
-              { label: 'Niche', points: MISSION_POINTS.niche },
             ]}
           />
           <Category

--- a/src/lib/readiness/config.ts
+++ b/src/lib/readiness/config.ts
@@ -26,24 +26,74 @@ import type {
   Trajectory,
 } from './types'
 
-/** Mission category bonus — §15 #13 (bonus, not a hard sort tier). */
+/**
+ * Mission favoring bonus. FFC's board prioritizes basic-needs causes (food,
+ * water, shelter) first, then veterans, then everything else at the neutral
+ * baseline. The bonus drives both the readiness score and the queue sort tier.
+ */
 export const MISSION_POINTS: Record<MissionCategory, number> = {
-  essential: 50,
+  'basic-needs': 50,
+  veterans: 30,
   general: 0,
-  niche: -10,
 }
 
-/** §15 #39 — the essential-mission category list (editorial copy). */
-export const ESSENTIAL_MISSIONS = [
-  'Food',
-  'Water',
-  'Shelter',
-  'Emergency response',
-  'Disaster relief',
-  'Mental health crisis services',
-  'Veterans services',
-  'Domestic violence services',
+/**
+ * Display copy + dropdown option string for each tier, in favoring order.
+ * `MISSION_LABELS` is the single source the methodology page, the card badge,
+ * and the intake-form dropdown all read so they can never drift.
+ */
+export const MISSION_LABELS: Record<MissionCategory, string> = {
+  'basic-needs': 'Basic needs (food, water, shelter)',
+  veterans: 'Veterans / military',
+  general: 'General',
+}
+
+/**
+ * Keywords that auto-classify a mission tier from the charity's free-text
+ * mission (used when no explicit category is supplied — e.g. WHMCS-sourced
+ * stubs). Basic-needs is checked first so a "food for veterans" charity lands
+ * in the higher tier. Word-boundary matched, case-insensitive.
+ */
+export const BASIC_NEEDS_KEYWORDS = [
+  'food',
+  'hunger',
+  'hungry',
+  'meal',
+  'meals',
+  'nutrition',
+  'pantry',
+  'famine',
+  'water',
+  'sanitation',
+  'shelter',
+  'homeless',
+  'homelessness',
+  'unhoused',
+  'housing',
 ] as const
+
+export const VETERANS_KEYWORDS = [
+  'veteran',
+  'veterans',
+  'military',
+  'servicemember',
+  'troops',
+  'armed forces',
+  'wounded warrior',
+] as const
+
+/**
+ * Infer the mission tier from free-text mission copy. Pure; returns 'general'
+ * when nothing matches. Basic-needs wins over veterans on overlap.
+ */
+export function classifyMission(text: string | undefined | null): MissionCategory {
+  const t = (text ?? '').toLowerCase()
+  const matches = (words: readonly string[]) =>
+    words.some((w) => new RegExp(`\\b${w.replace(/\s+/g, '\\s+')}\\b`).test(t))
+  if (matches(BASIC_NEEDS_KEYWORDS)) return 'basic-needs'
+  if (matches(VETERANS_KEYWORDS)) return 'veterans'
+  return 'general'
+}
 
 export const CHARITY_STAGE_POINTS: Record<CharityStage, number> = {
   '501c3': 20,

--- a/src/lib/readiness/config.ts
+++ b/src/lib/readiness/config.ts
@@ -88,8 +88,14 @@ export const VETERANS_KEYWORDS = [
  */
 export function classifyMission(text: string | undefined | null): MissionCategory {
   const t = (text ?? '').toLowerCase()
+  // Escape regex metacharacters before building the pattern (a future keyword
+  // could contain `+`, `(`, `.`, etc.), then allow flexible whitespace.
   const matches = (words: readonly string[]) =>
-    words.some((w) => new RegExp(`\\b${w.replace(/\s+/g, '\\s+')}\\b`).test(t))
+    words.some((w) =>
+      new RegExp(`\\b${w.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').replace(/\s+/g, '\\s+')}\\b`).test(
+        t
+      )
+    )
   if (matches(BASIC_NEEDS_KEYWORDS)) return 'basic-needs'
   if (matches(VETERANS_KEYWORDS)) return 'veterans'
   return 'general'

--- a/src/lib/readiness/parseIntake.ts
+++ b/src/lib/readiness/parseIntake.ts
@@ -26,7 +26,7 @@ import type {
   RevenueForm,
   Trajectory,
 } from './types'
-import { INTEGRATION_PLATFORMS, POLICY_PAGES } from './config'
+import { INTEGRATION_PLATFORMS, POLICY_PAGES, MISSION_LABELS, classifyMission } from './config'
 
 const NO_RESPONSE = /^_no response_$/i
 
@@ -68,10 +68,12 @@ const STAGE: Record<string, CharityStage> = {
   'Pre-501(c)(3) (actively pursuing)': 'pre-501c3',
   'Ongoing nonprofit-nature project (not pursuing 501(c)(3))': 'non-pursuing',
 }
+// Built from the canonical labels so the dropdown option strings, the parser,
+// and the methodology page can never drift apart.
 const MISSION: Record<string, MissionCategory> = {
-  Essential: 'essential',
-  General: 'general',
-  Niche: 'niche',
+  [MISSION_LABELS['basic-needs']]: 'basic-needs',
+  [MISSION_LABELS.veterans]: 'veterans',
+  [MISSION_LABELS.general]: 'general',
 }
 const AFFILIATION: Record<string, Affiliation> = {
   Independent: 'independent',
@@ -194,7 +196,12 @@ export function parseIntakeIssue(body: string): ParsedIntake {
   const ops = checked(map.get('operations evidence (not pursuing 501(c)(3))') ?? '')
 
   const intake = emptyIntake({
-    missionCategory: mapEnum(map.get('mission category') ?? '', MISSION, 'general'),
+    // Prefer the explicit dropdown; otherwise infer the tier from the free-text
+    // mission so WHMCS-sourced stubs (which carry no category field) still favor
+    // basic-needs / veterans charities instead of defaulting to general.
+    missionCategory:
+      MISSION[(map.get('mission category') ?? '').trim()] ??
+      classifyMission(map.get('brief mission') ?? map.get('mission statement')),
     charityStage: mapEnum(map.get('charity status') ?? '', STAGE, 'non-pursuing'),
     affiliation: mapEnum(map.get('affiliation') ?? '', AFFILIATION, 'independent'),
     revenueForm: mapEnum(map.get('revenue and form filed') ?? '', REVENUE, 'pre-revenue'),

--- a/src/lib/readiness/parseIntake.ts
+++ b/src/lib/readiness/parseIntake.ts
@@ -199,9 +199,11 @@ export function parseIntakeIssue(body: string): ParsedIntake {
     // Prefer the explicit dropdown; otherwise infer the tier from the free-text
     // mission so WHMCS-sourced stubs (which carry no category field) still favor
     // basic-needs / veterans charities instead of defaulting to general.
+    // `||` (not `??`) so an empty Brief mission ("" from _No response_) falls
+    // through to a populated Mission statement instead of classifying on "".
     missionCategory:
       MISSION[(map.get('mission category') ?? '').trim()] ??
-      classifyMission(map.get('brief mission') ?? map.get('mission statement')),
+      classifyMission(map.get('brief mission') || map.get('mission statement')),
     charityStage: mapEnum(map.get('charity status') ?? '', STAGE, 'non-pursuing'),
     affiliation: mapEnum(map.get('affiliation') ?? '', AFFILIATION, 'independent'),
     revenueForm: mapEnum(map.get('revenue and form filed') ?? '', REVENUE, 'pre-revenue'),

--- a/src/lib/readiness/scoring.ts
+++ b/src/lib/readiness/scoring.ts
@@ -12,6 +12,7 @@
 
 import {
   MISSION_POINTS,
+  MISSION_LABELS,
   CHARITY_STAGE_POINTS,
   AFFILIATION_POINTS,
   REVENUE_FORM_POINTS,
@@ -265,7 +266,7 @@ export function computeReadiness(intake: IntakeData): ReadinessResult {
     single(
       'mission',
       'Mission category',
-      titleCase(intake.missionCategory),
+      MISSION_LABELS[intake.missionCategory],
       MISSION_POINTS[intake.missionCategory]
     ),
     single(

--- a/src/lib/readiness/types.ts
+++ b/src/lib/readiness/types.ts
@@ -13,7 +13,12 @@
  * logic — there are no duplicated point tables anywhere else.
  */
 
-export type MissionCategory = 'essential' | 'general' | 'niche'
+/**
+ * Mission favoring tiers (program decision): FFC's capacity is finite, so the
+ * roadmap favors the causes the board prioritizes. Basic-needs (food/water/
+ * shelter) sort first, veterans next, everything else at the neutral baseline.
+ */
+export type MissionCategory = 'basic-needs' | 'veterans' | 'general'
 
 export type CharityStage = '501c3' | 'pre-501c3' | 'non-pursuing'
 


### PR DESCRIPTION
## Summary

Replaces the old `essential / general / niche` mission model with the board-directed favoring order: **basic-needs (food/water/shelter) → veterans/military → all others**. The tier drives both the readiness-score bonus and the "Needs a sponsoring admin" queue sort — **never eligibility**.

| Tier | Mission bonus | Examples |
|---|---|---|
| Basic needs | **+50** | food, water, shelter, homeless/housing |
| Veterans / military | **+30** | veterans, military, servicemembers |
| General | **0** (neutral baseline) | everything else — welcome, just lower in the queue |

(Previously `essential` was a single +50 bucket of 8 causes and `niche` was a −10 penalty. There is no longer a penalty tier.)

## What changed
- **`types.ts` / `config.ts`** — `MissionCategory = 'basic-needs' | 'veterans' | 'general'`; `MISSION_POINTS` 50/30/0; new `MISSION_LABELS` (single source for the dropdown, card badge, and methodology table) plus `BASIC_NEEDS_KEYWORDS` / `VETERANS_KEYWORDS` and a pure `classifyMission(text)`.
- **`parseIntake.ts`** — the explicit dropdown still wins; when it's absent the tier is **auto-classified from the free-text mission**, so WHMCS-sourced stubs (which carry a *Brief mission* but no category field) land in the correct tier instead of defaulting to general.
- **`scoring.ts`** — mission line label now reads from `MISSION_LABELS` (no more `Basic-needs` title-casing artifact).
- **UI / form / docs** — `charity-intake.yml` dropdown, `RoadmapCard` badge + accent, the methodology page table & sort copy, the `/intake-help/mission-statement` page, and the `mission:*` labels all updated to match.

## Tests
`format` ✅ · `lint` ✅ (pre-existing unused-`source` warning only) · `type-check` ✅ · `build` ✅ · **563 tests** ✅ · **20 e2e** ✅. Added coverage for the veterans tier and for the text auto-classifier (incl. dropdown-overrides-text).

## Notes
- `basic-needs` wins over `veterans` on keyword overlap (e.g. "food for veterans" → basic-needs).
- `docs/program-plan.md` is the archived source document and is intentionally left unchanged; the methodology page is the live source of truth.

Refs the FFC Public Roadmap & Intake Program plan.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PNahWrNd3XsoTQJ4Q9QsQ9)_