### PR TITLE
feat(roadmap): branded 1200x630 OG share image from the FFC circle

### DIFF
--- a/src/app/roadmap/opengraph-image.tsx
+++ b/src/app/roadmap/opengraph-image.tsx
@@ -1,0 +1,10 @@
+import { renderRoadmapOg, OG_SIZE, OG_CONTENT_TYPE } from '@/lib/og'
+
+export const dynamic = 'force-static'
+export const size = OG_SIZE
+export const contentType = OG_CONTENT_TYPE
+export const alt = 'The FFC Public Roadmap — every charity Free For Charity is helping'
+
+export default function Image() {
+  return renderRoadmapOg()
+}

--- a/src/app/roadmap/twitter-image.tsx
+++ b/src/app/roadmap/twitter-image.tsx
@@ -1,0 +1,10 @@
+import { renderRoadmapOg, OG_SIZE, OG_CONTENT_TYPE } from '@/lib/og'
+
+export const dynamic = 'force-static'
+export const size = OG_SIZE
+export const contentType = OG_CONTENT_TYPE
+export const alt = 'The FFC Public Roadmap — every charity Free For Charity is helping'
+
+export default function Image() {
+  return renderRoadmapOg()
+}

--- a/src/lib/og.tsx
+++ b/src/lib/og.tsx
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
 import { ImageResponse } from 'next/og'
 import { LEGACY_WP_ADMIN_PAGES } from '@/data/legacy-wordpress-administration'
 
@@ -12,6 +14,21 @@ import { LEGACY_WP_ADMIN_PAGES } from '@/data/legacy-wordpress-administration'
  */
 export const OG_SIZE = { width: 1200, height: 630 } as const
 export const OG_CONTENT_TYPE = 'image/png'
+
+/**
+ * The canonical FFC circle mark (`public/Svgs/ffc-logo.svg`) as a base64 data
+ * URI, read once at build time. Satori rasterizes embedded SVG `<img>`s via
+ * resvg, so the gradients render faithfully. Cached so repeated OG routes in a
+ * single build don't re-read the file.
+ */
+let ffcLogoDataUri: string | null = null
+function ffcCircleLogo(): string {
+  if (ffcLogoDataUri === null) {
+    const svg = readFileSync(join(process.cwd(), 'public/Svgs/ffc-logo.svg'), 'utf8')
+    ffcLogoDataUri = `data:image/svg+xml;base64,${Buffer.from(svg).toString('base64')}`
+  }
+  return ffcLogoDataUri
+}
 
 export function renderOgImage({
   title,
@@ -60,6 +77,85 @@ export function renderOgImage({
         <span style={{ display: 'flex', fontWeight: 700 }}>Free For Charity</span>
         <span style={{ display: 'flex', color: '#94a3b8' }}>ffcadmin.org</span>
       </div>
+    </div>,
+    { ...OG_SIZE }
+  )
+}
+
+/**
+ * Roadmap share image — the FFC circle mark as the hero element beside the
+ * title. Used by the `/roadmap` opengraph-image + twitter-image routes so
+ * social shares of the public roadmap are branded with the FFC logo.
+ */
+export function renderRoadmapOg({
+  eyebrow = 'Free For Charity',
+  title = 'The Public Roadmap',
+  subtitle = 'Every charity we’re helping — from intake to launch.',
+}: {
+  eyebrow?: string
+  title?: string
+  subtitle?: string
+} = {}): ImageResponse {
+  return new ImageResponse(
+    <div
+      style={{
+        height: '100%',
+        width: '100%',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        background: 'linear-gradient(135deg, #0f172a 0%, #134e4a 100%)',
+        color: 'white',
+        padding: '80px',
+        fontFamily: 'sans-serif',
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+          height: '100%',
+          width: '700px',
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            fontSize: 32,
+            letterSpacing: 2,
+            textTransform: 'uppercase',
+            color: '#2dd4bf',
+            fontWeight: 700,
+          }}
+        >
+          {eyebrow}
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column' }}>
+          <div style={{ display: 'flex', fontSize: 76, fontWeight: 800, lineHeight: 1.05 }}>
+            {title}
+          </div>
+          <div style={{ display: 'flex', marginTop: 24, fontSize: 34, color: '#cbd5e1' }}>
+            {subtitle}
+          </div>
+        </div>
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            width: '100%',
+            fontSize: 30,
+          }}
+        >
+          <span style={{ display: 'flex', fontWeight: 700, color: '#cbd5e1' }}>
+            Free websites for 501(c)(3) nonprofits
+          </span>
+          <span style={{ display: 'flex', color: '#94a3b8' }}>ffcadmin.org</span>
+        </div>
+      </div>
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img src={ffcCircleLogo()} width={380} height={380} alt="" />
     </div>,
     { ...OG_SIZE }
   )


### PR DESCRIPTION
## Summary

Builds the dedicated roadmap share image that was deferred in #534 (the previous commit shipped text-only OG metadata). The user asked for the share image to be made "from the FFC logo circle" — this does exactly that, reusing the existing `next/og` (satori) infrastructure with **no new dependencies and no Playwright**.

- `src/lib/og.tsx`: `renderRoadmapOg()` features the canonical FFC circle mark (`public/Svgs/ffc-logo.svg`) as a 380px hero beside the title, on the established teal brand gradient. The SVG is read once at build time and embedded as a base64 data URI — resvg renders its gradients faithfully.
- `src/app/roadmap/opengraph-image.tsx` + `twitter-image.tsx`: file-convention routes that auto-wire `og:image` + `twitter:image` (1200×630) into the roadmap metadata, so shares render the branded card instead of plain text.

## Preview

The share card: eyebrow "FREE FOR CHARITY", title "The Public Roadmap", subtitle "Every charity we're helping — from intake to launch", a footer tagline + `ffcadmin.org`, and the FFC pinwheel circle (teal/orange quadrants with outward arrows) as the hero element.

## Verification

- `pnpm run format` / `lint` / `type-check` — clean (1 pre-existing unrelated warning).
- `pnpm run build` — static export succeeds; both `opengraph-image` and `twitter-image` PNGs (1200×630, ~94 KB) emitted under `out/roadmap/`, with correct absolute-URL `og:image` / `twitter:image` meta tags.
- `pnpm test` — 572 passed.

Refs: roadmap program plan (`docs/program-plan.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PNahWrNd3XsoTQJ4Q9QsQ9