### PR TITLE
fix(intake): consume the existing WHMCS org-type dropdown for the mission tier

### DIFF
--- a/__tests__/whmcs-applications.test.js
+++ b/__tests__/whmcs-applications.test.js
@@ -8,7 +8,7 @@
  */
 
 let buildApplicationRecords, TIER_BY_PID, MISSION_MAX_LENGTH, sanitizeCandidUrl, sanitizeEin
-let missionCategoryOption, MISSION_OPTION
+let missionCategoryOption, missionTierFromProduct, MISSION_OPTION
 
 beforeAll(async () => {
   const mod = await import('../scripts/whmcs-applications.mjs')
@@ -18,6 +18,7 @@ beforeAll(async () => {
   sanitizeCandidUrl = mod.sanitizeCandidUrl
   sanitizeEin = mod.sanitizeEin
   missionCategoryOption = mod.missionCategoryOption
+  missionTierFromProduct = mod.missionTierFromProduct
   MISSION_OPTION = mod.MISSION_OPTION
 })
 
@@ -110,17 +111,39 @@ describe('buildApplicationRecords', () => {
     expect(sanitizeEin('')).toBe('')
   })
 
-  it('maps the self-attested mission tier to its canonical option (3 choices only)', () => {
-    expect(missionCategoryOption('Food, water, or shelter')).toBe(MISSION_OPTION.basicNeeds)
-    expect(missionCategoryOption('Shelter & housing')).toBe(MISSION_OPTION.basicNeeds)
-    expect(missionCategoryOption('Veterans')).toBe(MISSION_OPTION.veterans)
-    expect(missionCategoryOption('Military / veterans services')).toBe(MISSION_OPTION.veterans)
-    // Anything else self-attests to the neutral baseline; never invents a 4th tier.
-    expect(missionCategoryOption('All other missions')).toBe(MISSION_OPTION.general)
-    expect(missionCategoryOption('Education')).toBe(MISSION_OPTION.general)
+  it('maps the live WHMCS onboarding options to the three tiers', () => {
+    // The exact option strings from the FFC onboarding dropdown.
+    expect(missionCategoryOption('501(c)(3) Food, Water, or Shelter Organization')).toBe(
+      MISSION_OPTION.basicNeeds
+    )
+    expect(missionCategoryOption('501(c)(19) Veterans Organization')).toBe(MISSION_OPTION.veterans)
+    expect(missionCategoryOption('Other Veterans Organization')).toBe(MISSION_OPTION.veterans)
+    // "Other 501(c)(3) Organization" carries no tier keyword -> neutral baseline.
+    expect(missionCategoryOption('Other 501(c)(3) Organization')).toBe(MISSION_OPTION.general)
     // Absent field -> omitted (caller falls back to text classification).
     expect(missionCategoryOption('')).toBe('')
     expect(missionCategoryOption(undefined)).toBe('')
+  })
+
+  it('resolves the tier from the org-type dropdown by value shape, not the mission prose', () => {
+    // Dropdown found even though its field name is "Organization Type", and the
+    // free-text mission (which mentions veterans + food) must NOT win.
+    const product = {
+      customfields: {
+        customfield: [
+          { name: 'Organization Type', value: '501(c)(3) Food, Water, or Shelter Organization' },
+          { name: 'Mission Statement', value: 'We help homeless veterans access food.' },
+        ],
+      },
+    }
+    expect(missionTierFromProduct(product)).toBe(MISSION_OPTION.basicNeeds)
+
+    // No org-type field -> '' so the caller falls back to text classification,
+    // even when the mission prose mentions a tier keyword.
+    const noDropdown = {
+      customfields: { customfield: [{ name: 'Mission Statement', value: 'We support veterans.' }] },
+    }
+    expect(missionTierFromProduct(noDropdown)).toBe('')
   })
 
   it('carries the self-attested mission tier onto the published record', () => {

--- a/scripts/whmcs-applications.mjs
+++ b/scripts/whmcs-applications.mjs
@@ -77,17 +77,28 @@ export const MISSION_OPTION = {
   general: 'General',
 }
 
-// Custom-field NAME that holds the self-attested mission tier (vs. the free-text
-// mission statement). Kept specific so the dropdown isn't mistaken for the
-// mission prose and vice-versa.
-const MISSION_CATEGORY_RE = /mission\s*(category|tier|type|group|focus)|cause\s*area/i
+// Custom-field NAME that holds the self-attested mission tier. The live FFC
+// onboarding form labels this as an organization-type selector, so we match
+// those names too — not just literal "mission category".
+const MISSION_CATEGORY_RE =
+  /mission\s*(category|tier|type|group|focus)|cause\s*area|organi[sz]ation\s*type|type\s*of\s*organi[sz]ation|charity\s*type/i
+
+// VALUE shape of the live onboarding dropdown options, e.g.
+//   "501(c)(3) Food, Water, or Shelter Organization"
+//   "501(c)(19) Veterans Organization"
+//   "Other Veterans Organization"
+//   "Other 501(c)(3) Organization"
+// Anchored (starts with a 501(c)(N)/Other classifier, ends with "Organization")
+// so it identifies the dropdown by value even when we don't know the field's
+// exact label, without ever matching free-text mission prose.
+const ORG_TYPE_VALUE_RE = /^(?:501\(c\)\(\d+\)|other\b).*\borganization\s*$/i
 
 /**
  * Map a self-attested WHMCS mission-tier value to its canonical intake-form
- * option string. The dropdown offers exactly three choices; we match by keyword
- * so minor wording differences in the WHMCS option labels still resolve. Returns
- * '' when no value is supplied (caller omits the field and the roadmap generator
- * falls back to classifying from the mission text). Exported for unit testing.
+ * option string. There are exactly three tiers; we match by keyword so the live
+ * option labels (which fold tax status + cause into one string, e.g. "501(c)(3)
+ * Food, Water, or Shelter Organization") resolve, and so does any minor future
+ * rewording. Returns '' when no value is supplied. Exported for unit testing.
  */
 export function missionCategoryOption(raw) {
   const v = String(raw || '')
@@ -98,6 +109,29 @@ export function missionCategoryOption(raw) {
     return MISSION_OPTION.basicNeeds
   if (/veteran|military|armed\s*forces|servicemember/.test(v)) return MISSION_OPTION.veterans
   return MISSION_OPTION.general
+}
+
+/**
+ * Resolve the self-attested mission tier from a product's custom fields. Finds
+ * the onboarding org-type dropdown either by field name (MISSION_CATEGORY_RE) or
+ * by the distinctive option value shape (ORG_TYPE_VALUE_RE), then maps it. The
+ * value-shape match means we don't depend on the exact field label. Returns ''
+ * when no such field is present (caller falls back to text classification).
+ * Exported for unit testing.
+ */
+export function missionTierFromProduct(product) {
+  const nodes = product?.customfields?.customfield
+  if (!nodes) return ''
+  for (const f of [].concat(nodes)) {
+    const name = String(f?.name || '')
+    const value = decodeEntities(String(f?.value || '')).trim()
+    if (!value) continue
+    if (MISSION_CATEGORY_RE.test(name) || ORG_TYPE_VALUE_RE.test(value)) {
+      const opt = missionCategoryOption(value)
+      if (opt) return opt
+    }
+  }
+  return ''
 }
 
 /** First populated custom-field value whose NAME matches `re` (decoded, trimmed). */
@@ -230,9 +264,10 @@ function missionFromProduct(product) {
   if (!nodes) return undefined
   for (const f of [].concat(nodes)) {
     const name = String(f?.name || '')
-    // The free-text mission statement, not the mission-tier dropdown.
-    if (/mission/i.test(name) && !MISSION_CATEGORY_RE.test(name)) {
-      const v = String(f?.value || '').trim()
+    const v = String(f?.value || '').trim()
+    // The free-text mission statement — not the org-type/mission-tier dropdown
+    // (excluded by field name and by the dropdown's distinctive value shape).
+    if (/mission/i.test(name) && !MISSION_CATEGORY_RE.test(name) && !ORG_TYPE_VALUE_RE.test(v)) {
       if (v) return v
     }
   }
@@ -301,7 +336,7 @@ async function collect() {
       if (!clientId) continue
       const regIso = isoDate(p?.regdate)
       const mission = missionFromProduct(p)
-      const missionOption = missionCategoryOption(fieldValue(p, MISSION_CATEGORY_RE))
+      const missionOption = missionTierFromProduct(p)
       // Non-PII transparency fields (allowlisted by field name; board/contact
       // fields are never matched). Candid link + EIN help donors evaluate.
       const candidUrl = sanitizeCandidUrl(fieldValue(p, /guidestar|candid/i))


### PR DESCRIPTION
## Summary

The FFC onboarding form **already has** the mission-tier dropdown (it was never missing). #521 matched it only by a field literally named "Mission category" — which it isn't — so it would never have found the live field. This points the code at the real dropdown.

The live options and their tiers:

| WHMCS option | Tier |
|---|---|
| `501(c)(3) Food, Water, or Shelter Organization` | basic-needs |
| `501(c)(19) Veterans Organization` | veterans |
| `Other Veterans Organization` | veterans |
| `Other 501(c)(3) Organization` | general |

## How it finds the field

`missionTierFromProduct()` matches the custom field by **name** (now includes "organization type" / "charity type" labels) **OR** by the distinctive **value shape** — `ORG_TYPE_VALUE_RE = /^(?:501\(c\)\(\d+\)|other\b).*\borganization\s*$/i` (starts with a 501(c)(N)/Other classifier, ends with "Organization"). The value-shape match means we don't depend on knowing the exact field label, and the `^…$` anchoring guarantees it never matches free-text mission prose (even prose mentioning "veterans"/"food"). The free-text mission matcher also excludes the dropdown by the same shape.

## Tests
`format` ✅ · `lint` ✅ (pre-existing warning only) · `type-check` ✅ · `build` ✅ · **566 unit tests** ✅. Added: the four exact live option strings → tiers, and a product-level test proving the dropdown wins over the mission prose and that an absent dropdown falls back to text classification.

## Verify after merge
Re-run `whmcs-intake.yml` — applicants who selected Food/Water/Shelter or a Veterans option should now show that tier on their roadmap card instead of "General".

Supersedes the WHMCS-field-creation ask (closing that issue — the field exists).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PNahWrNd3XsoTQJ4Q9QsQ9)_