### PR TITLE
feat(intake): self-attested mission tier from the WHMCS onboarding dropdown

### DIFF
--- a/__tests__/whmcs-applications.test.js
+++ b/__tests__/whmcs-applications.test.js
@@ -8,6 +8,7 @@
  */
 
 let buildApplicationRecords, TIER_BY_PID, MISSION_MAX_LENGTH, sanitizeCandidUrl, sanitizeEin
+let missionCategoryOption, MISSION_OPTION
 
 beforeAll(async () => {
   const mod = await import('../scripts/whmcs-applications.mjs')
@@ -16,6 +17,8 @@ beforeAll(async () => {
   MISSION_MAX_LENGTH = mod.MISSION_MAX_LENGTH
   sanitizeCandidUrl = mod.sanitizeCandidUrl
   sanitizeEin = mod.sanitizeEin
+  missionCategoryOption = mod.missionCategoryOption
+  MISSION_OPTION = mod.MISSION_OPTION
 })
 
 const ALLOWED_KEYS = [
@@ -23,6 +26,7 @@ const ALLOWED_KEYS = [
   'charityName',
   'charityStage',
   'charityStatusOption',
+  'missionCategoryOption',
   'serviceTier',
   'missionExcerpt',
   'candidUrl',
@@ -104,6 +108,40 @@ describe('buildApplicationRecords', () => {
     expect(sanitizeEin('413950250')).toBe('41-3950250')
     expect(sanitizeEin('none')).toBe('')
     expect(sanitizeEin('')).toBe('')
+  })
+
+  it('maps the self-attested mission tier to its canonical option (3 choices only)', () => {
+    expect(missionCategoryOption('Food, water, or shelter')).toBe(MISSION_OPTION.basicNeeds)
+    expect(missionCategoryOption('Shelter & housing')).toBe(MISSION_OPTION.basicNeeds)
+    expect(missionCategoryOption('Veterans')).toBe(MISSION_OPTION.veterans)
+    expect(missionCategoryOption('Military / veterans services')).toBe(MISSION_OPTION.veterans)
+    // Anything else self-attests to the neutral baseline; never invents a 4th tier.
+    expect(missionCategoryOption('All other missions')).toBe(MISSION_OPTION.general)
+    expect(missionCategoryOption('Education')).toBe(MISSION_OPTION.general)
+    // Absent field -> omitted (caller falls back to text classification).
+    expect(missionCategoryOption('')).toBe('')
+    expect(missionCategoryOption(undefined)).toBe('')
+  })
+
+  it('carries the self-attested mission tier onto the published record', () => {
+    const byClient = new Map([
+      [
+        '20',
+        {
+          clientId: '20',
+          pid: '16',
+          company: 'Hope Pantry',
+          missionOption: MISSION_OPTION.basicNeeds,
+        },
+      ],
+      ['21', { clientId: '21', pid: '16', company: 'No Tier Org' }],
+    ])
+    const apps = buildApplicationRecords(byClient)
+    expect(apps.find((a) => a.id === 'ffc-20').missionCategoryOption).toBe(
+      MISSION_OPTION.basicNeeds
+    )
+    // No self-attestation -> field omitted (roadmap classifies from mission text).
+    expect(apps.find((a) => a.id === 'ffc-21')).not.toHaveProperty('missionCategoryOption')
   })
 
   it('keeps angle brackets entity-encoded (no markup injection)', () => {

--- a/scripts/lib/intake-issues.mjs
+++ b/scripts/lib/intake-issues.mjs
@@ -100,6 +100,9 @@ export function stubBody(app, repo) {
   }
   field('Charity name', app.charityName)
   field('Charity status', app.charityStatusOption)
+  // Self-attested mission tier (WHMCS dropdown). Written as the canonical intake
+  // option so parseIntakeIssue uses it directly instead of guessing from text.
+  field('Mission category', app.missionCategoryOption)
   field('Brief mission', app.missionExcerpt)
   field('EIN', app.ein)
   field('Candid / GuideStar profile URL', app.candidUrl)

--- a/scripts/whmcs-applications.mjs
+++ b/scripts/whmcs-applications.mjs
@@ -9,10 +9,10 @@
  * pre-501c3 = pid 16, 501c3 = pid 33 (override via WHMCS_ONBOARDING_PIDS).
  * Donors hold no such product, so gating on these pids excludes them by
  * construction. Only non-PII fields are derived (an allowlist): an opaque id,
- * the public org name, charity status, service tier, an optional truncated
- * mission, a Candid/GuideStar profile link, EIN (public for registered
- * charities), and a date. Personal contact info — emails, phones, addresses,
- * board members — is never matched or read into the record.
+ * the public org name, charity status, service tier, the self-attested mission
+ * tier, an optional truncated mission, a Candid/GuideStar profile link, EIN
+ * (public for registered charities), and a date. Personal contact info — emails,
+ * phones, addresses, board members — is never matched or read into the record.
  *
  * Read-only against WHMCS (GetClientsProducts + GetClientsDetails). Graceful:
  * missing creds or a WHMCS error is a no-op, leaving state unchanged.
@@ -64,6 +64,40 @@ export const TIER_BY_PID = {
 export const STATUS_OPTION_BY_PID = {
   16: 'Pre-501(c)(3) (actively pursuing)',
   33: 'Approved 501(c)(3)',
+}
+
+// The three self-attested mission tiers. The applicant picks ONE in the WHMCS
+// onboarding dropdown; these are the only options offered. The strings here are
+// the canonical intake-form option labels (must match `MISSION_LABELS` in
+// src/lib/readiness/config.ts and the charity-intake.yml dropdown) so the stub
+// issue parses straight to the right tier instead of being guessed from text.
+export const MISSION_OPTION = {
+  basicNeeds: 'Basic needs (food, water, shelter)',
+  veterans: 'Veterans / military',
+  general: 'General',
+}
+
+// Custom-field NAME that holds the self-attested mission tier (vs. the free-text
+// mission statement). Kept specific so the dropdown isn't mistaken for the
+// mission prose and vice-versa.
+const MISSION_CATEGORY_RE = /mission\s*(category|tier|type|group|focus)|cause\s*area/i
+
+/**
+ * Map a self-attested WHMCS mission-tier value to its canonical intake-form
+ * option string. The dropdown offers exactly three choices; we match by keyword
+ * so minor wording differences in the WHMCS option labels still resolve. Returns
+ * '' when no value is supplied (caller omits the field and the roadmap generator
+ * falls back to classifying from the mission text). Exported for unit testing.
+ */
+export function missionCategoryOption(raw) {
+  const v = String(raw || '')
+    .trim()
+    .toLowerCase()
+  if (!v) return ''
+  if (/food|water|shelter|basic\s*need|hunger|homeless|housing/.test(v))
+    return MISSION_OPTION.basicNeeds
+  if (/veteran|military|armed\s*forces|servicemember/.test(v)) return MISSION_OPTION.veterans
+  return MISSION_OPTION.general
 }
 
 /** First populated custom-field value whose NAME matches `re` (decoded, trimmed). */
@@ -195,7 +229,9 @@ function missionFromProduct(product) {
   const nodes = product?.customfields?.customfield
   if (!nodes) return undefined
   for (const f of [].concat(nodes)) {
-    if (/mission/i.test(String(f?.name || ''))) {
+    const name = String(f?.name || '')
+    // The free-text mission statement, not the mission-tier dropdown.
+    if (/mission/i.test(name) && !MISSION_CATEGORY_RE.test(name)) {
       const v = String(f?.value || '').trim()
       if (v) return v
     }
@@ -225,6 +261,9 @@ export function buildApplicationRecords(byClient) {
       charityStage: rec.pid === '33' ? '501c3' : 'pre-501c3',
       charityStatusOption: STATUS_OPTION_BY_PID[rec.pid] || STATUS_OPTION_BY_PID[16],
       serviceTier: TIER_BY_PID[rec.pid] || 'Tier 1 — Application & verification',
+      // Self-attested mission tier (the WHMCS dropdown). Omitted when the
+      // applicant predates the field; the roadmap then classifies from the text.
+      ...(rec.missionOption ? { missionCategoryOption: rec.missionOption } : {}),
       ...(mission ? { missionExcerpt: mission } : {}),
       ...(rec.candidUrl ? { candidUrl: rec.candidUrl } : {}),
       ...(rec.ein ? { ein: rec.ein } : {}),
@@ -262,6 +301,7 @@ async function collect() {
       if (!clientId) continue
       const regIso = isoDate(p?.regdate)
       const mission = missionFromProduct(p)
+      const missionOption = missionCategoryOption(fieldValue(p, MISSION_CATEGORY_RE))
       // Non-PII transparency fields (allowlisted by field name; board/contact
       // fields are never matched). Candid link + EIN help donors evaluate.
       const candidUrl = sanitizeCandidUrl(fieldValue(p, /guidestar|candid/i))
@@ -270,6 +310,7 @@ async function collect() {
       if (existing) {
         if (pid === '33') existing.pid = pid
         if (!existing.mission && mission) existing.mission = mission
+        if (!existing.missionOption && missionOption) existing.missionOption = missionOption
         if (!existing.regIso && regIso) existing.regIso = regIso
         if (!existing.candidUrl && candidUrl) existing.candidUrl = candidUrl
         if (!existing.ein && ein) existing.ein = ein
@@ -278,6 +319,7 @@ async function collect() {
           clientId,
           pid,
           mission,
+          missionOption,
           regIso,
           candidUrl,
           ein,


### PR DESCRIPTION
## Summary

The mission tier (**basic-needs / veterans / general**) is now driven by a **self-attested WHMCS onboarding dropdown** instead of being guessed from the applicant's free-text mission. Exactly three options are offered — no fourth/nuance tier.

## Flow

WHMCS dropdown → `whmcs-applications.mjs` → stub issue `### Mission category` field → `parseIntakeIssue` (the explicit dropdown already wins over the text classifier).

## Changes
- **`whmcs-applications.mjs`**
  - `MISSION_OPTION` — the three canonical option labels (kept in sync with `MISSION_LABELS` in `src/lib/readiness/config.ts` and the `charity-intake.yml` dropdown).
  - `missionCategoryOption(raw)` — maps a self-attested value to one of the three options via keyword match (so minor WHMCS label wording still resolves); returns `''` when absent. **Only ever yields one of the three tiers.**
  - Reads a `Mission category` / `cause area` custom field and threads it onto the published record as `missionCategoryOption`. The free-text mission matcher now **skips** this dropdown field so the two don't collide.
- **`lib/intake-issues.mjs`** — `stubBody` writes a `### Mission category` field, so the roadmap uses the self-attestation directly.
- **Fallback preserved:** applicants who predate the WHMCS field have no dropdown value → the field is omitted → the roadmap falls back to classifying from the mission text (current behavior). Forward-compatible: it activates the moment the WHMCS field exists.

## Tests
`format` ✅ · `lint` ✅ (pre-existing unused-`source` warning only) · `type-check` ✅ · `build` ✅ · **565 unit tests** ✅ (added: 3-tier mapping incl. empty, record passthrough, allowlist now includes `missionCategoryOption`). E2E runs in CI.

## Requires (your side)
The matching **three options must be configured in the WHMCS onboarding form** — tracked in the linked WHMCS-config issue. No fourth option should be offered.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PNahWrNd3XsoTQJ4Q9QsQ9)_