### PR TITLE
fix(sponsor): state the 3-sponsorship cap as a hard limit

### DIFF
--- a/src/app/roadmap/sponsor/page.tsx
+++ b/src/app/roadmap/sponsor/page.tsx
@@ -90,8 +90,9 @@ export default function SponsorPage() {
         <section>
           <h2 className="text-2xl font-bold text-gray-900">Capacity & stepping back</h2>
           <p className="mt-2 text-gray-700">
-            We recommend a maximum of <strong>3 concurrent active sponsorships</strong> (one in
-            active build, others in maintenance). You can step back any time by commenting on your
+            You may hold a maximum of <strong>3 concurrent active sponsorships</strong> (one in
+            active build, others in maintenance). This is a hard cap — taking on a fourth requires
+            explicit approval from FFC leadership. You can step back any time by commenting on your
             assigned issue and requesting reassignment — the site returns to the pool. This is
             normal; admins should never feel locked in.
           </p>


### PR DESCRIPTION
## Summary

Reconciles a wording inconsistency on `/roadmap/sponsor`: the 3-sponsorship cap was stated as a **hard commitment** in commitment #8 ("Maintaining no more than 3 concurrent active sponsorships unless explicitly approved by FFC leadership") but only as a **recommendation** in the Capacity section. Per direction, it's a **hard cap** — exceeding it requires explicit FFC leadership approval. The Capacity section now says so, matching commitment #8.

The rest of the commitment language is unchanged (approved as-is).

## Change
- `src/app/roadmap/sponsor/page.tsx` — Capacity section: "We recommend a maximum of 3…" → "You may hold a maximum of 3… This is a hard cap — taking on a fourth requires explicit approval from FFC leadership."

## Tests
`format` ✅ · `lint` ✅ (pre-existing unused-`source` warning only) · `type-check` ✅ · `build` ✅ · **563 unit tests** ✅. E2E runs in CI (the local sandbox lacks the Playwright 1.61.1 browser binary post dev-deps bump; CI installs browsers and this Playwright version already passed E2E on #516/#517).

Refs #519 (sponsor-page link wiring tracks the same page).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PNahWrNd3XsoTQJ4Q9QsQ9)_