### PR TITLE
feat(search): /search results page + Google SearchAction deep links

### DIFF
--- a/__tests__/components/SearchResults.test.tsx
+++ b/__tests__/components/SearchResults.test.tsx
@@ -1,0 +1,46 @@
+/**
+ * /search results page (client half) tests — deep-link query parsing,
+ * refinement, and empty states.
+ */
+import '@testing-library/jest-dom'
+import { render, screen, fireEvent } from '@testing-library/react'
+import SearchResults from '@/app/search/SearchResults'
+
+let mockQuery = ''
+jest.mock('next/navigation', () => ({
+  useSearchParams: () => new URLSearchParams(mockQuery),
+}))
+
+describe('SearchResults', () => {
+  beforeEach(() => {
+    mockQuery = ''
+  })
+
+  it('prompts for input with no query', () => {
+    render(<SearchResults />)
+    expect(screen.getByText(/Type above to search all/)).toBeInTheDocument()
+  })
+
+  it('renders deep-linked ?q= results with a count', () => {
+    mockQuery = 'q=methodology'
+    render(<SearchResults />)
+    expect(screen.getByRole('searchbox')).toHaveValue('methodology')
+    expect(screen.getByRole('status')).toHaveTextContent(/result/)
+    expect(screen.getByRole('link', { name: /Readiness methodology/ })).toHaveAttribute(
+      'href',
+      '/roadmap/methodology'
+    )
+  })
+
+  it('refines results as the visitor types', () => {
+    render(<SearchResults />)
+    fireEvent.change(screen.getByRole('searchbox'), { target: { value: 'intake help' } })
+    expect(screen.getByRole('link', { name: /Intake Help/ })).toBeInTheDocument()
+  })
+
+  it('shows the no-match state for gibberish', () => {
+    mockQuery = 'q=zzzznotapage'
+    render(<SearchResults />)
+    expect(screen.getByText(/No pages match/)).toBeInTheDocument()
+  })
+})

--- a/e2e/global-search.spec.ts
+++ b/e2e/global-search.spec.ts
@@ -32,4 +32,22 @@ test.describe('Global site search', () => {
     await dialog.getByRole('searchbox').fill('zzzznotapage')
     await expect(dialog.getByText(/No pages match/)).toBeVisible()
   })
+
+  test('modal links through to the full /search results page', async ({ page }) => {
+    await page.goto('/')
+    await page.keyboard.press('Control+k')
+    const dialog = page.getByRole('dialog', { name: 'Search the site' })
+    await dialog.getByRole('searchbox').fill('guide')
+    await dialog.getByRole('button', { name: /See all results/ }).click()
+    await expect(page).toHaveURL(/\/search\/?\?q=guide$/)
+    await expect(page.getByRole('heading', { name: 'Search the site' })).toBeVisible()
+  })
+})
+
+test.describe('Search results page', () => {
+  test('deep link /search?q= renders ranked results', async ({ page }) => {
+    await page.goto('/search/?q=methodology')
+    await expect(page.getByRole('searchbox')).toHaveValue('methodology')
+    await expect(page.getByRole('link', { name: /Readiness methodology/ })).toBeVisible()
+  })
 })

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -110,6 +110,27 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             }),
           }}
         />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify({
+              '@context': 'https://schema.org',
+              '@type': 'WebSite',
+              name: 'Free For Charity Admin',
+              url: 'https://ffcadmin.org',
+              // Lets Google offer a sitelinks search box that deep-links into
+              // the on-site /search results page (#543).
+              potentialAction: {
+                '@type': 'SearchAction',
+                target: {
+                  '@type': 'EntryPoint',
+                  urlTemplate: 'https://ffcadmin.org/search?q={search_term_string}',
+                },
+                'query-input': 'required name=search_term_string',
+              },
+            }),
+          }}
+        />
       </head>
       <body className="min-h-screen flex flex-col">
         <noscript>

--- a/src/app/search/SearchResults.tsx
+++ b/src/app/search/SearchResults.tsx
@@ -1,0 +1,94 @@
+'use client'
+
+import Link from 'next/link'
+import { useEffect, useMemo, useState } from 'react'
+import { useSearchParams } from 'next/navigation'
+import { SEARCH_DOCS, searchDocs } from '@/data/search-index'
+
+/**
+ * Client half of the /search page: reads `?q=` (deep-linkable, and the target
+ * of the Google SearchAction in layout.tsx), lets the visitor refine it, and
+ * renders the full uncapped result list from the shared search index.
+ */
+export default function SearchResults() {
+  const params = useSearchParams()
+  const initial = params.get('q') ?? ''
+  const [query, setQuery] = useState(initial)
+
+  // A back/forward navigation changes ?q= without remounting — follow it.
+  useEffect(() => {
+    setQuery(initial)
+  }, [initial])
+
+  const results = useMemo(() => searchDocs(query, SEARCH_DOCS.length), [query])
+
+  return (
+    <div>
+      <label htmlFor="site-search" className="sr-only">
+        Search the site
+      </label>
+      <div className="relative">
+        <svg
+          className="absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 text-gray-400"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+          />
+        </svg>
+        <input
+          id="site-search"
+          type="search"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search pages, guides, roles, docs…"
+          className="w-full rounded-lg border border-gray-300 py-3 pl-10 pr-4 outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-500"
+        />
+      </div>
+
+      {query && (
+        <p className="mt-3 text-sm text-gray-500" role="status">
+          {results.length} result{results.length === 1 ? '' : 's'} for “{query}”
+        </p>
+      )}
+
+      <ul className="mt-6 space-y-3">
+        {query && results.length === 0 && (
+          <li className="rounded-xl border border-gray-200 bg-white p-6 text-center text-gray-600">
+            No pages match “{query}”. Try a different term.
+          </li>
+        )}
+        {results.map((doc) => (
+          <li key={doc.href}>
+            <Link
+              href={doc.href}
+              className="block rounded-xl border border-gray-200 bg-white p-5 shadow-sm transition-colors hover:border-teal-300 hover:bg-teal-50/40"
+            >
+              <span className="flex items-center justify-between gap-2">
+                <span className="font-semibold text-gray-900">{doc.title}</span>
+                <span className="flex-shrink-0 rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-500">
+                  {doc.category}
+                </span>
+              </span>
+              <span className="mt-1 block text-sm text-gray-600">{doc.description}</span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+
+      {!query && (
+        <p className="mt-6 rounded-xl border border-gray-200 bg-white p-6 text-center text-gray-500">
+          Type above to search all {SEARCH_DOCS.length} pages — or press{' '}
+          <kbd className="rounded border border-gray-200 bg-gray-50 px-1.5 py-0.5 text-xs">⌘K</kbd>{' '}
+          anywhere on the site.
+        </p>
+      )}
+    </div>
+  )
+}

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,0 +1,43 @@
+import type { Metadata } from 'next'
+import { Suspense } from 'react'
+import Breadcrumbs from '@/components/Breadcrumbs'
+import SearchResults from './SearchResults'
+
+export const metadata: Metadata = {
+  title: 'Search',
+  description:
+    'Search every page on the Free For Charity admin portal — training, guides, the public roadmap, intake help, operations, and policies.',
+  alternates: { canonical: 'https://ffcadmin.org/search/' },
+  // A results page for an arbitrary query shouldn't compete with the real
+  // pages in search engines; the SearchAction in layout.tsx still lets Google
+  // offer a sitelinks search box.
+  robots: { index: false, follow: true },
+}
+
+/**
+ * Shareable search results (#543). The static shell prerenders empty; the
+ * client component reads `?q=` and ranks against the shared search index.
+ */
+export default function SearchPage() {
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Breadcrumbs items={[{ label: 'Home', href: '/' }, { label: 'Search' }]} />
+
+      <div className="bg-ffc-gradient text-white">
+        <div className="mx-auto max-w-5xl px-4 py-12 sm:px-6 lg:px-8">
+          <h1 className="text-3xl font-bold md:text-4xl">Search the site</h1>
+          <p className="mt-2 text-lg text-teal-50">
+            Every page — training, guides, the roadmap, intake help, operations, and policies.
+          </p>
+        </div>
+      </div>
+
+      <main className="mx-auto max-w-3xl px-4 py-10 sm:px-6 lg:px-8">
+        {/* useSearchParams requires a Suspense boundary in the static shell. */}
+        <Suspense fallback={null}>
+          <SearchResults />
+        </Suspense>
+      </main>
+    </div>
+  )
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -186,6 +186,8 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.5,
     })),
     { url: `${SITE_URL}/guides/`, lastModified: now, changeFrequency: 'monthly', priority: 0.8 },
+    // NOTE: /search is deliberately absent — it's noindexed (a results page
+    // for arbitrary queries), and noindexed URLs don't belong in a sitemap.
     // Public roadmap & intake program
     { url: `${SITE_URL}/roadmap/`, lastModified: now, changeFrequency: 'daily', priority: 0.9 },
     {

--- a/src/components/GlobalSearch.tsx
+++ b/src/components/GlobalSearch.tsx
@@ -169,6 +169,18 @@ export default function GlobalSearch() {
           </ul>
         )}
 
+        {query && results.length > 0 && (
+          <div className="border-t border-gray-100 px-4 py-2.5">
+            <button
+              type="button"
+              onClick={() => go(`/search?q=${encodeURIComponent(query)}`)}
+              className="text-sm font-medium text-blue-700 hover:text-blue-900"
+            >
+              See all results for “{query}” →
+            </button>
+          </div>
+        )}
+
         {!query && (
           <p className="px-4 py-6 text-center text-sm text-gray-400">
             Start typing to search every page on the site.


### PR DESCRIPTION
## Summary

Closes the two gaps the modal-only search (#540) left open: **results couldn't be linked to**, and **Google couldn't offer a sitelinks search box** for the domain.

- **`/search` page** — static shell whose client half reads `?q=` (deep-linkable, e.g. `/search?q=roadmap`), lets the visitor refine the query, and renders the full uncapped result list from the shared search index (same `searchDocs()` ranker — zero new dependencies). The page is `noindex` (an arbitrary-query results page) and deliberately absent from the sitemap to match.
- **Modal handoff** — the ⌘K modal now shows a "See all results for *X* →" footer that lands on `/search?q=X`.
- **`WebSite` + `SearchAction` JSON-LD** in `layout.tsx` targeting `/search?q={search_term_string}`, so Google can deep-link a sitelinks search box straight into on-site results.

## Verification

- `pnpm run format` / `lint` / `type-check` — clean.
- `pnpm run build` — static export succeeds; built `out/search/index.html` verified (renders, noindexed); SearchAction JSON-LD verified in built home page; modal footer link verified in the client bundle.
- `pnpm test` — **844 passed**. New: `SearchResults` component tests (deep-link parse, live refine, no-match, empty prompt).
- `e2e/global-search.spec.ts` — modal → `/search?q=` handoff and direct `?q=` deep link (runs in CI).

Fixes #543

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PNahWrNd3XsoTQJ4Q9QsQ9

---
_Generated by [Claude Code](https://claude.ai/code/session_01PNahWrNd3XsoTQJ4Q9QsQ9)_