### PR TITLE
feat(roadmap): donor entry point, discoverability, OG + intake-help links

### DIFF
--- a/.github/ISSUE_TEMPLATE/charity-intake.yml
+++ b/.github/ISSUE_TEMPLATE/charity-intake.yml
@@ -74,7 +74,7 @@ body:
     id: mission-category
     attributes:
       label: Mission category
-      description: 'FFC favors basic-needs causes (food, water, shelter) first, then veterans/military, then all other missions. See /intake-help/mission-statement.'
+      description: 'FFC favors basic-needs causes (food, water, shelter) first, then veterans/military, then all other missions. See https://ffcadmin.org/intake-help/mission-statement.'
       options:
         - Basic needs (food, water, shelter)
         - Veterans / military
@@ -85,7 +85,7 @@ body:
     id: affiliation
     attributes:
       label: Affiliation
-      description: See /intake-help/fiscal-sponsorship for what each option means.
+      description: See https://ffcadmin.org/intake-help/fiscal-sponsorship for what each option means.
       options:
         - Independent
         - Sponsored by an FFC charity recipient
@@ -142,7 +142,7 @@ body:
         ### Contacts & board
         Provide your org main contact and your three required officers (President, Secretary,
         Treasurer); Vice President and Member at Large are optional. Phone/email types are scored —
-        see /intake-help/public-contact-info and /intake-help/board-requirements.
+        see https://ffcadmin.org/intake-help/public-contact-info and https://ffcadmin.org/intake-help/board-requirements.
   - type: input
     id: org-main-name
     attributes:
@@ -323,7 +323,7 @@ body:
     id: address-type
     attributes:
       label: Mailing address type
-      description: See /intake-help/mailing-address.
+      description: See https://ffcadmin.org/intake-help/mailing-address.
       options:
         - No address
         - Personal residence
@@ -354,7 +354,7 @@ body:
     id: candid-profile
     attributes:
       label: Candid / GuideStar profile URL
-      description: "For 501(c)(3) charities. Gold Seal is FFC's minimum — see /intake-help/guidestar-candid."
+      description: "For 501(c)(3) charities. Gold Seal is FFC's minimum — see https://ffcadmin.org/intake-help/guidestar-candid."
     validations:
       required: false
   - type: input
@@ -392,7 +392,7 @@ body:
     id: policy-pages
     attributes:
       label: Policy pages published
-      description: See /intake-help/policy-pages.
+      description: See https://ffcadmin.org/intake-help/policy-pages.
       options:
         - label: Donation Policy
         - label: Privacy Policy
@@ -415,7 +415,7 @@ body:
     id: documents
     attributes:
       label: Documents on file
-      description: Attach or link these in a comment. See /intake-help/supporting-documents.
+      description: Attach or link these in a comment. See https://ffcadmin.org/intake-help/supporting-documents.
       options:
         - label: Articles of incorporation
         - label: Bylaws
@@ -434,7 +434,7 @@ body:
     id: application-progress
     attributes:
       label: Application progress (pre-501(c)(3))
-      description: Only for charities still pursuing 501(c)(3). See /intake-help/getting-501c3.
+      description: Only for charities still pursuing 501(c)(3). See https://ffcadmin.org/intake-help/getting-501c3.
       options:
         - label: State incorporation filed
         - label: State incorporation approved
@@ -445,7 +445,7 @@ body:
     id: form-1023-status
     attributes:
       label: Form 1023 status
-      description: See /intake-help/501c3-application.
+      description: See https://ffcadmin.org/intake-help/501c3-application.
       options:
         - Not started
         - Form 1023-EZ drafted

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -148,7 +148,7 @@ export default function Home() {
               Pick the path that fits you — each one leads straight to the right starting point.
             </p>
           </div>
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-6">
             {/* Charity applicant */}
             <Link
               href="/charity-prerequisites"
@@ -265,6 +265,40 @@ export default function Home() {
               </p>
               <span className="inline-flex items-center text-sm font-semibold text-teal-700 group-hover:text-teal-900">
                 See the volunteer tracks
+                <svg
+                  className="w-4 h-4 ml-1"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M9 5l7 7-7 7"
+                  />
+                </svg>
+              </span>
+            </Link>
+
+            {/* Donor / supporter */}
+            <Link
+              href="/roadmap"
+              className="group block rounded-xl border-2 border-amber-200 bg-amber-50 p-6 hover:border-amber-400 hover:shadow-lg transition-all"
+            >
+              <span className="text-3xl" aria-hidden="true">
+                ❤️
+              </span>
+              <h3 className="text-lg font-bold text-amber-900 mt-3 mb-1">
+                I want to support a charity
+              </h3>
+              <p className="text-sm text-amber-900/80 mb-3">
+                Browse the charities FFC is helping — see each one&apos;s mission and status, then
+                visit its site to give.
+              </p>
+              <span className="inline-flex items-center text-sm font-semibold text-amber-700 group-hover:text-amber-900">
+                Explore the roadmap
                 <svg
                   className="w-4 h-4 ml-1"
                   fill="none"

--- a/src/app/roadmap/RoadmapCard.tsx
+++ b/src/app/roadmap/RoadmapCard.tsx
@@ -152,9 +152,10 @@ export default function RoadmapCard({ entry, section }: RoadmapCardProps) {
               href={entry.liveUrl}
               target="_blank"
               rel="noopener noreferrer"
+              aria-label={`Visit ${entry.charityName}’s website to support them`}
               className="font-medium text-emerald-700 hover:text-emerald-900"
             >
-              Visit site ↗
+              Visit &amp; support ↗
             </a>
           )}
           {section === 'needs-admin' ? (

--- a/src/app/roadmap/page.tsx
+++ b/src/app/roadmap/page.tsx
@@ -11,6 +11,19 @@ export const metadata: Metadata = {
   keywords:
     'Free For Charity roadmap, nonprofit intake, charity sponsorship, FFC queue, volunteer admin, charity website pipeline',
   alternates: { canonical: 'https://ffcadmin.org/roadmap/' },
+  openGraph: {
+    type: 'website',
+    title: 'The FFC Public Roadmap — charities we’re helping',
+    description:
+      'Browse every charity Free For Charity is helping — search and filter by mission and status, see readiness and transparency details, and visit a charity’s site to support it.',
+    url: 'https://ffcadmin.org/roadmap/',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'The FFC Public Roadmap — charities we’re helping',
+    description:
+      'Search and filter the charities Free For Charity is helping; see readiness and how to support them.',
+  },
 }
 
 export default function RoadmapPage() {
@@ -79,10 +92,10 @@ export default function RoadmapPage() {
               Become a sponsoring admin
             </Link>
             <a
-              href="#needs-admin"
+              href="#launched"
               className="rounded-lg border border-white/70 px-5 py-2.5 font-semibold text-white hover:bg-white/10"
             >
-              Browse the backlog
+              Support a charity
             </a>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Second PR from the human-UX audit (after the explorer, #533). Closes the donor gap, improves discoverability, and tidies share/intake details. **No concierge framing** — the 520-222-8104 line is untouched and stays scoped to *technical trouble submitting*, per your direction.

## Changes
- **Donor entry point (audit #2).** The home "What brings you here?" router had four contributor personas but nothing for a donor. Added **"I want to support a charity" → /roadmap** (and widened the grid to fit it). On the roadmap, the third hero CTA is now **"Support a charity"** (→ the launched, donatable sites) instead of the sponsor-oriented "Browse the backlog" (the explorer + status chips now cover browsing).
- **Card action + a11y (audit #5/#9).** Launched cards now read **"Visit & support ↗"** with a per-charity `aria-label` (`Visit {name}'s website to support them`) — previously a wall of identical, screen-reader-ambiguous "Visit site" links.
- **Shareable previews (audit #10).** Added `openGraph`/`twitter` text metadata to the roadmap page. *(A dedicated 1200×630 OG image needs a design asset — flagged as a follow-up; the site logo is inherited meanwhile.)*
- **Intake-help links (audit #8).** Made the `charity-intake.yml` → `/intake-help/*` references **absolute URLs** so they actually resolve from the GitHub issue form (relative paths there pointed at github.com).

## Tests
572 unit tests green · build · lint · format clean. (E2E in CI.)

## Series status
This is PR 2 of the UX series. After this: only design-dependent / infra items remain (a dedicated OG image; an email-alert signup for the empty queue, which needs a mail service) — I'll summarize those as optional rather than build blind.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PNahWrNd3XsoTQJ4Q9QsQ9)_