### PR TITLE
docs: reconcile docs with shipped behavior (mission tiers, local WHMCS, hard cap, GPG)

### DIFF
--- a/CODE_QUALITY.md
+++ b/CODE_QUALITY.md
@@ -701,17 +701,17 @@ Create `lighthouserc.json`:
 
 ### Current State vs. Best Practices
 
-| Standard           | Current                      | Industry Best Practice              | Status                |
-| ------------------ | ---------------------------- | ----------------------------------- | --------------------- |
-| Linting            | ESLint + Prettier            | ESLint + Prettier                   | ✅ Implemented        |
-| Type Checking      | TypeScript strict mode       | TypeScript strict + explicit checks | ⚠️ Add explicit check |
-| Testing            | Jest + RTL (62 tests)        | Jest + RTL + Coverage thresholds    | ⚠️ Add thresholds     |
-| Security           | CodeQL scanning              | CodeQL + Dependency scanning        | ✅ Good               |
-| CI/CD              | Format + Lint + Build + Test | Format + Lint + Build + Test        | ✅ Implemented        |
-| Git Hooks          | Husky + lint-staged          | Pre-commit hooks                    | ✅ Implemented        |
-| Commit Style       | GPG-signed commits           | GPG + Conventional Commits          | ⚠️ Add conventional   |
-| Dependency Updates | Manual                       | Automated (Dependabot)              | ❌ Missing            |
-| Documentation      | Excellent                    | Good documentation                  | ✅ Excellent          |
+| Standard           | Current                           | Industry Best Practice              | Status                |
+| ------------------ | --------------------------------- | ----------------------------------- | --------------------- |
+| Linting            | ESLint + Prettier                 | ESLint + Prettier                   | ✅ Implemented        |
+| Type Checking      | TypeScript strict mode            | TypeScript strict + explicit checks | ⚠️ Add explicit check |
+| Testing            | Jest + RTL (62 tests)             | Jest + RTL + Coverage thresholds    | ⚠️ Add thresholds     |
+| Security           | CodeQL scanning                   | CodeQL + Dependency scanning        | ✅ Good               |
+| CI/CD              | Format + Lint + Build + Test      | Format + Lint + Build + Test        | ✅ Implemented        |
+| Git Hooks          | Husky + lint-staged               | Pre-commit hooks                    | ✅ Implemented        |
+| Commit Style       | Conventional Commits (commitlint) | Conventional Commits                | ✅ Implemented        |
+| Dependency Updates | Manual                            | Automated (Dependabot)              | ❌ Missing            |
+| Documentation      | Excellent                         | Good documentation                  | ✅ Excellent          |
 
 **Overall Grade: A (93/100)**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,7 +137,7 @@ git push origin feature/your-feature-name
 
 **Pre-commit Hooks:** The project now uses Husky and lint-staged to automatically format and lint your code before each commit. This happens automatically when you run `git commit` and helps catch issues before they reach CI.
 
-**Note:** All commits to `main` must be GPG-signed. For feature branches, signing is optional but recommended. The CI/CD pipeline will automatically sign commits when merging to `main`.
+**Note:** GPG commit signing was previously required on `main` but has been **removed** (see [FAILED_FEATURES.md](FAILED_FEATURES.md)). Commits are not signed automatically; merges to `main` are gated by branch protection and required status checks instead.
 
 ## Order of Operations
 
@@ -288,7 +288,6 @@ Once approved and all checks pass:
 
 1. **Squash and Merge** (preferred) or **Rebase and Merge**
 2. GitHub Actions will automatically:
-   - GPG-sign the merge commit
    - Run final validation
    - Deploy to GitHub Pages (for `main` branch)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -35,14 +35,12 @@ Dependabot is configured to monitor and automatically update dependencies:
 
 ### Code Quality and Security Controls
 
-**GPG Commit Signing**
+**Commit Signing**
 
-All commits to the `main` branch must be GPG-signed:
-
-- Ensures commit authenticity and integrity
-- Automated signing configured via GitHub Actions
-- See [GPG_SIGNING.md](GPG_SIGNING.md) for technical details
-- See [QUICK_START.md](QUICK_START.md) for setup instructions
+GPG commit signing was previously required on `main` but has been **removed** due
+to automation/compatibility challenges. See [FAILED_FEATURES.md](FAILED_FEATURES.md)
+for historical context (archived setup notes live under `docs/archived/`). Commit
+integrity now relies on branch protection and required status checks (below).
 
 **CI/CD Security Gates**
 

--- a/docs/migration-plan.md
+++ b/docs/migration-plan.md
@@ -68,14 +68,20 @@ email) are unchanged; only the trigger and input-resolution are added.
 See `docs/proposed-cloudflare-labels.yml` for label additions to PR into the
 Cloudflare repo so cross-repo automation can apply consistent labels.
 
-## 5. Applications feed (the roadmap intake source)
+## 5. Applications feed (optional fallback intake source)
 
-FFCadmin holds no WHMCS/Zeffy credentials. The repo that owns those flows
-(`FFC-Cloudflare-Automation`) extracts genuine applicants and **publishes a
+The **primary** intake path is local: FFCadmin's `whmcs-intake.yml` queries WHMCS
+directly using credentials fetched at runtime from Azure Key Vault (see
+`docs/azure-keyvault-setup.md`), and opens a `kind:intake` issue per new applicant.
+No long-lived WHMCS/Zeffy secrets are stored in GitHub.
+
+As an **optional fallback**, the repo that owns those upstream flows
+(`FFC-Cloudflare-Automation`) can extract genuine applicants and **publish a
 PII-safe `applications.json`**, the same way it already publishes `sites-list`.
 FFCadmin's `sync-applications.yml` reads that public file daily and opens a
 `kind:intake` issue per new applicant; `build-roadmap-data.yml` then scores and
-renders them on the roadmap.
+renders them on the roadmap. The schema and producer responsibilities below
+describe that fallback feed.
 
 **Where to publish:** a public raw path in the Cloudflare repo, e.g.
 `applications/applications.json` (override via the `APPLICATIONS_SRC_URL` repo

--- a/docs/private-repo-setup.md
+++ b/docs/private-repo-setup.md
@@ -15,10 +15,12 @@ See `docs/program-plan.md` for the full program context.
 - [ ] **Grant the team access** to the private repo (write).
 - [ ] **Add Clarke + current verified admins** to the team.
 - [ ] **Create/append `FreeForCharity/.github/SECURITY.md`** (org-level fallback).
-- [ ] **Publish an applications feed from `FFC-Cloudflare-Automation`** — the repo
-      that owns the WHMCS/Zeffy flows extracts genuine applicants (product-gated,
-      PII-safe) and publishes `applications.json`. FFCadmin consumes it; it holds
-      no WHMCS/Zeffy credentials itself. See the contract in `docs/migration-plan.md`.
+- [ ] **(Optional fallback) Publish an applications feed from `FFC-Cloudflare-Automation`** —
+      the **primary** intake is local: `whmcs-intake.yml` queries WHMCS directly using
+      credentials fetched at runtime from Azure Key Vault (see `docs/azure-keyvault-setup.md`).
+      As an optional fallback, the Cloudflare repo can publish a product-gated, PII-safe
+      `applications.json` that `sync-applications.yml` consumes. See the contract in
+      `docs/migration-plan.md`.
 - [ ] **Create/confirm a PAT** with scopes `repo`, `workflow`, `read:org`
       (`read:org` is required for the team-membership check).
 - [ ] **Define the `cloudflare-automation` Actions environment** in FFCadmin repo
@@ -36,12 +38,13 @@ repo-level secrets also work.
 | -------- | --------------------------------------------------- | --------------------------------------- |
 | `GH_PAT` | `verify-assignment.yml`, `trigger-provisioning.yml` | PAT with `repo`, `workflow`, `read:org` |
 
-FFCadmin holds **no WHMCS/Zeffy credentials**. The intake source is the
-applications feed published by `FFC-Cloudflare-Automation` (the repo with those
-flows); `sync-applications.yml` reads that public file and `build-roadmap-data.yml`
-both run on the **built-in `GITHUB_TOKEN`** — no extra secret. Until `GH_PAT` is
-set, `verify-assignment.yml` / `trigger-provisioning.yml` emit a `::warning::`
-and exit successfully.
+FFCadmin's primary intake queries WHMCS directly via `whmcs-intake.yml`, using
+credentials fetched at runtime from **Azure Key Vault** through GitHub OIDC — **no
+long-lived WHMCS/Zeffy secrets are stored in GitHub** (see `docs/azure-keyvault-setup.md`).
+The optional `sync-applications.yml` fallback reads a Cloudflare-published
+`applications.json`; it and `build-roadmap-data.yml` run on the **built-in
+`GITHUB_TOKEN`** — no extra secret. Until `GH_PAT` is set, `verify-assignment.yml` /
+`trigger-provisioning.yml` emit a `::warning::` and exit successfully.
 
 > **Security:** never paste a real token into a file, commit, or comment. Add
 > tokens only through GitHub's secrets UI. See `.claude/rules/01-security.md`.

--- a/docs/program-plan.md
+++ b/docs/program-plan.md
@@ -262,7 +262,7 @@ FFC staff reviews new intake within 5 business days:
 
 - Confirms mission fit and prioritization policy alignment
 - Removes `needs-info` label if structured data is sufficient
-- Adds mission tier label (`mission:essential` / `mission:general` / `mission:niche`)
+- Adds mission tier label (`mission:basic-needs` / `mission:veterans` / `mission:general`)
 - Adds affiliation labels if applicable (`affiliation:franchise`, `affiliation:fiscal-sponsored`, etc.)
 - Confirms sponsorship eligibility decisions
 - Changes status to `status:needs-admin` if approved, or `status:on-hold` with explanation if not yet eligible
@@ -399,7 +399,7 @@ Public-facing labels mapped from the numeric score. Charities see their own tier
 | 180 – 269   | Established          |
 | 270+        | Mature               |
 
-A maximally-prepared 501(c)(3) charity with essential mission scores around +375. FFC's own self-score is approximately +280 (Mature, with room to grow on multi-state RA coverage and full social platform presence).
+A maximally-prepared 501(c)(3) charity with a basic-needs mission scores around +375. FFC's own self-score is approximately +280 (Mature, with room to grow on multi-state RA coverage and full social platform presence).
 
 ### What the score affects
 
@@ -411,7 +411,7 @@ A maximally-prepared 501(c)(3) charity with essential mission scores around +375
 ### What the score does NOT affect
 
 - **Eligibility for service.** A charity at "Just getting started" is not excluded; they're just lower in the queue. The only hard exclusions are those coded explicitly (e.g., fiscal sponsorship policy, US-only requirement, 501(c)(3) status mismatched with service type).
-- **Mission tier ranking primacy.** Mission category contributes a substantial bonus (+50 for essential), making essential-mission charities sort higher even when their other scoring is moderate. But mission isn't a hard tier gate; an exceptional general-mission charity can sort above a stalled essential-mission charity.
+- **Mission tier ranking primacy.** Mission category contributes a substantial bonus (+50 for basic-needs, +30 for veterans), making favored-mission charities sort higher even when their other scoring is moderate. But mission isn't a hard tier gate; an exceptional general-mission charity can sort above a stalled basic-needs-mission charity.
 
 ### Time-in-status decay
 
@@ -468,7 +468,7 @@ This prevents accidental assignments from triggering provisioning.
 
 ### Capacity expectations
 
-Each verified admin has a recommended maximum of 3 concurrent active sponsorships (one in active-build, others in support/maintenance). This is a soft cap surfaced on the sponsor page. Phase 2's volunteer tracking system enforces this more rigorously.
+Each verified admin has a maximum of 3 concurrent active sponsorships (one in active-build, others in support/maintenance). This is a hard cap surfaced on the sponsor page — taking on a fourth requires explicit FFC leadership approval. Phase 2's volunteer tracking system enforces this more rigorously.
 
 ### Stepping back
 
@@ -525,14 +525,14 @@ This section communicates: FFC has received your application; we're reviewing mi
 
 Issues with `status:needs-admin`, no assignee. Sorted by:
 
-1. Mission tier bonus (essential first via the score)
+1. Mission tier bonus (basic-needs, then veterans, first via the score)
 2. Readiness score (higher first)
 3. `+1` reaction count (community signal)
 4. Created date (oldest first)
 
 Each card prominently displays:
 
-- Charity name and mission tier badge (essential cards visually accented)
+- Charity name and mission tier badge (basic-needs cards visually accented)
 - Tier label badge (readiness)
 - Service tier they're seeking (Tier 2, Tier 3, etc.)
 - Sponsoring admin CTA: "Sponsor this site"
@@ -897,7 +897,7 @@ These need confirmation from Clarke. Each has a proposed default that will be ap
 
 | #   | Question                                              | Default                                                                                                                                     |
 | --- | ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| 13  | Mission category as point bonus vs. sort tier         | **Bonus** (+50 essential, 0 general, -10 niche) — single combined sort key                                                                  |
+| 13  | Mission category as point bonus vs. sort tier         | **Bonus** (+50 basic-needs, +30 veterans, 0 general) — single combined sort key; no niche penalty tier                                      |
 | 14  | Phone/email per-person caps                           | **Cap penalties to required roles only** (org main + 3 required board) — optional roles missing is 0, not negative                          |
 | 15  | Northwest specifically vs. registered-agent generally | **Treat all registered-agent services equally at +20**; Northwest preference is editorial in `/intake-help/mailing-address`, not in scoring |
 | 16  | Form 1023 vs. 1023-EZ small bonus                     | **+12 voluntary long form, +10 either form when used as required**                                                                          |
@@ -939,11 +939,11 @@ These need confirmation from Clarke. Each has a proposed default that will be ap
 
 ### 15.7 Lists
 
-| #   | Question                                                                                                      | Default                                                                                                                                                  |
-| --- | ------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 37  | Policy pages list (5 confirmed): Donation, Privacy, Terms, Vulnerability Disclosure, Security Acknowledgement | **Confirmed** — drop Code of Conduct and Conflict of Interest from scoring                                                                               |
-| 38  | External integrations list                                                                                    | **Zeffy, Idealist, Taproot, VolunteerMatch, Charity Navigator, Benevity, Network for Good** (7 platforms × +3 = max +21) — drop AmazonSmile and GiveWell |
-| 39  | Mission essential category                                                                                    | **Food, water, shelter, emergency response, disaster relief, mental health crisis services, veterans services, domestic violence services**              |
+| #   | Question                                                                                                      | Default                                                                                                                                                                                              |
+| --- | ------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 37  | Policy pages list (5 confirmed): Donation, Privacy, Terms, Vulnerability Disclosure, Security Acknowledgement | **Confirmed** — drop Code of Conduct and Conflict of Interest from scoring                                                                                                                           |
+| 38  | External integrations list                                                                                    | **Zeffy, Idealist, Taproot, VolunteerMatch, Charity Navigator, Benevity, Network for Good** (7 platforms × +3 = max +21) — drop AmazonSmile and GiveWell                                             |
+| 39  | Mission tiers (self-attested, 3 only)                                                                         | **Basic needs (food, water, shelter) +50; Veterans / military +30; all other missions 0** — self-attested via the WHMCS onboarding org-type dropdown, with keyword auto-classification as a fallback |
 
 ### 15.8 Operational
 
@@ -961,11 +961,11 @@ These need confirmation from Clarke. Each has a proposed default that will be ap
 
 ### Mission category (single, applied)
 
-| Category                                                                                                                                       | Points |
-| ---------------------------------------------------------------------------------------------------------------------------------------------- | ------ |
-| Essential (food, water, shelter, emergency response, disaster relief, mental health crisis, veterans services, domestic violence)              | +50    |
-| General (most 501(c)(3) charities — education, health non-emergency, animal welfare, arts, environment, community development, youth services) | 0      |
-| Niche (hobby clubs, narrow historical societies, fan organizations, etc.)                                                                      | -10    |
+| Category                                                | Points |
+| ------------------------------------------------------- | ------ |
+| Basic needs (food, water, shelter)                      | +50    |
+| Veterans / military                                     | +30    |
+| General (all other missions — most 501(c)(3) charities) | 0      |
 
 ### Charity stage (single, applied)
 
@@ -1207,16 +1207,16 @@ The 5 FFC-recognized policies: **Donation Policy, Privacy Policy, Terms of Servi
 
 ### Theoretical maximums by stage
 
-- **Approved 501(c)(3), essential mission, all infrastructure ideal**: ~375 points
+- **Approved 501(c)(3), basic-needs mission, all infrastructure ideal**: ~375 points
 - **Approved 501(c)(3), general mission, all infrastructure ideal**: ~325 points
-- **Pre-501(c)(3), essential mission, fully prepared, application submitted**: ~330 points
-- **Non-pursuing nonprofit-nature, essential mission, fully realized**: ~265 points
+- **Pre-501(c)(3), basic-needs mission, fully prepared, application submitted**: ~330 points
+- **Non-pursuing nonprofit-nature, basic-needs mission, fully realized**: ~265 points
 
 ### FFC self-score estimate
 
 Approximately **+280** based on FFC's actual current state:
 
-- General mission category (FFC supports charities; not directly essential): 0
+- General mission category (FFC supports charities; not directly basic-needs or veterans): 0
 - Independent: 0
 - Approved 501(c)(3): +20
 - 990-N filer: +20


### PR DESCRIPTION
## Summary

An audit-driven cleanup so the documentation set stops contradicting the shipped product. Markdown only — no code or behavior change. Driven by a full audit of `docs/**` + root docs against the current code.

## Fixed drift

**Mission tiers** (`docs/program-plan.md`) — the model is now exactly three tiers, but the doc still described the old `essential`/`general`/`niche` scheme (incl. a `-10` niche penalty and an 8-item "essential" list). Updated everywhere — the `mission:*` label list, §15 decisions #13 and #39, the Appendix A scoring table, and all scoring examples:

| | Old (doc) | New (matches `config.ts`) |
|---|---|---|
| Tiers | essential / general / niche | **basic-needs (+50) / veterans (+30) / general (0)** |
| Penalty | niche −10 | none |
| Source | 8-item "essential" list | self-attested WHMCS org-type dropdown + keyword fallback |

**Sponsorship cap** (`docs/program-plan.md`) — was described as a "soft cap"; it's a **hard cap** (a 4th sponsorship needs FFC leadership approval), matching `/roadmap/sponsor`.

**WHMCS intake architecture** (`docs/private-repo-setup.md`, `docs/migration-plan.md`) — both said FFCadmin "holds no WHMCS/Zeffy credentials" and that the intake source is a Cloudflare-published `applications.json` feed. Reality: the **primary** path is local — `whmcs-intake.yml` queries WHMCS directly using credentials fetched at runtime from **Azure Key Vault via GitHub OIDC** (no long-lived secrets in GitHub). The Cloudflare feed (`sync-applications.yml`) is now an **optional fallback**. Reframed both accordingly.

**GPG signing** (`SECURITY.md`, `CONTRIBUTING.md`, `CODE_QUALITY.md`) — these still claimed commits to `main` "must be GPG-signed" (and linked a now-archived `GPG_SIGNING.md`). GPG signing was removed (per `FAILED_FEATURES.md`); replaced the claims with the current reality (branch protection + required checks). README already documented the removal correctly and is unchanged.

## Tests
`prettier --check .` ✅ (markdown reformatted/realigned). No code touched.

## Out of scope / noted for follow-up
- `CODE_QUALITY.md` is a dated point-in-time self-assessment with several other stale metrics (test counts, "Next.js 14", "Dependabot Missing"). I fixed only the wrong GPG cell; a full refresh of that assessment is a separate task.
- `QUICK_START.md` and `docs/archived/*` GPG docs are already self-labeled archived/historical and left as-is.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PNahWrNd3XsoTQJ4Q9QsQ9)_