### PR TITLE
feat(roadmap): searchable/filterable explorer + card a11y

### DIFF
--- a/__tests__/roadmap-filter.test.ts
+++ b/__tests__/roadmap-filter.test.ts
@@ -1,0 +1,69 @@
+import { entryMatches, filtersAreEmpty } from '@/app/roadmap/roadmapFilter'
+import type { RoadmapEntry } from '@/app/roadmap/roadmapData'
+
+function entry(overrides: Partial<RoadmapEntry>): RoadmapEntry {
+  return {
+    issueNumber: 1,
+    charityName: 'Example Org',
+    missionExcerpt: '',
+    status: 'intake',
+    charityStage: 'pre-501c3',
+    missionCategory: 'general',
+    serviceTier: 'Tier 1',
+    readinessScore: 0,
+    readinessTier: 'Foundational',
+    submittedAt: '',
+    updatedAt: '',
+    sponsor: null,
+    plusOne: 0,
+    issueUrl: 'https://example.org',
+    ...overrides,
+  }
+}
+
+describe('entryMatches', () => {
+  it('matches free text against name and mission, case-insensitively', () => {
+    const e = entry({ charityName: 'Hope Pantry', missionExcerpt: 'We feed families.' })
+    expect(entryMatches(e, { query: 'pantry', tiers: [] })).toBe(true)
+    expect(entryMatches(e, { query: 'FEED', tiers: [] })).toBe(true)
+    expect(entryMatches(e, { query: 'veterans', tiers: [] })).toBe(false)
+  })
+
+  it('an empty query matches everything', () => {
+    expect(entryMatches(entry({}), { query: '   ', tiers: [] })).toBe(true)
+  })
+
+  it('tier filter matches a scored entry of that tier', () => {
+    const e = entry({ missionCategory: 'basic-needs', readinessTier: 'Developing' })
+    expect(entryMatches(e, { query: '', tiers: ['basic-needs'] })).toBe(true)
+    expect(entryMatches(e, { query: '', tiers: ['veterans'] })).toBe(false)
+    expect(entryMatches(e, { query: '', tiers: ['veterans', 'basic-needs'] })).toBe(true)
+  })
+
+  it('tier filter excludes placeholder (unscored) portfolio entries', () => {
+    // Launched portfolio rows carry a stub missionCategory but null readinessTier.
+    const placeholder = entry({ missionCategory: 'general', readinessTier: null })
+    expect(entryMatches(placeholder, { query: '', tiers: ['general'] })).toBe(false)
+    // …but they are still findable by name search.
+    expect(entryMatches(placeholder, { query: 'example', tiers: [] })).toBe(true)
+  })
+
+  it('combines text and tier (both must pass)', () => {
+    const e = entry({
+      charityName: 'Veterans Bridge',
+      missionCategory: 'veterans',
+      readinessTier: 'Established',
+    })
+    expect(entryMatches(e, { query: 'bridge', tiers: ['veterans'] })).toBe(true)
+    expect(entryMatches(e, { query: 'bridge', tiers: ['basic-needs'] })).toBe(false)
+  })
+})
+
+describe('filtersAreEmpty', () => {
+  it('is true only when nothing narrows the results', () => {
+    expect(filtersAreEmpty({ query: '', tiers: [] })).toBe(true)
+    expect(filtersAreEmpty({ query: '  ', tiers: [] })).toBe(true)
+    expect(filtersAreEmpty({ query: 'x', tiers: [] })).toBe(false)
+    expect(filtersAreEmpty({ query: '', tiers: ['veterans'] })).toBe(false)
+  })
+})

--- a/e2e/roadmap.spec.ts
+++ b/e2e/roadmap.spec.ts
@@ -19,6 +19,22 @@ test.describe('Public Roadmap', () => {
     await expect(page.getByText('Readiness pending').first()).toBeVisible()
   })
 
+  test('explorer search narrows to a no-match state and clears', async ({ page }) => {
+    await page.goto('/roadmap/')
+    await page.getByPlaceholder('Search by charity name or mission').fill('zzzznotacharity')
+    await expect(page.getByText('No charities match your filters.')).toBeVisible()
+    await page.getByRole('button', { name: 'Clear filters' }).first().click()
+    await expect(page.getByRole('heading', { name: 'Launched charities' })).toBeVisible()
+  })
+
+  test('explorer mission-tier chip toggles pressed state', async ({ page }) => {
+    await page.goto('/roadmap/')
+    const chip = page.getByRole('button', { name: 'Basic needs' })
+    await expect(chip).toHaveAttribute('aria-pressed', 'false')
+    await chip.click()
+    await expect(chip).toHaveAttribute('aria-pressed', 'true')
+  })
+
   test('top-level Roadmap nav link works', async ({ page }) => {
     await page.goto('/')
     await page.locator('nav a[href*="/roadmap"]').first().click()

--- a/src/app/roadmap/RoadmapCard.tsx
+++ b/src/app/roadmap/RoadmapCard.tsx
@@ -119,6 +119,7 @@ export default function RoadmapCard({ entry, section }: RoadmapCardProps) {
           href={entry.sponsor.profileUrl}
           target="_blank"
           rel="noopener noreferrer"
+          aria-label={`Sponsored by @${entry.sponsor.handle} (opens GitHub profile)`}
           className="mt-3 inline-flex items-center gap-2 text-sm text-gray-700 hover:text-blue-600"
         >
           {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -129,7 +130,7 @@ export default function RoadmapCard({ entry, section }: RoadmapCardProps) {
             height={24}
             className="h-6 w-6 rounded-full"
           />
-          <span>
+          <span aria-hidden="true">
             Sponsored by <span className="font-medium">@{entry.sponsor.handle}</span>
           </span>
         </a>
@@ -138,7 +139,11 @@ export default function RoadmapCard({ entry, section }: RoadmapCardProps) {
       <div className="mt-4 flex items-center justify-between border-t border-gray-100 pt-3">
         <div className="text-sm text-gray-500">
           {section === 'needs-admin' && (
-            <span aria-label={`${entry.plusOne} community votes`}>👍 {entry.plusOne}</span>
+            <span
+              aria-label={`${entry.plusOne} community ${entry.plusOne === 1 ? 'vote' : 'votes'} on GitHub`}
+            >
+              <span aria-hidden="true">👍</span> {entry.plusOne}
+            </span>
           )}
         </div>
         <div className="flex items-center gap-3 text-sm">

--- a/src/app/roadmap/RoadmapExplorer.tsx
+++ b/src/app/roadmap/RoadmapExplorer.tsx
@@ -1,0 +1,184 @@
+'use client'
+
+import Link from 'next/link'
+import { useMemo, useState } from 'react'
+import RoadmapSection from './RoadmapSection'
+import type { RoadmapEntry, RoadmapSectionId } from './roadmapData'
+import type { MissionCategory } from '@/lib/readiness/types'
+import { entryMatches, TIER_FILTERS } from './roadmapFilter'
+
+export interface ExplorerSection {
+  id: RoadmapSectionId
+  heading: string
+  description: string
+  emptyMessage: string
+  entries: RoadmapEntry[]
+}
+
+const STATUS_FILTERS: { id: RoadmapSectionId; label: string }[] = [
+  { id: 'review', label: 'In review' },
+  { id: 'needs-admin', label: 'Needs admin' },
+  { id: 'active', label: 'Active build' },
+  { id: 'launched', label: 'Launched' },
+]
+
+/** How many launched cards to show before the "Show all" control (unfiltered). */
+const LAUNCHED_INITIAL = 24
+
+function chip(active: boolean): string {
+  return `rounded-full border px-3 py-1 text-sm font-medium transition-colors ${
+    active
+      ? 'border-teal-600 bg-teal-50 text-teal-800'
+      : 'border-gray-300 bg-white text-gray-600 hover:bg-gray-50'
+  }`
+}
+
+/**
+ * Client-side search + filter over the whole roadmap so a human can actually
+ * navigate ~100 charities: free-text by name/mission, mission-tier chips, and
+ * lifecycle-status chips (e.g. a donor narrowing to "Launched"). Sections keep
+ * their server-computed order; this only narrows what renders.
+ */
+export default function RoadmapExplorer({ sections }: { sections: ExplorerSection[] }) {
+  const [query, setQuery] = useState('')
+  const [tiers, setTiers] = useState<MissionCategory[]>([])
+  const [statuses, setStatuses] = useState<RoadmapSectionId[]>([])
+
+  const active = query.trim() !== '' || tiers.length > 0 || statuses.length > 0
+
+  const visible = useMemo(() => {
+    const filters = { query, tiers }
+    return sections
+      .filter((s) => statuses.length === 0 || statuses.includes(s.id))
+      .map((s) => ({ ...s, filtered: s.entries.filter((e) => entryMatches(e, filters)) }))
+  }, [sections, statuses, query, tiers])
+
+  const total = visible.reduce((n, s) => n + s.filtered.length, 0)
+
+  const toggleTier = (t: MissionCategory) =>
+    setTiers((cur) => (cur.includes(t) ? cur.filter((x) => x !== t) : [...cur, t]))
+  const toggleStatus = (id: RoadmapSectionId) =>
+    setStatuses((cur) => (cur.includes(id) ? cur.filter((x) => x !== id) : [...cur, id]))
+  const clearAll = () => {
+    setQuery('')
+    setTiers([])
+    setStatuses([])
+  }
+
+  return (
+    <>
+      <div className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
+        <label htmlFor="roadmap-search" className="sr-only">
+          Search charities
+        </label>
+        <div className="relative">
+          <svg
+            className="absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 text-gray-400"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+            />
+          </svg>
+          <input
+            id="roadmap-search"
+            type="search"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search by charity name or mission…"
+            className="w-full rounded-lg border border-gray-300 py-3 pl-10 pr-4 outline-none focus:border-teal-500 focus:ring-2 focus:ring-teal-500"
+          />
+        </div>
+
+        <div className="mt-3 flex flex-wrap items-center gap-2">
+          <span className="text-xs font-semibold uppercase tracking-wide text-gray-400">
+            Mission
+          </span>
+          {TIER_FILTERS.map(({ value, label }) => (
+            <button
+              key={value}
+              type="button"
+              aria-pressed={tiers.includes(value)}
+              onClick={() => toggleTier(value)}
+              className={chip(tiers.includes(value))}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+
+        <div className="mt-2 flex flex-wrap items-center gap-2">
+          <span className="text-xs font-semibold uppercase tracking-wide text-gray-400">
+            Status
+          </span>
+          {STATUS_FILTERS.map(({ id, label }) => (
+            <button
+              key={id}
+              type="button"
+              aria-pressed={statuses.includes(id)}
+              onClick={() => toggleStatus(id)}
+              className={chip(statuses.includes(id))}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+
+        {active && (
+          <div className="mt-3 flex items-center justify-between text-sm">
+            <p role="status" className="text-gray-500">
+              {total} {total === 1 ? 'charity' : 'charities'} match
+            </p>
+            <button
+              type="button"
+              onClick={clearAll}
+              className="font-medium text-blue-600 hover:underline"
+            >
+              Clear filters
+            </button>
+          </div>
+        )}
+
+        <p className="mt-3 text-xs text-gray-400">
+          Mission filters apply to charities with a scored readiness; launched portfolio sites are
+          searchable by name. Readiness tiers are explained in the{' '}
+          <Link href="/roadmap/methodology" className="underline">
+            methodology
+          </Link>
+          .
+        </p>
+      </div>
+
+      {active && total === 0 ? (
+        <p className="rounded-lg border border-dashed border-gray-300 bg-white p-8 text-center text-gray-500">
+          No charities match your filters.{' '}
+          <button
+            type="button"
+            onClick={clearAll}
+            className="font-medium text-blue-600 hover:underline"
+          >
+            Clear filters
+          </button>
+        </p>
+      ) : (
+        visible.map((s) => (
+          <RoadmapSection
+            key={s.id}
+            id={s.id}
+            heading={s.heading}
+            description={s.description}
+            entries={s.filtered}
+            emptyMessage={active ? 'No charities here match your filters.' : s.emptyMessage}
+            initialLimit={s.id === 'launched' && !active ? LAUNCHED_INITIAL : undefined}
+          />
+        ))
+      )}
+    </>
+  )
+}

--- a/src/app/roadmap/RoadmapSection.tsx
+++ b/src/app/roadmap/RoadmapSection.tsx
@@ -1,3 +1,6 @@
+'use client'
+
+import { useState } from 'react'
 import RoadmapCard from './RoadmapCard'
 import type { RoadmapEntry, RoadmapSectionId } from './roadmapData'
 
@@ -7,6 +10,8 @@ interface RoadmapSectionProps {
   description: string
   entries: RoadmapEntry[]
   emptyMessage: string
+  /** Cards rendered before a "Show all" control appears. Defaults to all. */
+  initialLimit?: number
 }
 
 /** One labelled section of the public roadmap with its grid of cards. */
@@ -16,7 +21,13 @@ export default function RoadmapSection({
   description,
   entries,
   emptyMessage,
+  initialLimit,
 }: RoadmapSectionProps) {
+  const [expanded, setExpanded] = useState(false)
+  const limit = initialLimit ?? entries.length
+  const shown = expanded ? entries : entries.slice(0, limit)
+  const hidden = entries.length - shown.length
+
   return (
     <section id={id} className="scroll-mt-20">
       <div className="mb-4">
@@ -31,15 +42,28 @@ export default function RoadmapSection({
           {emptyMessage}
         </p>
       ) : (
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {entries.map((entry) => (
-            <RoadmapCard
-              key={entry.issueNumber || entry.liveUrl || entry.charityName}
-              entry={entry}
-              section={id}
-            />
-          ))}
-        </div>
+        <>
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {shown.map((entry) => (
+              <RoadmapCard
+                key={entry.issueNumber || entry.liveUrl || entry.charityName}
+                entry={entry}
+                section={id}
+              />
+            ))}
+          </div>
+          {hidden > 0 && (
+            <div className="mt-4 text-center">
+              <button
+                type="button"
+                onClick={() => setExpanded(true)}
+                className="rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+              >
+                Show all {entries.length}
+              </button>
+            </div>
+          )}
+        </>
       )}
     </section>
   )

--- a/src/app/roadmap/page.tsx
+++ b/src/app/roadmap/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
 import Breadcrumbs from '@/components/Breadcrumbs'
-import RoadmapSection from './RoadmapSection'
+import RoadmapExplorer, { type ExplorerSection } from './RoadmapExplorer'
 import { loadRoadmap, sectionEntries, graduatedCount } from './roadmapData'
 
 export const metadata: Metadata = {
@@ -15,11 +15,42 @@ export const metadata: Metadata = {
 
 export default function RoadmapPage() {
   const data = loadRoadmap()
-  const review = sectionEntries(data, 'review')
-  const needsAdmin = sectionEntries(data, 'needs-admin')
-  const active = sectionEntries(data, 'active')
-  const launched = sectionEntries(data, 'launched')
   const graduated = graduatedCount(data)
+
+  const sections: ExplorerSection[] = [
+    {
+      id: 'review',
+      heading: 'In application & verification review',
+      description:
+        'FFC has received these applications and is reviewing mission fit and basic eligibility before offering products.',
+      emptyMessage: 'No applications are awaiting review right now.',
+      entries: sectionEntries(data, 'review'),
+    },
+    {
+      id: 'needs-admin',
+      heading: 'Needs a sponsoring admin',
+      description:
+        'Approved charities waiting for a verified volunteer to steward their build. Basic-needs and veterans missions, then higher readiness, sort first; community votes (👍) break ties.',
+      emptyMessage: 'Every approved charity currently has a sponsor — check back soon.',
+      entries: sectionEntries(data, 'needs-admin'),
+    },
+    {
+      id: 'active',
+      heading: 'Active builds',
+      description:
+        'Charities with a committed sponsoring admin, currently being built and configured.',
+      emptyMessage: 'No active builds at the moment.',
+      entries: sectionEntries(data, 'active'),
+    },
+    {
+      id: 'launched',
+      heading: 'Launched charities',
+      description:
+        'Live FFC charity sites. 🎉 Readiness shows once a charity completes structured intake; until then it’s marked “pending.”',
+      emptyMessage: 'No live charity sites recorded yet.',
+      entries: sectionEntries(data, 'launched'),
+    },
+  ]
 
   return (
     <div className="min-h-screen bg-gray-50">
@@ -58,37 +89,7 @@ export default function RoadmapPage() {
       </div>
 
       <main className="mx-auto max-w-7xl space-y-14 px-4 py-12 sm:px-6 lg:px-8">
-        <RoadmapSection
-          id="review"
-          heading="In application & verification review"
-          description="FFC has received these applications and is reviewing mission fit and basic eligibility before offering products."
-          entries={review}
-          emptyMessage="No applications are awaiting review right now."
-        />
-
-        <RoadmapSection
-          id="needs-admin"
-          heading="Needs a sponsoring admin"
-          description="Approved charities waiting for a verified volunteer to steward their build. Essential-mission and higher-readiness charities sort first; community votes (👍) break ties."
-          entries={needsAdmin}
-          emptyMessage="Every approved charity currently has a sponsor — check back soon."
-        />
-
-        <RoadmapSection
-          id="active"
-          heading="Active builds"
-          description="Charities with a committed sponsoring admin, currently being built and configured."
-          entries={active}
-          emptyMessage="No active builds at the moment."
-        />
-
-        <RoadmapSection
-          id="launched"
-          heading="Launched charities"
-          description="Live FFC charity sites. 🎉 Readiness shows once a charity completes structured intake; until then it’s marked “pending.”"
-          entries={launched}
-          emptyMessage="No live charity sites recorded yet."
-        />
+        <RoadmapExplorer sections={sections} />
 
         {/* Graduated alumni tile (Phase 2 page; placeholder in Phase 1A) */}
         <section className="rounded-xl border border-gray-200 bg-white p-6">

--- a/src/app/roadmap/roadmapFilter.ts
+++ b/src/app/roadmap/roadmapFilter.ts
@@ -1,0 +1,49 @@
+/**
+ * Pure, client-safe filtering for the roadmap explorer.
+ *
+ * Kept free of `fs` (unlike `roadmapData.ts`) so the `'use client'` explorer and
+ * the unit tests can both import it. `RoadmapEntry` is a type-only import, so it
+ * erases at compile time and never drags the filesystem loader into the bundle.
+ */
+import type { MissionCategory } from '@/lib/readiness/types'
+import type { RoadmapEntry } from './roadmapData'
+
+export interface RoadmapFilters {
+  /** Free-text needle matched against charity name + mission excerpt. */
+  query: string
+  /** Mission tiers to include; empty means "no tier filter". */
+  tiers: MissionCategory[]
+}
+
+/** Human labels for the mission-tier chips (favoring order). */
+export const TIER_FILTERS: { value: MissionCategory; label: string }[] = [
+  { value: 'basic-needs', label: 'Basic needs' },
+  { value: 'veterans', label: 'Veterans / military' },
+  { value: 'general', label: 'General' },
+]
+
+/**
+ * Does an entry match the active filters?
+ *
+ * Text search always applies. The tier filter only matches entries that carry a
+ * real, scored classification (`readinessTier != null`) — placeholder portfolio
+ * rows have a stub `missionCategory` that the card doesn't even display, so they
+ * must not be swept in by a tier filter.
+ */
+export function entryMatches(entry: RoadmapEntry, filters: RoadmapFilters): boolean {
+  const q = filters.query.trim().toLowerCase()
+  if (q) {
+    const haystack = `${entry.charityName} ${entry.missionExcerpt ?? ''}`.toLowerCase()
+    if (!haystack.includes(q)) return false
+  }
+  if (filters.tiers.length > 0) {
+    if (entry.readinessTier == null) return false
+    if (!filters.tiers.includes(entry.missionCategory)) return false
+  }
+  return true
+}
+
+/** True when no filter is narrowing the results. */
+export function filtersAreEmpty(filters: RoadmapFilters): boolean {
+  return filters.query.trim() === '' && filters.tiers.length === 0
+}


### PR DESCRIPTION
## Summary

The #1 human-UX gap from the audit: the roadmap renders ~100 charities as an unsearchable wall of cards. This adds a client-side **explorer** so donors, charities, and volunteers can actually find what they want.

## What's new
- **`RoadmapExplorer`** (client) above the sections:
  - **Search** by charity name + mission (case-insensitive).
  - **Mission-tier chips** — Basic needs / Veterans / General.
  - **Status chips** — In review / Needs admin / Active build / Launched (e.g. a donor narrows to *Launched* to see live, donatable sites).
  - Live **result count**, **Clear filters**, and a no-match state.
  - Sections keep their server-computed sort order; the explorer only narrows what renders.
- **`roadmapFilter.ts`** — pure, client-safe, unit-tested. Important correctness detail: the ~84 "launched" rows are placeholder portfolio entries (`readinessTier` is null, mission is a stub), so **tier filters only match scored entries** — placeholders are found by name search but never silently swept into a tier.
- **`RoadmapSection`** — "Show all N" cap (launched starts at 24) to cut the mobile scroll and initial render.
- **`RoadmapCard` a11y** — sponsor link now has an aria-label with the visible text `aria-hidden` (screen readers announce it once, not twice); 👍 vote count is pluralized and sourced ("…votes on GitHub").

## Tests
6 `roadmap-filter` unit tests + 2 new e2e (search → no-match → clear; tier-chip pressed-state toggle). **572 unit tests** green · build · lint · format all clean. (E2E runs in CI — the local sandbox's Playwright browser is version-mismatched after the recent dev-deps bump.)

## Part of the human-UX series
This is the first of a few small PRs from the UX audit. Next: donor entry point + roadmap discoverability (nav/home), then intake-help link + readiness-explainer polish. (Per your direction: **no "text us and we'll fill out your application" framing** — the 520-222-8104 line stays scoped to technical trouble submitting.)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PNahWrNd3XsoTQJ4Q9QsQ9)_