### PR TITLE
fix(roadmap): defer /roadmap/submit apply to canonical freeforcharity.org

### DIFF
--- a/src/app/roadmap/submit/page.tsx
+++ b/src/app/roadmap/submit/page.tsx
@@ -11,7 +11,7 @@ export const metadata: Metadata = {
   alternates: { canonical: 'https://ffcadmin.org/roadmap/submit/' },
 }
 
-const ZEFFY_APPLICATION_URL = 'https://www.zeffy.com/'
+const FFC_APPLICATION_URL = 'https://freeforcharity.org/submit-information/'
 const INTAKE_ISSUE_URL =
   'https://github.com/FreeForCharity/FFC-IN-ffcadmin.org/issues/new?template=charity-intake.yml'
 const ESCALATION_ISSUE_URL =
@@ -28,9 +28,9 @@ interface PathCard {
 const cards: PathCard[] = [
   {
     title: 'Apply for FFC service',
-    body: 'New to FFC? Start with the Zeffy application and verification form. We assess mission fit first, then offer the service products you are ready for.',
-    href: ZEFFY_APPLICATION_URL,
-    cta: 'Start the Zeffy application',
+    body: 'New to FFC? Applications and mission-fit verification start on freeforcharity.org — our front door for new charities. We assess mission fit first, then offer the service products you are ready for.',
+    href: FFC_APPLICATION_URL,
+    cta: 'Apply at freeforcharity.org',
     external: true,
   },
   {
@@ -64,8 +64,8 @@ export default function SubmitPage() {
         <div className="mx-auto max-w-4xl px-4 py-14 sm:px-6 lg:px-8">
           <h1 className="text-3xl font-bold md:text-4xl">Submit a request</h1>
           <p className="mt-3 max-w-2xl text-lg text-teal-50">
-            Pick the path that fits. Zeffy is FFC’s front door for applications and service
-            products; structured intake and coordination continue on GitHub.
+            Pick the path that fits. New applications start on freeforcharity.org, FFC’s front door
+            for charities and donors; structured intake and coordination continue here on GitHub.
           </p>
         </div>
       </div>
@@ -111,8 +111,8 @@ export default function SubmitPage() {
             </li>
           </ul>
           <p className="mt-4 rounded-lg bg-teal-50 p-4 text-sm text-teal-900">
-            Not comfortable with GitHub? Text <strong>520-222-8104</strong> and an FFC admin will
-            complete the intake on your behalf.
+            Hitting a technical snag submitting? Text <strong>520-222-8104</strong> and an FFC admin
+            will help you get unstuck so you can finish the submission yourself.
           </p>
         </div>
       </main>


### PR DESCRIPTION
## Summary

Reconciles the on-site `/roadmap/submit` page with FFC's deliberate two-site split: **freeforcharity.org is the canonical front door for charity applications & donations; ffcadmin.org is the volunteer/admin portal + the public roadmap (a transparency view).** The footer, nav "For Charities & Donors", `NonprofitCallout`, `charity-prerequisites`, and legacy `PageHeader` already route apply → freeforcharity.org. `/roadmap/submit` was the one page that contradicted the model:

- **Competing apply entry:** the "Apply for FFC service" card linked to a generic `zeffy.com` URL and the hero called Zeffy "FFC's front door." Now points at `freeforcharity.org/submit-information/` (the canonical apply URL) with matching hero copy.
- **Concierge framing:** the phone-fallback line said an admin "will complete the intake on your behalf." Rescoped to **technical trouble submitting only** — we help you get unstuck so you finish the submission yourself. The `520-222-8104` number is unchanged.

GitHub-side intake (for existing FFC charities) and the escalation form stay on-site as before — only the *new-charity apply* entry now defers to the canonical funnel.

## Verification

- `pnpm run format` / `lint` / `type-check` — clean.
- `pnpm run build` — static export succeeds; built `out/roadmap/submit/index.html` verified: canonical apply link present, no `zeffy.com`, no "on your behalf" framing, technical-trouble copy + phone number + "Apply for FFC service" heading intact.
- `pnpm test` — 572 passed.
- e2e runs in CI (local Playwright browser version is mismatched in this environment; the change is copy/link-only and the asserted heading + phone number are preserved).

Refs: roadmap program plan (`docs/program-plan.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PNahWrNd3XsoTQJ4Q9QsQ9

---
_Generated by [Claude Code](https://claude.ai/code/session_01PNahWrNd3XsoTQJ4Q9QsQ9)_