### PR TITLE
feat(ux): 404 recovery page with search + sitemap coverage for roadmap/intake-help

### DIFF
--- a/__tests__/sitemap-coverage.test.ts
+++ b/__tests__/sitemap-coverage.test.ts
@@ -1,0 +1,40 @@
+import fs from 'fs'
+import path from 'path'
+import sitemap from '@/app/sitemap'
+import { SEARCH_DOCS } from '@/data/search-index'
+
+function normalize(pathname: string): string {
+  const trimmed = pathname.replace(/\/+$/, '')
+  return trimmed === '' ? '/' : trimmed
+}
+
+describe('sitemap coverage', () => {
+  const sitemapPaths = new Set(sitemap().map((e) => normalize(new URL(e.url).pathname)))
+
+  it('has no duplicate URLs', () => {
+    expect(sitemapPaths.size).toBe(sitemap().length)
+  })
+
+  // If the page is worth surfacing in site search, it's worth surfacing to
+  // search engines. This catches new sections being added to the search index
+  // (or a data module) without sitemap entries — the roadmap + intake-help
+  // sections shipped with 16 pages missing from the sitemap this exact way.
+  SEARCH_DOCS.forEach((doc) => {
+    it(`search-indexed page ${doc.href} is in the sitemap`, () => {
+      expect(sitemapPaths.has(normalize(doc.href))).toBe(true)
+    })
+  })
+})
+
+describe('custom 404 page (requires build output)', () => {
+  const notFoundPath = path.join(process.cwd(), 'out', '404.html')
+  const built = fs.existsSync(notFoundPath)
+  const maybe = built ? it : it.skip
+
+  maybe('404.html is the branded recovery page with search', () => {
+    const html = fs.readFileSync(notFoundPath, 'utf-8')
+    expect(html).toContain('Page not found')
+    expect(html).toContain('Search the site')
+    expect(html).toContain('Popular destinations')
+  })
+})

--- a/e2e/not-found.spec.ts
+++ b/e2e/not-found.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Custom 404 page', () => {
+  test('unknown URL shows the recovery page with working search', async ({ page }) => {
+    await page.goto('/this-page-does-not-exist/')
+    await expect(page.getByRole('heading', { name: 'Page not found' })).toBeVisible()
+    await expect(page.getByRole('link', { name: /Public Roadmap/ })).toBeVisible()
+
+    // The search button on the 404 page opens the global search modal.
+    await page.getByRole('button', { name: 'Search the site' }).last().click()
+    await expect(page.getByRole('dialog', { name: 'Search the site' })).toBeVisible()
+  })
+})

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,103 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import OpenSearchButton from '@/components/OpenSearchButton'
+
+export const metadata: Metadata = {
+  title: 'Page Not Found',
+  description:
+    'The page you were looking for doesn’t exist or has moved. Search the site or jump to a popular destination.',
+}
+
+const POPULAR_DESTINATIONS = [
+  {
+    label: 'Public Roadmap',
+    href: '/roadmap',
+    description: 'Every charity FFC is helping, at every stage.',
+  },
+  {
+    label: 'Manage My Site',
+    href: '/site-owner',
+    description: 'Edit and maintain your FFC-built charity website.',
+  },
+  {
+    label: 'Get Involved',
+    href: '/get-involved',
+    description: 'Ways to volunteer with FFC and how to start.',
+  },
+  {
+    label: 'Guides',
+    href: '/guides',
+    description: 'Step-by-step how-tos and account setup walkthroughs.',
+  },
+  {
+    label: 'Intake Help',
+    href: '/intake-help',
+    description: 'Help for charities completing FFC intake.',
+  },
+  {
+    label: 'Documentation',
+    href: '/documentation',
+    description: 'Browse all project documentation and references.',
+  },
+]
+
+/**
+ * Custom 404 — a recovery point instead of a dead end. Ships as `out/404.html`
+ * in the static export, which GitHub Pages (and serve-handler in e2e) serves
+ * for any unknown URL. Offers global search plus the most common destinations.
+ */
+export default function NotFound() {
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="bg-ffc-gradient text-white">
+        <div className="mx-auto max-w-5xl px-4 py-16 sm:px-6 lg:px-8 text-center">
+          <p className="text-6xl font-bold" aria-hidden="true">
+            404
+          </p>
+          <h1 className="mt-3 text-3xl font-bold md:text-4xl">Page not found</h1>
+          <p className="mx-auto mt-3 max-w-2xl text-lg text-teal-50">
+            The page you were looking for doesn’t exist or has moved — some WordPress-era links were
+            retired when sites migrated to the new platform.
+          </p>
+          <div className="mt-6 flex flex-wrap items-center justify-center gap-3">
+            <OpenSearchButton>Search the site</OpenSearchButton>
+            <Link
+              href="/"
+              className="rounded-lg border border-white/70 px-5 py-2.5 font-semibold text-white hover:bg-white/10"
+            >
+              Go to the home page
+            </Link>
+          </div>
+        </div>
+      </div>
+
+      <main className="mx-auto max-w-5xl px-4 py-12 sm:px-6 lg:px-8">
+        <h2 className="text-xl font-bold text-gray-900">Popular destinations</h2>
+        <div className="mt-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {POPULAR_DESTINATIONS.map((d) => (
+            <Link
+              key={d.href}
+              href={d.href}
+              className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm transition-colors hover:border-teal-300 hover:bg-teal-50/40"
+            >
+              <p className="font-semibold text-gray-900">{d.label}</p>
+              <p className="mt-1 text-sm text-gray-600">{d.description}</p>
+            </Link>
+          ))}
+        </div>
+
+        <p className="mt-10 text-center text-sm text-gray-500">
+          Looking for an FFC-managed charity site? Check the{' '}
+          <Link href="/sites-list" className="text-blue-600 hover:underline">
+            sites list
+          </Link>
+          , or see the{' '}
+          <Link href="/legacy-wordpress-administration" className="text-blue-600 hover:underline">
+            legacy WordPress administration
+          </Link>{' '}
+          section for WordPress-era procedures.
+        </p>
+      </main>
+    </div>
+  )
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -5,6 +5,7 @@ import { LEGACY_WP_ADMIN_BASE, LEGACY_WP_ADMIN_PAGES } from '@/data/legacy-wordp
 import { VOLUNTEER_ROLES } from '@/data/volunteer-roles'
 import { CE_LANDING_BODIES } from '@/data/ce-bodies'
 import { SETUP_GUIDES } from '@/data/setup-guides'
+import { INTAKE_HELP_BASE, INTAKE_HELP_PAGES } from '@/data/intake-help'
 
 export const dynamic = 'force-static'
 
@@ -185,6 +186,32 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.5,
     })),
     { url: `${SITE_URL}/guides/`, lastModified: now, changeFrequency: 'monthly', priority: 0.8 },
+    // Public roadmap & intake program
+    { url: `${SITE_URL}/roadmap/`, lastModified: now, changeFrequency: 'daily', priority: 0.9 },
+    {
+      url: `${SITE_URL}/roadmap/submit/`,
+      lastModified: now,
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+    {
+      url: `${SITE_URL}/roadmap/sponsor/`,
+      lastModified: now,
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+    {
+      url: `${SITE_URL}/roadmap/methodology/`,
+      lastModified: now,
+      changeFrequency: 'monthly',
+      priority: 0.6,
+    },
+    {
+      url: `${SITE_URL}${INTAKE_HELP_BASE}/`,
+      lastModified: now,
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
     {
       url: `${SITE_URL}${LEGACY_WP_ADMIN_BASE}/`,
       lastModified: now,
@@ -270,6 +297,14 @@ export default function sitemap(): MetadataRoute.Sitemap {
     priority: 0.6,
   }))
 
+  // Intake-help leaf pages (charity intake guidance)
+  const intakeHelpPages: MetadataRoute.Sitemap = INTAKE_HELP_PAGES.map((p) => ({
+    url: `${SITE_URL}${INTAKE_HELP_BASE}/${p.slug}/`,
+    lastModified: now,
+    changeFrequency: 'monthly' as const,
+    priority: 0.6,
+  }))
+
   // Continuing-education per-body landing pages (#363)
   const ceLandingPages: MetadataRoute.Sitemap = CE_LANDING_BODIES.map((b) => ({
     url: `${SITE_URL}/continuing-education/${b.landing!.slug}/`,
@@ -285,6 +320,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     ...blogPages,
     ...legacyWpAdminPages,
     ...volunteerRolePages,
+    ...intakeHelpPages,
     ...ceLandingPages,
   ]
 }

--- a/src/components/OpenSearchButton.tsx
+++ b/src/components/OpenSearchButton.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import { openGlobalSearch } from './GlobalSearch'
+
+/**
+ * A styled trigger for the global search modal, usable from server components
+ * (e.g. the 404 page). The modal itself is rendered once inside Navigation.
+ */
+export default function OpenSearchButton({ children }: { children: React.ReactNode }) {
+  return (
+    <button
+      type="button"
+      onClick={openGlobalSearch}
+      className="inline-flex items-center gap-2 rounded-lg bg-gradient-to-r from-teal-600 to-cyan-600 px-5 py-2.5 font-semibold text-white shadow-sm hover:opacity-90 transition-opacity"
+    >
+      <svg
+        className="h-5 w-5"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+        />
+      </svg>
+      {children}
+    </button>
+  )
+}


### PR DESCRIPTION
## Summary

Two searchability/user-flow fixes that follow on from the global search (#540):

**1 — Sitemap coverage for the roadmap & intake-help program (SEO gap)**
The entire new program section — **16 pages** (`/roadmap`, `/roadmap/submit`, `/roadmap/sponsor`, `/roadmap/methodology`, `/intake-help` + 11 leaves) — was missing from `sitemap.ts`, i.e. invisible to search engines. Now added: the roadmap family (roadmap `daily`, the rest `monthly`) plus intake-help hub + leaves driven from `INTAKE_HELP_PAGES` (single source of truth). Sitemap grows 111 → **127 URLs**, matching the search index exactly.

**2 — Custom 404 recovery page**
A mistyped or retired URL was a dead end (default bare Next 404). The new `not-found.tsx` ships as `out/404.html` — which GitHub Pages serves for any unknown URL — and offers:
- a **"Search the site"** button that opens the global ⌘K search (new `OpenSearchButton` client component; the modal itself stays rendered once in Navigation),
- six popular destinations (Roadmap, Manage My Site, Get Involved, Guides, Intake Help, Documentation),
- pointers for WordPress-era URLs (sites list + legacy WP admin section).

## Drift guard

`__tests__/sitemap-coverage.test.ts` asserts **every search-indexed href is in the sitemap** — the exact drift that produced this 16-page gap (new section added to pages + search but not the sitemap) now fails CI. Also verifies `404.html` carries the recovery content, and `e2e/not-found.spec.ts` covers the unknown-URL → search flow in a real browser.

## Verification

- `pnpm run format` / `lint` / `type-check` — clean.
- `pnpm run build` — static export succeeds; built `sitemap.xml` verified at 127 URLs including the full roadmap/intake-help family; `404.html` verified branded.
- `pnpm test` — **840 passed** (was 711; the increase is the per-page sitemap-coverage assertions).

Refs: roadmap program plan (`docs/program-plan.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PNahWrNd3XsoTQJ4Q9QsQ9

---
_Generated by [Claude Code](https://claude.ai/code/session_01PNahWrNd3XsoTQJ4Q9QsQ9)_