### PR TITLE
feat(nav): global site search (⌘K command palette)

### DIFF
--- a/__tests__/components/GlobalSearch.test.tsx
+++ b/__tests__/components/GlobalSearch.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * GlobalSearch (command-palette) tests.
+ */
+import '@testing-library/jest-dom'
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import GlobalSearch, { openGlobalSearch } from '@/components/GlobalSearch'
+
+const push = jest.fn()
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push, replace: jest.fn(), prefetch: jest.fn() }),
+}))
+
+describe('GlobalSearch', () => {
+  beforeEach(() => push.mockReset())
+
+  it('is closed until opened', () => {
+    render(<GlobalSearch />)
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('opens via openGlobalSearch(), filters results, and navigates on click', async () => {
+    render(<GlobalSearch />)
+    await act(async () => {
+      openGlobalSearch()
+    })
+    expect(screen.getByRole('dialog', { name: 'Search the site' })).toBeInTheDocument()
+
+    fireEvent.change(screen.getByRole('searchbox'), { target: { value: 'methodology' } })
+    fireEvent.click(screen.getByRole('button', { name: /Readiness methodology/ }))
+
+    expect(push).toHaveBeenCalledWith('/roadmap/methodology')
+    // Navigating closes the modal.
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('toggles open on Ctrl+K and closes on Escape', async () => {
+    render(<GlobalSearch />)
+    await act(async () => {
+      fireEvent.keyDown(document, { key: 'k', ctrlKey: true })
+    })
+    const dialog = screen.getByRole('dialog')
+    expect(dialog).toBeInTheDocument()
+
+    await act(async () => {
+      fireEvent.keyDown(dialog, { key: 'Escape' })
+    })
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('shows an empty state for a query with no matches', async () => {
+    render(<GlobalSearch />)
+    await act(async () => {
+      openGlobalSearch()
+    })
+    fireEvent.change(screen.getByRole('searchbox'), { target: { value: 'zzzznotapage' } })
+    expect(screen.getByText(/No pages match/)).toBeInTheDocument()
+  })
+})

--- a/__tests__/components/Navigation.test.tsx
+++ b/__tests__/components/Navigation.test.tsx
@@ -11,6 +11,14 @@ import { render, screen, fireEvent, act } from '@testing-library/react'
 import Navigation from '@/components/Navigation'
 import { volunteerMenu, menuItems } from '@/data/navigation'
 
+// Navigation renders <GlobalSearch>, which calls useRouter(); that throws
+// without an app-router context, so provide a mock. usePathname mirrors the
+// unmocked default ('' → Home treated as active) to keep existing assertions.
+jest.mock('next/navigation', () => ({
+  usePathname: () => '',
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn(), prefetch: jest.fn() }),
+}))
+
 // Helper to render and flush the queueMicrotask from the pathname effect
 async function renderNavigation() {
   render(<Navigation />)

--- a/__tests__/search-index.test.ts
+++ b/__tests__/search-index.test.ts
@@ -1,0 +1,71 @@
+import fs from 'fs'
+import path from 'path'
+import { SEARCH_DOCS, searchDocs } from '@/data/search-index'
+
+describe('search index', () => {
+  it('has entries and no duplicate hrefs', () => {
+    expect(SEARCH_DOCS.length).toBeGreaterThan(30)
+    const hrefs = SEARCH_DOCS.map((d) => d.href.replace(/\/+$/, '') || '/')
+    expect(new Set(hrefs).size).toBe(hrefs.length)
+  })
+
+  it('every entry is an internal absolute path with required fields', () => {
+    for (const doc of SEARCH_DOCS) {
+      expect(doc.href.startsWith('/')).toBe(true)
+      expect(doc.title.length).toBeGreaterThan(0)
+      expect(doc.description.length).toBeGreaterThan(0)
+      expect(doc.category.length).toBeGreaterThan(0)
+    }
+  })
+})
+
+describe('searchDocs ranking', () => {
+  it('returns nothing for an empty or whitespace query', () => {
+    expect(searchDocs('')).toEqual([])
+    expect(searchDocs('   ')).toEqual([])
+  })
+
+  it('ranks a title match first', () => {
+    const results = searchDocs('roadmap')
+    expect(results.length).toBeGreaterThan(0)
+    expect(results[0].href).toBe('/roadmap')
+  })
+
+  it('matches on keywords not present in the title/description', () => {
+    // "apply" is a keyword on the Submit page, whose title is "Submit a request".
+    const results = searchDocs('apply')
+    expect(results.some((d) => d.href === '/roadmap/submit')).toBe(true)
+  })
+
+  it('applies AND semantics across tokens', () => {
+    const results = searchDocs('readiness methodology')
+    expect(results.length).toBeGreaterThan(0)
+    expect(results.every((d) => d.href === '/roadmap/methodology' || d.category.length > 0)).toBe(
+      true
+    )
+    expect(results[0].href).toBe('/roadmap/methodology')
+  })
+
+  it('returns nothing for gibberish', () => {
+    expect(searchDocs('zzzznotapage')).toEqual([])
+  })
+
+  it('respects the result limit', () => {
+    // "a" appears broadly; ensure the cap holds.
+    expect(searchDocs('a', 5).length).toBeLessThanOrEqual(5)
+  })
+})
+
+describe('search index has no dead links (requires build output)', () => {
+  const outDir = path.join(process.cwd(), 'out')
+  const built = fs.existsSync(outDir)
+
+  const maybe = built ? it : it.skip
+  SEARCH_DOCS.forEach((doc) => {
+    maybe(`${doc.href} resolves to a generated page`, () => {
+      const rel = doc.href === '/' ? '' : doc.href.replace(/^\//, '').replace(/\/$/, '')
+      const file = path.join(outDir, rel, 'index.html')
+      expect(fs.existsSync(file)).toBe(true)
+    })
+  })
+})

--- a/e2e/global-search.spec.ts
+++ b/e2e/global-search.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Global site search', () => {
+  test('opens with Ctrl+K, finds a page, and navigates to it', async ({ page }) => {
+    await page.goto('/')
+    await page.keyboard.press('Control+k')
+
+    const dialog = page.getByRole('dialog', { name: 'Search the site' })
+    await expect(dialog).toBeVisible()
+
+    await dialog.getByRole('searchbox').fill('methodology')
+    await dialog.getByRole('button', { name: /Readiness methodology/ }).click()
+
+    await expect(page).toHaveURL(/\/roadmap\/methodology\/?$/)
+  })
+
+  test('trigger button opens the modal and Escape closes it', async ({ page }) => {
+    await page.goto('/')
+    await page.getByRole('button', { name: 'Search the site' }).first().click()
+
+    const dialog = page.getByRole('dialog', { name: 'Search the site' })
+    await expect(dialog).toBeVisible()
+
+    await page.keyboard.press('Escape')
+    await expect(dialog).not.toBeVisible()
+  })
+
+  test('shows a no-match state for gibberish', async ({ page }) => {
+    await page.goto('/')
+    await page.keyboard.press('Control+k')
+    const dialog = page.getByRole('dialog', { name: 'Search the site' })
+    await dialog.getByRole('searchbox').fill('zzzznotapage')
+    await expect(dialog.getByText(/No pages match/)).toBeVisible()
+  })
+})

--- a/src/components/GlobalSearch.tsx
+++ b/src/components/GlobalSearch.tsx
@@ -1,0 +1,180 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { searchDocs } from '@/data/search-index'
+
+/**
+ * Global site search — a ⌘K / Ctrl-K command-palette modal that searches every
+ * page on the site (see `src/data/search-index.ts`). Rendered once in the
+ * header; the trigger buttons live in `Navigation` and call `openGlobalSearch()`
+ * so the single modal + keyboard listener isn't duplicated.
+ */
+
+const OPEN_EVENT = 'ffc:open-search'
+
+/** Open the global search modal from anywhere (header trigger buttons). */
+export function openGlobalSearch() {
+  window.dispatchEvent(new Event(OPEN_EVENT))
+}
+
+export default function GlobalSearch() {
+  const router = useRouter()
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const [active, setActive] = useState(0)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const results = useMemo(() => searchDocs(query), [query])
+
+  const close = useCallback(() => {
+    setOpen(false)
+    setQuery('')
+    setActive(0)
+  }, [])
+
+  const go = useCallback(
+    (href: string) => {
+      close()
+      router.push(href)
+    },
+    [close, router]
+  )
+
+  // Open on custom event (from header triggers) and on ⌘K / Ctrl-K anywhere.
+  useEffect(() => {
+    const onOpen = () => setOpen(true)
+    const onKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+        e.preventDefault()
+        setOpen((v) => !v)
+      }
+    }
+    window.addEventListener(OPEN_EVENT, onOpen)
+    document.addEventListener('keydown', onKeyDown)
+    return () => {
+      window.removeEventListener(OPEN_EVENT, onOpen)
+      document.removeEventListener('keydown', onKeyDown)
+    }
+  }, [])
+
+  // Focus the input and lock body scroll while open.
+  useEffect(() => {
+    if (!open) return
+    inputRef.current?.focus()
+    const prev = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      document.body.style.overflow = prev
+    }
+  }, [open])
+
+  if (!open) return null
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      e.preventDefault()
+      close()
+    } else if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      setActive((i) => Math.min(i + 1, results.length - 1))
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      setActive((i) => Math.max(i - 1, 0))
+    } else if (e.key === 'Enter') {
+      e.preventDefault()
+      const target = results[active]
+      if (target) go(target.href)
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-[100] flex items-start justify-center bg-black/40 px-4 pt-[12vh]"
+      onMouseDown={close}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Search the site"
+        className="w-full max-w-xl overflow-hidden rounded-xl bg-white shadow-2xl"
+        onMouseDown={(e) => e.stopPropagation()}
+        onKeyDown={onKeyDown}
+      >
+        <div className="flex items-center gap-3 border-b border-gray-200 px-4">
+          <svg
+            className="h-5 w-5 flex-shrink-0 text-gray-400"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+            />
+          </svg>
+          <input
+            ref={inputRef}
+            type="search"
+            value={query}
+            onChange={(e) => {
+              setQuery(e.target.value)
+              setActive(0)
+            }}
+            placeholder="Search pages, guides, roles, docs…"
+            aria-label="Search the site"
+            aria-controls="global-search-results"
+            className="w-full py-4 text-base text-gray-900 outline-none placeholder:text-gray-400"
+          />
+          <kbd className="hidden flex-shrink-0 rounded border border-gray-200 bg-gray-50 px-1.5 py-0.5 text-xs text-gray-400 sm:block">
+            Esc
+          </kbd>
+        </div>
+
+        {query && (
+          <ul
+            id="global-search-results"
+            className="max-h-[50vh] overflow-y-auto py-2"
+            role="listbox"
+          >
+            {results.length === 0 ? (
+              <li className="px-4 py-6 text-center text-sm text-gray-500" role="status">
+                No pages match “{query}”. Try a different term.
+              </li>
+            ) : (
+              results.map((doc, i) => (
+                <li key={doc.href} role="option" aria-selected={i === active}>
+                  <button
+                    type="button"
+                    onMouseEnter={() => setActive(i)}
+                    onClick={() => go(doc.href)}
+                    className={`flex w-full flex-col items-start gap-0.5 px-4 py-2.5 text-left transition-colors ${
+                      i === active ? 'bg-blue-50' : 'hover:bg-gray-50'
+                    }`}
+                  >
+                    <span className="flex w-full items-center justify-between gap-2">
+                      <span className="font-semibold text-gray-900">{doc.title}</span>
+                      <span className="flex-shrink-0 rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-500">
+                        {doc.category}
+                      </span>
+                    </span>
+                    <span className="line-clamp-1 text-sm text-gray-500">{doc.description}</span>
+                  </button>
+                </li>
+              ))
+            )}
+          </ul>
+        )}
+
+        {!query && (
+          <p className="px-4 py-6 text-center text-sm text-gray-400">
+            Start typing to search every page on the site.
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -5,6 +5,9 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { usePathname } from 'next/navigation'
 import { assetPath } from '@/lib/assetPath'
 import { NAV_MENUS, menuItems, type NavMenu } from '@/data/navigation'
+import GlobalSearch, { openGlobalSearch } from './GlobalSearch'
+
+const searchIconPath = 'M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z'
 
 export default function Navigation() {
   const [isMenuOpen, setIsMenuOpen] = useState(false)
@@ -273,37 +276,81 @@ export default function Navigation() {
                 />
               </svg>
             </a>
+
+            <button
+              type="button"
+              onClick={openGlobalSearch}
+              aria-label="Search the site"
+              className="inline-flex items-center gap-2 rounded-lg border border-gray-200 px-3 py-1.5 text-sm text-gray-500 hover:border-gray-300 hover:text-gray-700 transition-colors"
+            >
+              <svg
+                className="h-4 w-4"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d={searchIconPath}
+                />
+              </svg>
+              <span>Search</span>
+              <kbd className="rounded border border-gray-200 bg-gray-50 px-1 text-xs">⌘K</kbd>
+            </button>
           </div>
 
-          {/* Mobile menu button */}
-          <button
-            onClick={() => {
-              const willClose = isMenuOpen
-              setIsMenuOpen(!isMenuOpen)
-              if (willClose) setMobileAccordions(new Set())
-            }}
-            className="xl:hidden p-2 rounded-md hover:bg-gray-100 text-gray-600 transition-colors"
-            aria-label="Toggle menu"
-            aria-expanded={isMenuOpen}
-            aria-controls="mobile-menu"
-          >
-            <svg
-              className="h-6 w-6"
-              fill="none"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth="2"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              aria-hidden="true"
+          {/* Mobile controls: search + menu toggle */}
+          <div className="flex items-center gap-1 xl:hidden">
+            <button
+              type="button"
+              onClick={openGlobalSearch}
+              className="p-2 rounded-md hover:bg-gray-100 text-gray-600 transition-colors"
+              aria-label="Search the site"
             >
-              {isMenuOpen ? (
-                <path d="M6 18L18 6M6 6l12 12" />
-              ) : (
-                <path d="M4 6h16M4 12h16M4 18h16" />
-              )}
-            </svg>
-          </button>
+              <svg
+                className="h-6 w-6"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" d={searchIconPath} />
+              </svg>
+            </button>
+
+            <button
+              onClick={() => {
+                const willClose = isMenuOpen
+                setIsMenuOpen(!isMenuOpen)
+                if (willClose) setMobileAccordions(new Set())
+              }}
+              className="p-2 rounded-md hover:bg-gray-100 text-gray-600 transition-colors"
+              aria-label="Toggle menu"
+              aria-expanded={isMenuOpen}
+              aria-controls="mobile-menu"
+            >
+              <svg
+                className="h-6 w-6"
+                fill="none"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="2"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                aria-hidden="true"
+              >
+                {isMenuOpen ? (
+                  <path d="M6 18L18 6M6 6l12 12" />
+                ) : (
+                  <path d="M4 6h16M4 12h16M4 18h16" />
+                )}
+              </svg>
+            </button>
+          </div>
         </div>
 
         {/* Mobile menu */}
@@ -347,6 +394,8 @@ export default function Navigation() {
           </div>
         )}
       </div>
+
+      <GlobalSearch />
     </nav>
   )
 }

--- a/src/data/search-index.ts
+++ b/src/data/search-index.ts
@@ -1,0 +1,343 @@
+/**
+ * Global site search index.
+ *
+ * A single, flat list of every meaningful page on the site, aggregated from the
+ * existing data modules (so titles/descriptions stay in one place and don't
+ * drift) plus a curated list of standalone pages that aren't backed by a data
+ * module. Consumed by the header `GlobalSearch` component.
+ *
+ * Adding a page: if it belongs to one of the aggregated data modules (blog,
+ * guides, intake-help, volunteer roles, legacy WP admin, CE bodies) it appears
+ * here automatically. Otherwise add it to `STANDALONE_PAGES` below.
+ */
+import { blogPosts } from './blog'
+import { guides } from './guides'
+import { SETUP_GUIDES } from './setup-guides'
+import { INTAKE_HELP_PAGES, INTAKE_HELP_BASE } from './intake-help'
+import { VOLUNTEER_ROLES } from './volunteer-roles'
+import { LEGACY_WP_ADMIN_PAGES, LEGACY_WP_ADMIN_BASE } from './legacy-wordpress-administration'
+import { CE_BODIES } from './ce-bodies'
+import { NAV_MENUS } from './navigation'
+
+export interface SearchDoc {
+  title: string
+  description: string
+  href: string
+  /** Human-readable grouping shown as a chip in results. */
+  category: string
+  /** Extra terms to match on that aren't in the title/description. */
+  keywords?: string
+}
+
+/** Map a nav section heading to a search category label. */
+const NAV_SECTION_CATEGORY: Record<string, string> = {
+  'Get involved': 'Volunteer',
+  'Training tracks': 'Training',
+  Operations: 'Operations',
+  Resources: 'Resources',
+}
+
+// Pages that aren't backed by a data module (hubs, policies, single pages).
+const STANDALONE_PAGES: SearchDoc[] = [
+  {
+    title: 'Home',
+    description:
+      'The Free For Charity volunteer & admin portal — training, operations, and the public roadmap.',
+    href: '/',
+    category: 'Main',
+    keywords: 'home start portal ffc admin',
+  },
+  {
+    title: 'Public Roadmap',
+    description:
+      'Every charity FFC is helping — in review, awaiting a sponsor, in active build, and launched.',
+    href: '/roadmap',
+    category: 'Roadmap',
+    keywords: 'transparency queue charities status pipeline',
+  },
+  {
+    title: 'Submit a request',
+    description:
+      'Apply for FFC service, request another service, or file a question or escalation.',
+    href: '/roadmap/submit',
+    category: 'Roadmap',
+    keywords: 'apply application intake escalation request',
+  },
+  {
+    title: 'Become a sponsoring admin',
+    description: 'Steward a charity build as a verified volunteer sponsor.',
+    href: '/roadmap/sponsor',
+    category: 'Roadmap',
+    keywords: 'sponsor sponsoring admin steward volunteer',
+  },
+  {
+    title: 'Readiness methodology',
+    description: 'How FFC scores charity readiness transparently and sorts the queue.',
+    href: '/roadmap/methodology',
+    category: 'Roadmap',
+    keywords: 'readiness scoring methodology tiers sort',
+  },
+  {
+    title: 'Intake Help',
+    description: 'Guides for charities completing FFC intake — board, contact info, and more.',
+    href: '/intake-help',
+    category: 'For charities',
+    keywords: 'intake help charity onboarding requirements',
+  },
+  {
+    title: 'Manage my charity site',
+    description: 'Edit and maintain the FFC-built website for your charity.',
+    href: '/site-owner',
+    category: 'Site owners',
+    keywords: 'site owner edit manage my site charity website',
+  },
+  {
+    title: 'Accept your site invitation',
+    description: 'Set up access to manage your charity website.',
+    href: '/site-owner/accept-invitation',
+    category: 'Site owners',
+    keywords: 'invitation invite access onboarding github',
+  },
+  {
+    title: 'Common site edits',
+    description:
+      'Ready-to-paste prompts for the most common charity website edits — contact info, hours, donate button, photos, and more.',
+    href: '/site-owner/common-edits',
+    category: 'Site owners',
+    keywords: 'edits prompts contact hours donate photos team social',
+  },
+  {
+    title: 'Claude Desktop setup',
+    description: 'Set up Claude Desktop as your AI coding assistant for FFC work.',
+    href: '/developer-environment-setup/claude-desktop',
+    category: 'Resources',
+    keywords: 'claude desktop ai assistant setup environment',
+  },
+  {
+    title: 'Codex setup',
+    description: 'Set up OpenAI Codex as your AI coding assistant for FFC work.',
+    href: '/developer-environment-setup/codex',
+    category: 'Resources',
+    keywords: 'codex openai ai assistant setup environment',
+  },
+  {
+    title: 'Google Antigravity setup',
+    description: 'Set up Google Antigravity as your AI coding assistant for FFC work.',
+    href: '/developer-environment-setup/google-antigravity',
+    category: 'Resources',
+    keywords: 'google antigravity gemini ai assistant setup environment',
+  },
+  {
+    title: 'VS Code setup',
+    description: 'Set up VS Code with Copilot for FFC development.',
+    href: '/developer-environment-setup/vscode',
+    category: 'Resources',
+    keywords: 'vscode visual studio code copilot ai setup environment',
+  },
+  {
+    title: 'Sites in development',
+    description: 'FFC-managed charity sites currently being built.',
+    href: '/sites-list/development',
+    category: 'Operations',
+    keywords: 'sites list development building',
+  },
+  {
+    title: 'Sites in maintenance',
+    description: 'FFC-managed charity sites in ongoing maintenance.',
+    href: '/sites-list/maintenance',
+    category: 'Operations',
+    keywords: 'sites list maintenance',
+  },
+  {
+    title: 'Sites in migration',
+    description: 'FFC-managed charity sites migrating from WordPress to Next.js.',
+    href: '/sites-list/migration',
+    category: 'Operations',
+    keywords: 'sites list migration wordpress nextjs',
+  },
+  {
+    title: 'Sites list summary',
+    description: 'Overview counts and health across all FFC-managed domains.',
+    href: '/sites-list/summary',
+    category: 'Operations',
+    keywords: 'sites list summary counts health',
+  },
+  {
+    title: 'Terms of Service',
+    description: 'The terms governing use of FFC services and this site.',
+    href: '/terms-of-service',
+    category: 'Policies',
+    keywords: 'terms of service legal policy',
+  },
+  {
+    title: 'Privacy Policy',
+    description: 'How FFC handles personal data and privacy.',
+    href: '/privacy-policy',
+    category: 'Policies',
+    keywords: 'privacy data legal policy',
+  },
+  {
+    title: 'Cookie Policy',
+    description: 'How this site uses cookies.',
+    href: '/cookie-policy',
+    category: 'Policies',
+    keywords: 'cookies tracking legal policy',
+  },
+  {
+    title: 'Donation Policy',
+    description: 'How FFC handles donations and financial transparency.',
+    href: '/donation-policy',
+    category: 'Policies',
+    keywords: 'donation donate financial legal policy',
+  },
+  {
+    title: 'Vulnerability Disclosure Policy',
+    description: 'How to responsibly report a security vulnerability to FFC.',
+    href: '/vulnerability-disclosure-policy',
+    category: 'Policies',
+    keywords: 'security vulnerability disclosure report responsible',
+  },
+  {
+    title: 'Security Acknowledgements',
+    description: 'Researchers recognized for responsibly disclosing security issues.',
+    href: '/security-acknowledgements',
+    category: 'Policies',
+    keywords: 'security acknowledgements hall of fame researchers',
+  },
+]
+
+// Hub/section pages driven by the nav mega-menus (single source of truth).
+const NAV_PAGES: SearchDoc[] = NAV_MENUS.flatMap((menu) =>
+  menu.sections.flatMap((section) =>
+    section.items.map((item) => ({
+      title: item.label,
+      description: item.description,
+      href: item.href,
+      category: NAV_SECTION_CATEGORY[section.heading] ?? menu.label,
+    }))
+  )
+)
+
+const BLOG_PAGES: SearchDoc[] = blogPosts.map((post) => ({
+  title: post.title,
+  description: post.description,
+  href: post.href,
+  category: 'Blog',
+}))
+
+const GUIDE_PAGES: SearchDoc[] = guides.map((guide) => ({
+  title: guide.title,
+  description: guide.description,
+  href: guide.href,
+  category: 'Guides',
+}))
+
+const SETUP_GUIDE_PAGES: SearchDoc[] = SETUP_GUIDES.map((g) => ({
+  title: g.title,
+  description: g.description,
+  href: `/guides/${g.slug}`,
+  category: 'Account setup',
+  keywords: `${g.category} ${g.audience}`,
+}))
+
+const INTAKE_HELP_SEARCH_PAGES: SearchDoc[] = INTAKE_HELP_PAGES.map((p) => ({
+  title: p.title,
+  description: p.summary,
+  href: `${INTAKE_HELP_BASE}/${p.slug}`,
+  category: 'For charities',
+}))
+
+const VOLUNTEER_ROLE_PAGES: SearchDoc[] = VOLUNTEER_ROLES.map((role) => ({
+  title: role.title,
+  description: role.tagline,
+  href: `/volunteer/${role.slug}`,
+  category: 'Volunteer',
+  keywords: role.keywords,
+}))
+
+const LEGACY_WP_PAGES: SearchDoc[] = LEGACY_WP_ADMIN_PAGES.map((p) => ({
+  title: p.title,
+  description: p.summary,
+  href: `${LEGACY_WP_ADMIN_BASE}/${p.slug}`,
+  category: 'Legacy WP admin',
+}))
+
+const CE_PAGES: SearchDoc[] = CE_BODIES.filter((b) => b.landing).map((b) => ({
+  title: b.landing!.title,
+  description: b.landing!.description,
+  href: `/continuing-education/${b.landing!.slug}`,
+  category: 'Continuing education',
+  keywords: b.name,
+}))
+
+/** Normalize an href for de-duplication (drop trailing slash, lowercase). */
+function normalizeHref(href: string): string {
+  const trimmed = href.replace(/\/+$/, '')
+  return (trimmed === '' ? '/' : trimmed).toLowerCase()
+}
+
+/**
+ * The full search index. Earlier entries win on duplicate href, so the curated
+ * standalone/nav entries take precedence over auto-generated ones.
+ */
+export const SEARCH_DOCS: SearchDoc[] = (() => {
+  const all = [
+    ...STANDALONE_PAGES,
+    ...NAV_PAGES,
+    ...BLOG_PAGES,
+    ...GUIDE_PAGES,
+    ...SETUP_GUIDE_PAGES,
+    ...INTAKE_HELP_SEARCH_PAGES,
+    ...VOLUNTEER_ROLE_PAGES,
+    ...LEGACY_WP_PAGES,
+    ...CE_PAGES,
+  ]
+  const seen = new Set<string>()
+  const deduped: SearchDoc[] = []
+  for (const doc of all) {
+    const key = normalizeHref(doc.href)
+    if (seen.has(key)) continue
+    seen.add(key)
+    deduped.push(doc)
+  }
+  return deduped
+})()
+
+function scoreDoc(doc: SearchDoc, tokens: string[]): number {
+  const title = doc.title.toLowerCase()
+  const keywords = (doc.keywords ?? '').toLowerCase()
+  const description = doc.description.toLowerCase()
+  const category = doc.category.toLowerCase()
+  let score = 0
+  for (const token of tokens) {
+    // AND semantics: every token must match somewhere in the doc.
+    if (
+      !title.includes(token) &&
+      !keywords.includes(token) &&
+      !description.includes(token) &&
+      !category.includes(token)
+    ) {
+      return -1
+    }
+    if (title.startsWith(token)) score += 100
+    else if (title.includes(token)) score += 60
+    else if (keywords.includes(token)) score += 25
+    else if (description.includes(token)) score += 12
+    else score += 5 // category-only match
+  }
+  return score
+}
+
+/**
+ * Rank the index against a free-text query. Returns the top `limit` docs,
+ * highest score first, ties broken alphabetically. Empty query → no results.
+ */
+export function searchDocs(query: string, limit = 8): SearchDoc[] {
+  const tokens = query.toLowerCase().split(/\s+/).filter(Boolean)
+  if (tokens.length === 0) return []
+  return SEARCH_DOCS.map((doc) => ({ doc, score: scoreDoc(doc, tokens) }))
+    .filter((x) => x.score >= 0)
+    .sort((a, b) => b.score - a.score || a.doc.title.localeCompare(b.doc.title))
+    .slice(0, limit)
+    .map((x) => x.doc)
+}


### PR DESCRIPTION
## Summary

The site has 70+ pages but only `/documentation` had a scoped search — there was no header-level way to find anything. This adds a **global ⌘K command-palette search** available from every page.

- **`src/data/search-index.ts`** — a single flat index (**127 pages**) aggregated from the existing data modules (nav mega-menus, blog, guides, setup guides, intake-help, volunteer roles, legacy WP admin, CE bodies) so titles/descriptions stay in one place and don't drift, **plus** curated entries for standalone pages (roadmap family, site-owner family, dev-env leaves, sites-list leaves, policies). Deduped by href. Exports a pure `searchDocs()` ranker (title > keywords > description > category, AND across tokens).
- **`src/components/GlobalSearch.tsx`** — a ⌘K / Ctrl-K modal (also opens from the header buttons) with live results, arrow-key navigation, Enter to open, Escape/backdrop to close, body-scroll lock, and `dialog`/`listbox` a11y roles.
- **`src/components/Navigation.tsx`** — a desktop "Search ⌘K" trigger and a mobile search icon, both firing the shared modal (rendered once so there's no duplicate keyboard listener).

## How it works

The trigger buttons dispatch a custom event that the single `GlobalSearch` instance listens for; ⌘K/Ctrl-K toggles it globally. Selecting a result client-side-navigates via the router. No new dependencies.

## Verification

- `pnpm run format` / `lint` / `type-check` — clean.
- `pnpm run build` — static export succeeds; the search trigger renders on built pages.
- `pnpm test` — **711 passed** (was 572). New tests:
  - `search-index.test.ts` — `searchDocs` ranking + AND semantics + a **dead-link guard** asserting every one of the 127 indexed hrefs resolves to a generated page.
  - `components/GlobalSearch.test.tsx` — open / filter / navigate / Escape / empty-state.
  - `Navigation.test.tsx` — gains a `next/navigation` mock (GlobalSearch's `useRouter`).
- `e2e/global-search.spec.ts` — opens via Ctrl+K, finds a page, navigates; button + Escape; no-match state (runs in CI; local Playwright browser version is mismatched in this environment).

Refs: roadmap program plan (`docs/program-plan.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PNahWrNd3XsoTQJ4Q9QsQ9

---
_Generated by [Claude Code](https://claude.ai/code/session_01PNahWrNd3XsoTQJ4Q9QsQ9)_