### PR TITLE
docs: re-sequence charity journey to the gated model (WHMCS intake, website before domain)

### DIFF
--- a/.github/ISSUE_TEMPLATE/charity-intake.yml
+++ b/.github/ISSUE_TEMPLATE/charity-intake.yml
@@ -1,13 +1,16 @@
 name: Charity intake
-description: Structured intake for a charity seeking Free For Charity service. Captures the data that drives the public roadmap and readiness scoring.
+description: Website-provisioning intake for an approved Free For Charity charity. Captures the data that drives the public roadmap and readiness scoring.
 title: '[Intake] <charity name>'
 labels: ['kind:intake', 'status:needs-info']
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for applying to Free For Charity! This form captures the information that powers your
-        listing on the [public roadmap](https://ffcadmin.org/roadmap) and your readiness score.
+        Welcome! **New to FFC?** Applications are submitted and tracked at
+        [freeforcharity.org](https://freeforcharity.org/submit-information/) — start there. This
+        GitHub issue is the **website-provisioning work order** for charities whose application has
+        been approved. It captures the information that powers your listing on the
+        [public roadmap](https://ffcadmin.org/roadmap) and your readiness score.
 
         Fill in what you can — a half-complete form still scores, and your score rises as you add
         more. Not comfortable with GitHub? Text **520-222-8104** and an FFC admin will complete it

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: true
 contact_links:
-  - name: Apply via Zeffy (front door)
+  - name: Apply at freeforcharity.org (front door)
     url: https://ffcadmin.org/roadmap/submit
-    about: New charities start here — apply for FFC service and pick a service product.
+    about: New charities start here — applications are submitted and tracked in FFC's client portal; GitHub issues are website-provisioning work orders.
   - name: Security or sensitive report
     url: https://github.com/FreeForCharity/FFC-IN-ffcadmin.org/blob/main/SECURITY.md
     about: Never file security or sensitive details in a public issue. Use this private channel.

--- a/docs/application-prerequisites-inventory.md
+++ b/docs/application-prerequisites-inventory.md
@@ -92,18 +92,19 @@ of. This principle is what makes the flow in Section 2 logical and ordered.
 
 ## Where this lives in the codebase
 
-| Topic                                    | Source                                                                                          |
-| ---------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| End-to-end lifecycle + eligibility floor | `src/app/legacy-wordpress-administration/wordpress-service-delivery-stages/page.tsx`            |
-| External + internal validation checks    | `src/app/legacy-wordpress-administration/wordpress-charity-validation/page.tsx`                 |
-| Candid/GuideStar seal progression        | `src/app/legacy-wordpress-administration/wordpress-guidestar-guide/page.tsx`                    |
-| Onboarding prerequisites + accounts      | `src/app/legacy-wordpress-administration/wordpress-online-impacts-onboarding/page.tsx`          |
-| **Step-by-step account setup guides**    | **`src/data/setup-guides.ts`** (GitHub, MFA, LinkedIn, Facebook, M365, password manager, Canva) |
-| What the charity receives in return      | `src/app/what-ffc-delivers/page.tsx`                                                            |
-| Public application entry point           | <https://freeforcharity.org/submit-information/> (linked from What FFC Delivers)                |
-| 501(c)(3) onboarding entry point         | <https://freeforcharity.org/501c3/>                                                             |
-| Pre-501(c)(3) onboarding entry point     | <https://freeforcharity.org/pre501c3/>                                                          |
-| Recommended tools + setup order          | <https://freeforcharity.org/free-for-charitys-tools-for-success/>                               |
+| Topic                                            | Source                                                                                          |
+| ------------------------------------------------ | ----------------------------------------------------------------------------------------------- |
+| End-to-end lifecycle + eligibility floor         | `src/app/legacy-wordpress-administration/wordpress-service-delivery-stages/page.tsx`            |
+| External + internal validation checks            | `src/app/legacy-wordpress-administration/wordpress-charity-validation/page.tsx`                 |
+| Candid/GuideStar seal progression                | `src/app/legacy-wordpress-administration/wordpress-guidestar-guide/page.tsx`                    |
+| Onboarding prerequisites + accounts              | `src/app/legacy-wordpress-administration/wordpress-online-impacts-onboarding/page.tsx`          |
+| **Step-by-step account setup guides**            | **`src/data/setup-guides.ts`** (GitHub, MFA, LinkedIn, Facebook, M365, password manager, Canva) |
+| What the charity receives in return              | `src/app/what-ffc-delivers/page.tsx`                                                            |
+| Public application entry point                   | <https://freeforcharity.org/submit-information/> (linked from What FFC Delivers)                |
+| Application intake & tracking (system of record) | **WHMCS client portal** — <https://freeforcharity.org/hub>                                      |
+| 501(c)(3) onboarding entry point                 | <https://freeforcharity.org/501c3/>                                                             |
+| Pre-501(c)(3) onboarding entry point             | <https://freeforcharity.org/pre501c3/>                                                          |
+| Recommended tools + setup order                  | <https://freeforcharity.org/free-for-charitys-tools-for-success/>                               |
 
 ---
 
@@ -119,11 +120,17 @@ submission). The **Glossary** at the end defines the terms.
    passkeys, the applicant's personal accounts, and org basics; then create the
    organization **LinkedIn + Facebook Pages**. Ends with the **self-check** (2c).
    _Nothing else is provisioned until Phase 0 is complete._
-3. **Submit** (Section 3) — apply through **GitHub**.
+3. **Submit** (Section 3) — apply through **WHMCS** (the client portal at
+   <https://freeforcharity.org/hub> — FFC's core intake and application-tracking
+   tool).
 4. **Tracks diverge** (Section 4) — 501(c)(3) vs pre-501(c)(3) legal documentation.
 5. **FFC-side, after submission** — validation checks (Section 5), the
    GuideStar/Candid seal (Section 6), and FFC-supported org accounts (Section 7).
-6. **Service-delivery lifecycle** (Section 8) — legacy WordPress-era flow, kept
+6. **Gated service delivery** (Section 4a) — the four gates, in order: charity
+   application fully approved → website application approved → website built and
+   **validated on its GitHub Pages URL** → only then the **domain** (register or
+   transfer), with email after the domain.
+7. **Service-delivery lifecycle** (Section 8) — legacy WordPress-era flow, kept
    for reference.
 
 ---
@@ -137,7 +144,7 @@ these generally results in a polite decline rather than a fix-and-retry.
    charities are politely declined — US-only restriction.)
 2. **501(c)(3) status active** — or on the **pre-501(c)(3) track** for
    organizations not yet recognized (see Section 1a; this track has its own
-   landing page on freeforcharity.org that points into the GitHub-only
+   landing page on freeforcharity.org that points into the WHMCS
    application flow — see Section 3).
 3. **(501(c)(3) track only)** at minimum a Gold Candid (GuideStar) seal (see
    Section 6). This is **not** a universal gate — a pre-501(c)(3) organization
@@ -155,7 +162,7 @@ these generally results in a polite decline rather than a fix-and-retry.
 
 Organizations that are not yet IRS-recognized 501(c)(3)s can still apply through
 the **pre-501(c)(3) track** (its <https://freeforcharity.org/pre501c3/> landing page points into the
-GitHub-only application flow — Section 3). The track carries its own prerequisite
+WHMCS application flow — Section 3). The track carries its own prerequisite
 expectations:
 
 - The organization **Facebook Page and LinkedIn Page must still be created** (see
@@ -439,12 +446,13 @@ into the categories below.
   - _What:_ Your own GitHub account in your real name (e.g. `@FirstnameLastname`),
     MFA on. You add your charity email to it later — you do **not** create a
     separate "charity" login.
-  - _You:_ It is **how you apply** (FFC's application flow is GitHub-only — see
-    Section 3) and how you'll later review and approve changes to your website;
-    one personal account works across every charity and role you hold.
-  - _FFC:_ The application arrives through GitHub and we add your account to the
+  - _You:_ It is how your **website** gets built — once your WHMCS application is
+    approved, a GitHub **website-provisioning issue** drives the build (see
+    Sections 3 and 4a) — and how you'll later review and approve changes to your
+    website; one personal account works across every charity and role you hold.
+  - _FFC:_ The website work order lives in GitHub and we add your account to the
     charity's repository as a writer; a real, secured personal identity keeps the
-    application and contribution history accountable.
+    contribution history accountable.
   - _Guide:_ <https://ffcadmin.org/guides/github-account/>
 - **A personal LinkedIn profile — applicant and every board / planned-board
   member**
@@ -634,7 +642,9 @@ it is identical for both tracks.
 
 > The **organizational** GitHub (the charity's repo/org), **Microsoft 365** email,
 > the **domain**, and the **website** are provisioned by **FFC after acceptance** —
-> they are services, not applicant prerequisites.
+> they are services, not applicant prerequisites — and they arrive in the
+> **gated order** of Section 4a: **website first** (built and validated on its
+> free GitHub Pages URL), **then the domain**, then email.
 
 **End state:** the applicant has, unaided — a secured personal identity (devices,
 the three tools, and personal GitHub / LinkedIn / Facebook), and the
@@ -725,17 +735,29 @@ If you get stuck on any item, use **Contact us for help**.
 These are the steps the applicant actively performs. They double as the first
 technical-competence signals.
 
-> **Application channel — moving to GitHub-only** _(new FFC policy)_. FFC is
-> moving to a **GitHub-only application flow**: the applicant applies through
-> **GitHub** using the **personal GitHub account** created in Phase 0 (Group D).
-> The legacy **WHMCS portal product checkout** is **retired** as an application
-> mechanism, and the freeforcharity.org web forms (<https://freeforcharity.org/submit-information/>,
-> <https://freeforcharity.org/501c3/>, <https://freeforcharity.org/pre501c3/>) are informational landing pages that point into the
-> GitHub flow. This is exactly why a personal GitHub account is a Phase 0
-> requirement.
+> **Application channel — WHMCS is the front door** _(current FFC policy)_.
+> The applicant applies through the **WHMCS client portal**
+> (<https://freeforcharity.org/hub>) — FFC's **core intake and
+> application-tracking tool** and the **system of record** for the charity
+> journey. Each track has its own application product: **pre-501(c)(3)** and
+> **501(c)(3)**. The application captures **complete, validated data** — now
+> including the mandatory **organization Facebook Page** and **LinkedIn Page**
+> URLs, the **Terms of Service certification**, a **US-based attestation**, and
+> the **AI-usage questions** — and that validated data also auto-generates the
+> full FFC footer for the charity's site. **GitHub issues are not the
+> application**: a GitHub issue is a **website-provisioning work order**, created
+> only after the WHMCS application is approved and its data validated (see
+> Section 4a). The freeforcharity.org web forms
+> (<https://freeforcharity.org/submit-information/>,
+> <https://freeforcharity.org/501c3/>, <https://freeforcharity.org/pre501c3/>)
+> are informational landing pages that point into the WHMCS flow. The personal
+> GitHub account remains a Phase 0 requirement because it is how the applicant
+> participates in the website build later.
 
-1. **Apply through GitHub** with your personal GitHub account (Phase 0, Group D).
-2. **Acknowledge the FFC Terms of Service** (Section 18 — Supported Charities).
+1. **Apply through the WHMCS client portal** (<https://freeforcharity.org/hub>),
+   choosing your track's application product (pre-501(c)(3) or 501(c)(3)).
+2. **Acknowledge the FFC Terms of Service** (Section 18 — Supported Charities) —
+   a mandatory certification field on the application.
 3. _(501(c)(3) track)_ **Provide Candid/GuideStar profile links** (Public Profile
    and Full Profile).
 4. **Provide board contact information** — President/Chair, Secretary, Treasurer
@@ -744,8 +766,8 @@ technical-competence signals.
 5. **Designate primary + technical contacts**, including timezone and preferred
    contact hours.
 
-**Exit gate:** application submitted through GitHub, all fields completed, Terms of
-Service acknowledged.
+**Exit gate:** application submitted through WHMCS, all fields completed and
+validated, Terms of Service acknowledged.
 
 ### Prerequisite materials the charity must have in hand
 
@@ -758,8 +780,9 @@ of stuck onboardings.")
   [Terms of Service](https://ffcadmin.org/terms-of-service/) (Section 18 — Supported
   Charities), including the **full-stack commitment** (adopt and use the complete
   FFC stack, not pick-and-choose) and the **conflict-of-interest & data-handling**
-  terms. Acknowledgment is captured via the FFC application issue-template form (see
-  the plain-language [onboarding acknowledgment](./charity-onboarding-acknowledgment.md)).
+  terms. Acknowledgment is captured as a mandatory certification field on the
+  WHMCS application (see the plain-language
+  [onboarding acknowledgment](./charity-onboarding-acknowledgment.md)).
 - EIN (Employer Identification Number)
 - **Applicant's personal LinkedIn profile** (required for every applicant)
 - Board member names, titles, contact info, **personal LinkedIn profiles**, and
@@ -803,16 +826,62 @@ status and documentation**:
 |                | **501(c)(3) track**                                                   | **pre-501(c)(3) track**                                                                                          |
 | -------------- | --------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
 | Landing page   | <https://freeforcharity.org/501c3/>                                   | <https://freeforcharity.org/pre501c3/>                                                                           |
-| How you apply  | **GitHub-only flow** (see Section 3)                                  | **GitHub-only flow** (see Section 3)                                                                             |
+| How you apply  | **WHMCS client portal** (see Section 3)                               | **WHMCS client portal** (see Section 3)                                                                          |
 | Legal status   | Already IRS-recognized; has EIN + **IRS determination letter**        | Not yet recognized; working **IRS Form 1023** + state nonprofit formation + charitable-solicitation registration |
 | Board          | **Seated** legal board (officers)                                     | **Planned** board members                                                                                        |
 | Transparency   | **Candid/GuideStar to Gold** (Form 990, financials); see Sections 5–6 | No 990 yet; GuideStar deferred until recognized                                                                  |
 | Extra accounts | TechSoup, VolunteerMatch, PayPal emphasized                           | Deferred / as-available                                                                                          |
 
-After acceptance, FFC then provides the **services** (not prerequisites):
-organizational email on Microsoft 365 by default, domain + `info@` routing, and
-the website/template, plus — on the 501(c)(3) track — the validation work in
-Sections 5–6.
+After acceptance, FFC then provides the **services** (not prerequisites) — in
+the **gated order** described in Section 4a: the **website first** (built and
+validated on its free GitHub Pages URL), **then the domain** + `info@` routing,
+then organizational email on Microsoft 365 by default — plus, on the 501(c)(3)
+track, the validation work in Sections 5–6.
+
+---
+
+## 4a. The gated journey (service delivery, in order)
+
+FFC has re-sequenced the charity journey into **four gates**. **WHMCS**
+(<https://freeforcharity.org/hub>) is the **system of record** — every gate is
+an approved application/order there — while **GitHub issues are engineering
+work orders** for website provisioning only.
+
+1. **Gate 1 — Charity application fully approved.** The track application in
+   WHMCS (pre-501(c)(3) or 501(c)(3)) is approved with **complete, validated
+   data** — including the mandatory organization **Facebook Page** and
+   **LinkedIn Page**, the **Terms of Service certification**, the **US-based
+   attestation**, and the **AI-usage questions**. The validated data also
+   auto-generates the full FFC footer for the charity's site.
+2. **Gate 2 — Website application approved.** A separate **website product**
+   order in WHMCS, which requires Gate 1: the order form asks for the
+   approved organization's name and an attestation that the charity
+   application was approved.
+3. **Gate 3 — Website built, working, and validated on its GitHub Pages
+   default URL** (e.g. `https://freeforcharity.github.io/FFC-EX-yourcharity/`)
+   — **no custom domain yet**. This is the stage the **GitHub
+   website-provisioning issue** drives: the issue is created after Gate 2 and
+   the build runs entirely on the free default URL.
+4. **Gate 4 — Only now does FFC spend money on the domain.** The domain is
+   **registered or transferred in Cloudflare** (its own WHMCS order) and
+   pointed at the already-validated site. Those order forms require the live
+   GitHub Pages URL and an attestation that the website is validated.
+
+**Email comes after the domain** — organizational email (Microsoft 365 / Google
+nonprofit grants) is provisioned once the domain exists, and remains gated on
+501(c)(3) status per existing policy (unchanged).
+
+**Why this order:**
+
+- **No sunk domain cost on charities that stall.** A domain registration
+  (~$16.50/yr) is the first real money FFC spends; it now happens only after a
+  working, validated website proves the engagement is real.
+- **The sequence is itself a competence filter** — the same "filter out"
+  philosophy as the Phase 0 ladder, extended through delivery: each gate
+  demonstrates the charity can complete the previous stage.
+- **Clean separation of systems:** WHMCS holds the applications, approvals, and
+  orders (system of record); GitHub holds the engineering work orders that
+  build the website.
 
 ---
 
@@ -836,16 +905,16 @@ uniformly (see Section 4).
 
 ### 5a. External validation checks (third-party signals)
 
-| #   | Check                                                                                                                                           | Demonstrates                                                          |
-| --- | ----------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
-| 1   | **501(c)(3) status via Candid / GuideStar** (record NTEE code)                                                                                  | Legitimacy; mission-alignment scoring                                 |
-| 2   | **TechSoup legal-entity confirmation** ("Validated", not "Pending")                                                                             | Independent vetting; unlocks discounted-software pipeline             |
-| 3   | **VolunteerMatch engagement check**                                                                                                             | Charity can receive and act on volunteer work                         |
-| 4   | **Verified organization Facebook Page** (cross-checked vs. intake form)                                                                         | Identity/branding consistency; applicant-run litmus test              |
-| 5   | **Email on a reputable provider** (Microsoft 365 preferred; not Gmail/Yahoo)                                                                    | Technical readiness; enables SPF/DKIM/DMARC under charity domain      |
-| 6   | **PayPal Nonprofits account + donor flow** _(the legacy WHMCS checkout that once paired with this is **retired** under the GitHub-only intake)_ | KYC step; donor funding path                                          |
-| 7   | **Verified organization LinkedIn Page** (cross-checked vs. intake form)                                                                         | Professional identity; applicant-run litmus test                      |
-| 8   | **Personal LinkedIn profiles** — applicant **and every legal/planned board member**, each with the charity linked under "Volunteering"          | Real people stand behind the org; accepted board position & liability |
+| #   | Check                                                                                                                                                                                    | Demonstrates                                                          |
+| --- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| 1   | **501(c)(3) status via Candid / GuideStar** (record NTEE code)                                                                                                                           | Legitimacy; mission-alignment scoring                                 |
+| 2   | **TechSoup legal-entity confirmation** ("Validated", not "Pending")                                                                                                                      | Independent vetting; unlocks discounted-software pipeline             |
+| 3   | **VolunteerMatch engagement check**                                                                                                                                                      | Charity can receive and act on volunteer work                         |
+| 4   | **Verified organization Facebook Page** (cross-checked vs. intake form)                                                                                                                  | Identity/branding consistency; applicant-run litmus test              |
+| 5   | **Email on a reputable provider** (Microsoft 365 preferred; not Gmail/Yahoo)                                                                                                             | Technical readiness; enables SPF/DKIM/DMARC under charity domain      |
+| 6   | **PayPal Nonprofits account + donor flow** _(the legacy WHMCS product checkout that once paired with this is **retired**; today's WHMCS application products — Section 3 — replaced it)_ | KYC step; donor funding path                                          |
+| 7   | **Verified organization LinkedIn Page** (cross-checked vs. intake form)                                                                                                                  | Professional identity; applicant-run litmus test                      |
+| 8   | **Personal LinkedIn profiles** — applicant **and every legal/planned board member**, each with the charity linked under "Volunteering"                                                   | Real people stand behind the org; accepted board position & liability |
 
 > **Promoted from Phase 0 (founder decision):** the organization **Facebook Page**
 > (4), organization **LinkedIn Page** (7), and the **personal LinkedIn profiles**
@@ -919,11 +988,15 @@ flow), on both tracks. These (plus the personal LinkedIn profiles) are also
 ## 8. Service-delivery lifecycle (legacy — for reference)
 
 Once validation passes and the charity accepts the written offer (historically a
-signed WHMCS quote — **legacy/pending replacement** under the GitHub-only intake),
-the prerequisite/application phase is complete and the engagement moves into
+signed WHMCS quote — **legacy**; today the WHMCS application/website/domain
+orders and the gated flow in Section 4a fill this role), the
+prerequisite/application phase is complete and the engagement moves into
 provisioning. The full lifecycle below is the **legacy WordPress/Divi-era**
 eight-stage flow (stages 6–8 in particular reflect the old stack); it is retained
-**for reference** and is being superseded by the current FFC template direction:
+**for reference** and is superseded by the current FFC template direction and
+the **gated journey in Section 4a** (note the legacy order — domain in stage 4,
+website in stage 5 — is **reversed** in the current model: website first, then
+domain):
 
 1. Initial Contact & Onboarding
 2. **FFC Validation Checks** ← prerequisite gate (Sections 5–6)
@@ -975,8 +1048,13 @@ non-technical).
   Charities) carries the charity-specific terms a charity acknowledges to apply.
 - **Cloudflare** — the service FFC uses to register/secure charity domains; also
   offers the domain name-availability check used in Phase 0.
-- **WHMCS** — the legacy client/billing portal once used for intake; **retired**
-  as the application mechanism under the GitHub-only flow.
+- **WHMCS** — FFC's client portal (<https://freeforcharity.org/hub>) and the
+  **core intake and application-tracking tool** — the **system of record** for
+  the charity journey. The track applications, the website product, and the
+  domain register/transfer products are all ordered and tracked here; GitHub
+  issues are downstream **website-provisioning work orders** only (Section 4a).
+  (The legacy WordPress-era product **checkout** intake was retired; the current
+  application products replaced it.)
 - **TechSoup** — nonprofit tech-discount and validation service.
 - **VolunteerMatch / Idealist / Taproot** — platforms for finding volunteers and
   (Taproot) skills-based/pro-bono help.
@@ -1009,13 +1087,16 @@ All policy questions for this document are **resolved** (founder-approved,
 
 **Maintenance / follow-up tasks** (engineering, not policy):
 
-- **Wire the acknowledgment into the application form.** The Terms of Service is
-  live at `/terms-of-service/`; extend the FFC application issue-template form to
-  capture the Terms of Service / full-stack-commitment acknowledgment.
-- **GitHub-only application channel.** Build the GitHub entry point (repo + issue
-  template/form) that the freeforcharity.org pages
-  (<https://freeforcharity.org/submit-information/>,
+- **Acknowledgment lives in the application.** The Terms of Service is live at
+  `/terms-of-service/`; the Terms of Service / full-stack-commitment
+  acknowledgment is captured as a mandatory certification field on the WHMCS
+  application (Section 3).
+- **WHMCS application channel + GitHub work orders.** The freeforcharity.org
+  pages (<https://freeforcharity.org/submit-information/>,
   <https://freeforcharity.org/501c3/>, <https://freeforcharity.org/pre501c3/>)
-  point into; the legacy WHMCS checkout is retired.
+  point into the **WHMCS client portal** (<https://freeforcharity.org/hub>);
+  GitHub issues are created **after approval** as website-provisioning work
+  orders (Section 4a). The GitHub intake issue template remains in service for
+  that downstream purpose.
 - **Keep in sync.** Update this document and `src/data/setup-guides.ts` together
   whenever the program changes.

--- a/docs/program-plan.md
+++ b/docs/program-plan.md
@@ -5,6 +5,17 @@
 **Owner:** Clarke Moyer
 **Supersedes:** v1 (2026-05-09)
 
+> **Superseded intake model (2026-07).** This plan predates the current **gated
+> charity journey**: **WHMCS** (the client portal at freeforcharity.org/hub) is
+> now the **core intake and application-tracking tool** and system of record —
+> and **GitHub issues are website-provisioning work orders** created only after
+> a WHMCS application is approved and its data validated. The domain is
+> purchased only after the website is built and validated on its GitHub Pages
+> URL. See
+> [application-prerequisites-inventory.md](./application-prerequisites-inventory.md)
+> (Sections 3 and 4a) for the authoritative flow; the rest of this plan is
+> retained as drafted.
+
 **Repos affected:**
 
 - `FreeForCharity/FFC-IN-ffcadmin.org` (operational/admin hub — primary build target)

--- a/src/app/charity-prerequisites/page.tsx
+++ b/src/app/charity-prerequisites/page.tsx
@@ -224,8 +224,9 @@ export default function CharityPrerequisitesPage() {
             <h2 className="text-2xl font-bold text-gray-900 mb-2">4. Apply</h2>
             <p className="text-gray-700 text-sm mb-5 max-w-3xl">
               Most charities find and apply to Free For Charity on the main{' '}
-              <strong>freeforcharity.org</strong> website. Start there — the team will guide you
-              into the rest of onboarding. By applying, you agree to the{' '}
+              <strong>freeforcharity.org</strong> website. Start there — your application is
+              submitted and tracked in FFC&apos;s client portal, the system of record for your whole
+              journey. By applying, you agree to the{' '}
               <Link
                 href="/terms-of-service#section-18"
                 className="text-blue-700 underline hover:text-blue-900"
@@ -234,6 +235,33 @@ export default function CharityPrerequisitesPage() {
               </Link>{' '}
               (Section 18 covers supported charities, including the full-stack commitment).
             </p>
+            <div className="rounded-lg bg-gray-50 border border-gray-200 p-4 mb-5 max-w-3xl">
+              <h3 className="text-sm font-bold text-gray-900 mb-2">
+                What happens after you apply — the gated journey, in order
+              </h3>
+              <ol className="list-decimal list-inside space-y-1 text-sm text-gray-700">
+                <li>
+                  <strong>Your application is fully approved</strong> — with complete, validated
+                  data (including your organization&apos;s Facebook and LinkedIn Pages).
+                </li>
+                <li>
+                  <strong>Your website application is approved</strong> — a separate step that
+                  requires the approved application first.
+                </li>
+                <li>
+                  <strong>Your website is built and validated</strong> on its free GitHub Pages URL
+                  — no custom domain yet.
+                </li>
+                <li>
+                  <strong>Only then is your domain registered</strong> (or transferred) and pointed
+                  at the validated site — followed by professional email.
+                </li>
+              </ol>
+              <p className="text-xs text-gray-500 mt-2">
+                Each gate builds on the last — proving the site works before any money is spent on a
+                domain protects both your time and FFC&apos;s donor funds.
+              </p>
+            </div>
             <div className="flex flex-wrap gap-3">
               <a
                 href="https://freeforcharity.org/501c3/"

--- a/src/app/roadmap/submit/page.tsx
+++ b/src/app/roadmap/submit/page.tsx
@@ -35,7 +35,7 @@ const cards: PathCard[] = [
   },
   {
     title: 'I’m an existing FFC charity',
-    body: 'Already partnered with FFC and ready for the next service tier? Open a structured intake issue so we can score readiness and route it to a sponsoring admin.',
+    body: 'Application approved and ready for your website build or the next service tier? GitHub issues are FFC’s website-provisioning work orders — open one so we can score readiness and route it to a sponsoring admin.',
     href: INTAKE_ISSUE_URL,
     cta: 'Open an intake issue',
     external: true,
@@ -99,7 +99,7 @@ export default function SubmitPage() {
             </li>
             <li>
               <strong>Your charity appears on the roadmap</strong> as soon as you apply — even
-              before you complete the GitHub-side intake.
+              before your website-provisioning issue is opened on GitHub.
             </li>
             <li>
               <strong>Readiness is scored transparently.</strong> You’ll receive a breakdown with

--- a/src/app/what-ffc-delivers/page.tsx
+++ b/src/app/what-ffc-delivers/page.tsx
@@ -17,15 +17,15 @@ export const metadata: Metadata = {
 const included = [
   {
     title: 'A professional website',
-    body: 'A fast, secure, accessible static site built from the FFC template and hosted free, with AI-assisted editing so you can keep it current yourself.',
+    body: 'A fast, secure, accessible static site built from the FFC template and hosted free — built and validated first on its free GitHub Pages URL, with AI-assisted editing so you can keep it current yourself.',
   },
   {
     title: 'A domain',
-    body: 'A free .org registration (or transfer-in) and DNS managed through Cloudflare, kept renewed while you partner with FFC.',
+    body: 'A free .org registration (or transfer-in) and DNS managed through Cloudflare, kept renewed while you partner with FFC. Registered once your site is validated on its GitHub Pages URL — the website always comes first.',
   },
   {
     title: 'Email & Microsoft 365 / Google Workspace',
-    body: 'Charity email and a productivity suite for eligible 501(c)(3) organizations, with MFA and security baked in.',
+    body: 'Charity email and a productivity suite for eligible 501(c)(3) organizations, with MFA and security baked in — provisioned after your domain is live.',
   },
   {
     title: 'Analytics & basic SEO',


### PR DESCRIPTION
## Summary

Re-sequences the documented charity journey to FFC's new **gated model** (epic FreeForCharity/FFC-Cloudflare-Automation#669):

- **WHMCS** (freeforcharity.org/hub) is documented as the **core intake and application-tracking tool** and system of record — replacing the "GitHub-only application flow" wording. GitHub issues are now described as **website-provisioning work orders**, created only after a WHMCS application is approved and its data validated (validated data also auto-generates the FFC footer).
- Documents the **four gates, in order**: (1) charity application fully approved with complete validated data (incl. mandatory org Facebook/LinkedIn Pages, ToS certification, US-based attestation, AI-usage questions) → (2) website application approved → (3) website built and **validated on its GitHub Pages default URL** (no custom domain) → (4) **only then** the domain is registered/transferred in Cloudflare and pointed at the validated site. Email follows the domain, gated on 501(c)(3) status per existing policy (unchanged).
- **Founder-approved eligibility rules untouched** (US-only, <$1M revenue, board requirements, Candid Gold, Phase 0 ladder). Copy/docs only — no code or scoring changes; the charity-intake issue template is retained (reworded as the post-approval work order, not the application).

### Files changed

| File | Change |
| --- | --- |
| `docs/application-prerequisites-inventory.md` | New **Section 4a — The gated journey**; Section 3 rewritten from "GitHub-only" to WHMCS-as-front-door; "At a glance", Section 4 table/tail, Section 8 legacy note, glossary WHMCS entry, and maintenance notes aligned |
| `docs/program-plan.md` | Status note flagging the plan's Zeffy/GitHub intake model as superseded by the gated WHMCS model |
| `src/app/charity-prerequisites/page.tsx` | "What happens after you apply" gated-journey list added to the Apply section |
| `src/app/what-ffc-delivers/page.tsx` | Website/domain/email inclusion blurbs now state the gated order (site validated on GitHub Pages before domain; email after domain) |
| `src/app/roadmap/submit/page.tsx` | Existing-charity card and roadmap bullet reworded: GitHub issues = website-provisioning work orders |
| `.github/ISSUE_TEMPLATE/charity-intake.yml` | Intro reworded: applications start at freeforcharity.org; this issue is the post-approval website work order |
| `.github/ISSUE_TEMPLATE/config.yml` | Front-door contact link reworded from "Apply via Zeffy" to freeforcharity.org front door |

## Test plan

- [x] `pnpm run format` (prettier) — clean
- [x] `pnpm run lint` — no errors (1 pre-existing warning in `scripts/lib/intake-issues.mjs`)
- [x] `pnpm run type-check` — clean
- [x] `pnpm run build` — static export succeeds
- [x] `pnpm test` — 845/846 pass; the 1 failure (`commitlint-config.test.js` husky-hook executable bit) is a Windows-worktree checkout artifact — the file is `100755` in the git index, so Linux CI passes
- [x] `pnpm run test:e2e` — 28/28 pass

Refs FreeForCharity/FFC-Cloudflare-Automation#674

🤖 Generated with [Claude Code](https://claude.com/claude-code)
