### PR TITLE
feat: add WHMCS-to-footer config bridge for Gate 3 provisioning

### DIFF
--- a/__tests__/generate-footer-config.test.js
+++ b/__tests__/generate-footer-config.test.js
@@ -1,0 +1,148 @@
+/**
+ * Unit tests for the footer-config bridge (scripts/generate-footer-config.mjs).
+ *
+ * The transform is pure — a validated WHMCS application record in, the
+ * FFC-standard footer config out — so these tests lock in the happy-path
+ * mapping (org name, EIN, GuideStar link, social URLs, policy stack,
+ * copyright) and the loud failure when required fields are missing (missing
+ * data = application not validated for footer generation).
+ */
+
+let buildFooterConfig, validateApplication, selectRecord
+let REQUIRED_FIELDS, POLICY_LINKS, SAMPLE_APPLICATION
+
+beforeAll(async () => {
+  const mod = await import('../scripts/generate-footer-config.mjs')
+  buildFooterConfig = mod.buildFooterConfig
+  validateApplication = mod.validateApplication
+  selectRecord = mod.selectRecord
+  REQUIRED_FIELDS = mod.REQUIRED_FIELDS
+  POLICY_LINKS = mod.POLICY_LINKS
+  SAMPLE_APPLICATION = mod.SAMPLE_APPLICATION
+})
+
+describe('buildFooterConfig — happy path', () => {
+  it('maps a validated application onto the FFC footer shape', () => {
+    const now = new Date('2026-07-11T12:00:00.000Z')
+    const config = buildFooterConfig(SAMPLE_APPLICATION, { now })
+
+    expect(config.source).toMatchObject({
+      applicationId: 'ffc-90',
+      system: 'WHMCS',
+      generatedBy: 'scripts/generate-footer-config.mjs',
+    })
+    expect(config.organization).toEqual({
+      legalName: 'Helping Hands Shelter',
+      ein: '12-3456789',
+      charityStage: '501c3',
+      missionStatement: 'We provide shelter, food, and job placement to families in crisis.',
+    })
+    expect(config.endorsements).toEqual({
+      guidestarProfileUrl: 'https://www.guidestar.org/profile/12-3456789',
+      einLine: 'Helping Hands Shelter EIN: 12-3456789',
+    })
+    expect(config.socialLinks).toEqual([
+      {
+        platform: 'facebook',
+        label: 'Facebook',
+        url: 'https://www.facebook.com/helpinghandsshelter',
+      },
+      {
+        platform: 'linkedin',
+        label: 'LinkedIn',
+        url: 'https://www.linkedin.com/company/helping-hands-shelter/',
+      },
+    ])
+    expect(config.policyLinks).toEqual(POLICY_LINKS)
+    expect(config.copyright).toEqual({
+      holder: 'Helping Hands Shelter',
+      year: 2026,
+      line: '© 2026 All Rights Are Reserved by Helping Hands Shelter a US 501c3 Non Profit',
+      projectOf: { name: 'Free For Charity', url: 'https://freeforcharity.org' },
+    })
+    // Contact details are PII the sync never surfaces — emitted as explicit
+    // volunteer-fill placeholders, not silently omitted.
+    expect(config.contact).toEqual({ email: null, phone: null, addressLines: [] })
+  })
+
+  it('covers the FFC-standard policy stack routes', () => {
+    expect(POLICY_LINKS.map((l) => l.href)).toEqual([
+      '/free-for-charity-donation-policy',
+      '/privacy-policy',
+      '/cookie-policy',
+      '/terms-of-service',
+      '/vulnerability-disclosure-policy',
+      '/security-acknowledgements',
+    ])
+  })
+
+  it('omits social links the record does not carry and rejects off-host URLs', () => {
+    const record = {
+      ...SAMPLE_APPLICATION,
+      facebookUrl: undefined,
+      linkedinUrl: 'https://evil.example.com/spoof', // not linkedin.com -> dropped
+    }
+    const config = buildFooterConfig(record)
+    expect(config.socialLinks).toEqual([])
+  })
+
+  it('omits missionStatement when the sync record has no mission excerpt', () => {
+    const record = { ...SAMPLE_APPLICATION }
+    delete record.missionExcerpt
+    const config = buildFooterConfig(record)
+    expect(config.organization).not.toHaveProperty('missionStatement')
+  })
+})
+
+describe('buildFooterConfig — missing data fails loudly', () => {
+  it('throws listing EVERY missing required field (missing = not validated)', () => {
+    const record = { id: 'ffc-91', charityStage: '501c3' }
+    expect(() => buildFooterConfig(record)).toThrow(/not validated/)
+    try {
+      buildFooterConfig(record)
+    } catch (err) {
+      // All three gaps reported at once, so a volunteer sees the full picture.
+      expect(err.message).toMatch(/missing "charityName"/)
+      expect(err.message).toMatch(/missing "ein"/)
+      expect(err.message).toMatch(/missing "candidUrl"/)
+    }
+  })
+
+  it('rejects a pre-501c3 application (footer asserts US 501c3 status)', () => {
+    const record = { ...SAMPLE_APPLICATION, charityStage: 'pre-501c3' }
+    expect(() => buildFooterConfig(record)).toThrow(/pre-501c3/)
+  })
+
+  it('rejects a malformed EIN', () => {
+    const problems = validateApplication({ ...SAMPLE_APPLICATION, ein: '123456789' })
+    expect(problems.some((p) => /invalid "ein"/.test(p))).toBe(true)
+  })
+
+  it('rejects non-record input', () => {
+    expect(validateApplication(null)).toEqual(['input is not an application record object'])
+    expect(validateApplication([])).toEqual(['input is not an application record object'])
+  })
+
+  it('validateApplication returns [] for the documented sample', () => {
+    expect(validateApplication(SAMPLE_APPLICATION)).toEqual([])
+    // The sample stays honest: it satisfies exactly the documented bar.
+    for (const [field] of REQUIRED_FIELDS) {
+      expect(String(SAMPLE_APPLICATION[field] ?? '').trim()).not.toBe('')
+    }
+  })
+})
+
+describe('selectRecord — array input (sync dry-run output)', () => {
+  it('picks by --id from an array and passes single records through', () => {
+    const a = { id: 'ffc-1' }
+    const b = { id: 'ffc-2' }
+    expect(selectRecord([a, b], 'ffc-2')).toBe(b)
+    expect(selectRecord([a], '')).toBe(a)
+    expect(selectRecord(a, '')).toBe(a)
+  })
+
+  it('fails loudly on a multi-record array without --id or an unknown id', () => {
+    expect(() => selectRecord([{ id: 'a' }, { id: 'b' }], '')).toThrow(/--id/)
+    expect(() => selectRecord([{ id: 'a' }], 'ffc-99')).toThrow(/no application with id/)
+  })
+})

--- a/docs/footer-bridge.md
+++ b/docs/footer-bridge.md
@@ -1,0 +1,62 @@
+# Footer-Config Bridge (WHMCS → FFC-EX footer)
+
+Gate 3 of the gated charity journey requires each charity site's FFC-standard footer to be
+generated from **validated** WHMCS application data — not hand-typed. The bridge is
+`scripts/generate-footer-config.mjs`: a pure transform (no network calls) that turns one
+application record from the existing WHMCS sync (`scripts/whmcs-applications.mjs`) into the footer
+config file the charity's FFC-EX repo consumes. The canonical consumer is the footer component in
+[FFC-IN-Footer-Only-Template](https://github.com/FreeForCharity/FFC-IN-Footer-Only-Template); both
+site templates render the same block (endorsements/EIN, quick links + policy stack, contact,
+social icons, copyright).
+
+## What it does
+
+- **Input**: one PII-safe application record as published by the sync's
+  `buildApplicationRecords` — JSON on stdin, `--input <file>`, or `--sample` (a documented demo
+  record). An array (e.g. `WHMCS_DRY_RUN` output) works with `--id ffc-<clientId>`.
+- **Validation**: `charityName`, `ein` (NN-NNNNNNN), and `candidUrl` (Candid/GuideStar profile)
+  are required, and `charityStage` must be `501c3` (the footer's copyright line asserts US
+  501(c)(3) status). Anything missing means the application is **not validated** for footer
+  generation: the script exits non-zero and lists every gap. It never emits a partial footer.
+- **Output**: the footer config JSON on stdout, or `--output <file>` — provenance (`source`),
+  `organization` (legal name, EIN, stage, mission), `endorsements` (GuideStar profile URL + EIN
+  line), `contact` (volunteer-fill placeholders; see below), `socialLinks` (charity Facebook and
+  LinkedIn **page** URLs, host-checked), the six-link FFC policy stack, and the `copyright` line.
+
+Contact details (email, phone, address) are PII the WHMCS sync deliberately never surfaces, so
+they are emitted as explicit `null`/empty placeholders for the provisioning volunteer to fill from
+the charity's public website. The charity Facebook/LinkedIn page URLs collected by the hardened
+onboarding forms are accepted (`facebookUrl`, `linkedinUrl`) but not yet published by the sync's
+PII-safe allowlist — until the sync surfaces them, those links also need volunteer fill-in.
+
+## How a volunteer uses it (website-provisioning work order)
+
+1. Open the charity's `kind:intake` work-order issue; note the application id (`ffc-<clientId>`).
+2. Get the application record: run the **WHMCS Intake** workflow with dry-run enabled and copy the
+   record from the log, or save the JSON array to a file.
+3. Generate the config (from the FFC-IN-ffcadmin.org repo root):
+
+   ```bash
+   node scripts/generate-footer-config.mjs --input applications.json --id ffc-90 \
+     --output footer.config.json
+   ```
+
+   Try it without WHMCS data: `node scripts/generate-footer-config.mjs --sample`
+
+4. If it fails, the listed gaps are onboarding gaps — send the application back for completion in
+   WHMCS rather than guessing values.
+5. Fill the `contact` placeholders (and any missing social links) from the charity's public
+   website, then commit the file into the charity's FFC-EX repo where the footer component reads
+   it.
+
+## Future work
+
+- **Auto-PR the generated file** into the charity's FFC-EX repo from the work-order workflow, so
+  Gate 3's footer requirement is fully mechanical (generate → validate → PR → review → merge).
+- **Surface the charity page URLs** (`facebookUrl`, `linkedinUrl`) and public contact fields from
+  the hardened onboarding forms through the sync's allowlist so the volunteer fill-in step
+  disappears.
+- **Template consumption**: switch the Footer-Only-Template's footer component from hardcoded FFC
+  values to reading this config file, so one shape drives every charity site.
+
+Refs: FreeForCharity/FFC-Cloudflare-Automation#682 (part of epic #676).

--- a/scripts/generate-footer-config.mjs
+++ b/scripts/generate-footer-config.mjs
@@ -1,0 +1,244 @@
+#!/usr/bin/env node
+/**
+ * Footer-config bridge (Gate 3 of the gated charity journey): turn ONE
+ * validated WHMCS application record — the PII-safe shape produced by
+ * scripts/whmcs-applications.mjs (`buildApplicationRecords`) — into the
+ * FFC-standard footer config file a charity's FFC-EX site consumes (the
+ * canonical consumer is FFC-IN-Footer-Only-Template's footer component; both
+ * site templates render the same block: endorsements/EIN, policy links,
+ * contact, social icons, copyright).
+ *
+ * Pure transform, no network calls: the WHMCS sync already fetched the data.
+ * Missing required fields mean the application is NOT validated for footer
+ * generation, so the script fails loudly and lists every gap instead of
+ * emitting a half-empty footer.
+ *
+ * Usage:
+ *   node scripts/generate-footer-config.mjs --input application.json
+ *   cat application.json | node scripts/generate-footer-config.mjs
+ *   node scripts/generate-footer-config.mjs --sample            # demo record
+ *   node scripts/generate-footer-config.mjs --input apps.json --id ffc-90
+ *   ... --output footer.config.json                             # else stdout
+ *
+ * Input is a single application record, or an array of them (e.g. the
+ * WHMCS_DRY_RUN output) plus --id to pick one.
+ */
+import fs from 'fs'
+import { pathToFileURL } from 'url'
+
+/**
+ * Fields the footer cannot be generated without. Presence here is the
+ * "validated" bar: an approved 501(c)(3) application always carries them.
+ * Exported for unit testing.
+ */
+export const REQUIRED_FIELDS = [
+  ['charityName', 'public organization legal name'],
+  ['ein', 'EIN (NN-NNNNNNN; public for registered charities)'],
+  ['candidUrl', 'Candid/GuideStar profile URL (transparency endorsement)'],
+]
+
+/**
+ * Optional record fields the footer uses when present. `facebookUrl` and
+ * `linkedinUrl` come from the hardened onboarding forms (charity PAGE URLs,
+ * not board-member profiles) but are not yet surfaced by the WHMCS sync's
+ * PII-safe allowlist — the bridge accepts them so no shape change is needed
+ * when the sync starts emitting them. Exported for unit testing.
+ */
+export const OPTIONAL_FIELDS = ['missionExcerpt', 'facebookUrl', 'linkedinUrl', 'submittedAt']
+
+/** The FFC-standard policy stack every charity site footer links to. */
+export const POLICY_LINKS = [
+  { name: 'Donation Policy', href: '/free-for-charity-donation-policy' },
+  { name: 'Privacy Policy', href: '/privacy-policy' },
+  { name: 'Cookie Policy', href: '/cookie-policy' },
+  { name: 'Terms of Service', href: '/terms-of-service' },
+  { name: 'Vulnerability Disclosure Policy', href: '/vulnerability-disclosure-policy' },
+  { name: 'Security Acknowledgement', href: '/security-acknowledgements' },
+]
+
+/**
+ * Documented sample record for testing/demo (--sample). Mirrors the exact
+ * shape `buildApplicationRecords` publishes for an approved 501(c)(3)
+ * application, plus the two social page URLs the hardened onboarding forms
+ * collect. Exported for unit testing.
+ */
+export const SAMPLE_APPLICATION = {
+  id: 'ffc-90',
+  charityName: 'Helping Hands Shelter',
+  charityStage: '501c3',
+  charityStatusOption: 'Approved 501(c)(3)',
+  serviceTier: 'Tier 1 — Application & verification (501(c)(3))',
+  missionCategoryOption: 'Basic needs (food, water, shelter)',
+  missionExcerpt: 'We provide shelter, food, and job placement to families in crisis.',
+  candidUrl: 'https://www.guidestar.org/profile/12-3456789',
+  ein: '12-3456789',
+  submittedAt: '2026-07-11T00:00:00.000Z',
+  facebookUrl: 'https://www.facebook.com/helpinghandsshelter',
+  linkedinUrl: 'https://www.linkedin.com/company/helping-hands-shelter/',
+}
+
+/** Accept only a real https/http URL on the expected social host, else ''. */
+function sanitizeSocialUrl(raw, hostRe) {
+  if (!raw) return ''
+  let u
+  try {
+    u = new URL(String(raw).trim())
+  } catch {
+    return ''
+  }
+  if (u.protocol !== 'https:' && u.protocol !== 'http:') return ''
+  if (!hostRe.test(u.hostname)) return ''
+  return u.toString()
+}
+
+/**
+ * Validate an application record for footer generation. Returns the list of
+ * problems (empty = validated). Missing data means the application has not
+ * finished validation — the caller must fail loudly, not emit a partial
+ * footer. Exported for unit testing.
+ */
+export function validateApplication(record) {
+  const problems = []
+  if (!record || typeof record !== 'object' || Array.isArray(record)) {
+    return ['input is not an application record object']
+  }
+  for (const [field, why] of REQUIRED_FIELDS) {
+    const v = String(record[field] ?? '').trim()
+    if (!v) problems.push(`missing "${field}" — ${why}`)
+  }
+  const ein = String(record.ein ?? '').trim()
+  if (ein && !/^\d{2}-\d{7}$/.test(ein)) {
+    problems.push(`invalid "ein" (${ein}) — expected NN-NNNNNNN`)
+  }
+  // The footer's copyright line asserts US 501(c)(3) status; a pre-501(c)(3)
+  // application has not cleared Gate 3's legal-status validation yet.
+  if (record.charityStage && record.charityStage !== '501c3') {
+    problems.push(
+      `charityStage is "${record.charityStage}" — footer generation requires a validated 501c3 application`
+    )
+  }
+  return problems
+}
+
+/**
+ * Pure transform: validated application record -> FFC footer config. Throws
+ * with the full problem list when the record is not validated. Exported for
+ * unit testing.
+ */
+export function buildFooterConfig(record, { now = new Date() } = {}) {
+  const problems = validateApplication(record)
+  if (problems.length > 0) {
+    throw new Error(
+      `Application record is not validated for footer generation:\n` +
+        problems.map((p) => `  - ${p}`).join('\n')
+    )
+  }
+  const legalName = String(record.charityName).trim()
+  const socialLinks = []
+  const facebook = sanitizeSocialUrl(record.facebookUrl, /(^|\.)facebook\.com$/i)
+  if (facebook) socialLinks.push({ platform: 'facebook', label: 'Facebook', url: facebook })
+  const linkedin = sanitizeSocialUrl(record.linkedinUrl, /(^|\.)linkedin\.com$/i)
+  if (linkedin) socialLinks.push({ platform: 'linkedin', label: 'LinkedIn', url: linkedin })
+
+  return {
+    // Provenance: which validated application this footer derives from.
+    source: {
+      applicationId: String(record.id || ''),
+      system: 'WHMCS',
+      generatedBy: 'scripts/generate-footer-config.mjs',
+      generatedAt: now.toISOString(),
+    },
+    organization: {
+      legalName,
+      ein: record.ein,
+      charityStage: record.charityStage || '501c3',
+      ...(record.missionExcerpt ? { missionStatement: record.missionExcerpt } : {}),
+    },
+    // Column 1 of the FFC footer: transparency endorsements.
+    endorsements: {
+      guidestarProfileUrl: record.candidUrl,
+      einLine: `${legalName} EIN: ${record.ein}`,
+    },
+    // Column 3: contact + social. Contact details are PII the WHMCS sync
+    // deliberately never surfaces; the provisioning volunteer fills these
+    // from the charity's public website before committing the file.
+    contact: { email: null, phone: null, addressLines: [] },
+    socialLinks,
+    // Column 2: the FFC-standard policy stack (same routes on every site).
+    policyLinks: POLICY_LINKS,
+    copyright: {
+      holder: legalName,
+      year: now.getFullYear(),
+      line: `© ${now.getFullYear()} All Rights Are Reserved by ${legalName} a US 501c3 Non Profit`,
+      projectOf: { name: 'Free For Charity', url: 'https://freeforcharity.org' },
+    },
+  }
+}
+
+/**
+ * Resolve one record from parsed input: a single object passes through; an
+ * array (e.g. the sync's dry-run output) needs --id unless it has exactly one
+ * entry. Exported for unit testing.
+ */
+export function selectRecord(parsed, id) {
+  if (Array.isArray(parsed)) {
+    if (id) {
+      const hit = parsed.find((r) => r && r.id === id)
+      if (!hit) throw new Error(`no application with id "${id}" in input array`)
+      return hit
+    }
+    if (parsed.length === 1) return parsed[0]
+    throw new Error(
+      `input is an array of ${parsed.length} records — pass --id <application id> to pick one`
+    )
+  }
+  return parsed
+}
+
+function parseArgs(argv) {
+  const args = { input: '', output: '', id: '', sample: false }
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]
+    if (a === '--sample') args.sample = true
+    else if (a === '--input') args.input = argv[++i] || ''
+    else if (a === '--output') args.output = argv[++i] || ''
+    else if (a === '--id') args.id = argv[++i] || ''
+    else throw new Error(`unknown argument "${a}"`)
+  }
+  return args
+}
+
+async function readStdin() {
+  let data = ''
+  for await (const chunk of process.stdin) data += chunk
+  return data
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2))
+  let record
+  if (args.sample) {
+    record = SAMPLE_APPLICATION
+  } else {
+    const raw = args.input ? fs.readFileSync(args.input, 'utf8') : await readStdin()
+    if (!raw.trim()) {
+      throw new Error('no input: pipe an application record JSON, or pass --input/--sample')
+    }
+    record = selectRecord(JSON.parse(raw), args.id)
+  }
+  const config = buildFooterConfig(record)
+  const json = `${JSON.stringify(config, null, 2)}\n`
+  if (args.output) {
+    fs.writeFileSync(args.output, json)
+    console.error(`footer config written to ${args.output}`)
+  } else {
+    process.stdout.write(json)
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((err) => {
+    console.error(err instanceof Error ? err.message : String(err))
+    process.exitCode = 1
+  })
+}


### PR DESCRIPTION
## Summary

Gate 3 of the gated charity journey requires each charity site's FFC-standard footer to be generated from **validated** WHMCS application data. This adds the v1 bridge:

- **`scripts/generate-footer-config.mjs`** — pure transform (no network calls): takes one PII-safe application record as published by `scripts/whmcs-applications.mjs` (`buildApplicationRecords`) via stdin, `--input <file>`, or `--sample` (documented demo record; arrays from `WHMCS_DRY_RUN` output work with `--id ffc-<clientId>`) and emits the footer config JSON matching the FFC-IN-Footer-Only-Template footer block: `source` provenance, `organization` (legal name, EIN, stage, mission), `endorsements` (GuideStar profile URL + EIN line), `contact` (explicit volunteer-fill placeholders — the sync never surfaces PII), host-checked `socialLinks` (charity Facebook/LinkedIn page URLs), the six-link FFC policy stack, and `copyright`.
- **Fails loudly on missing data**: `charityName`, `ein` (NN-NNNNNNN), `candidUrl` required, and `charityStage` must be `501c3` (the footer copyright asserts US 501(c)(3) status). Every gap is listed at once and the exit code is non-zero — missing data means the application is not validated, so no partial footer is ever emitted.
- **`__tests__/generate-footer-config.test.js`** — unit tests following the `whmcs-applications.test.js` pattern: happy-path mapping, missing-field failure listing all gaps, pre-501c3 rejection, EIN format, off-host social URL rejection, array/`--id` selection.
- **`docs/footer-bridge.md`** — what it does, how a volunteer uses it during a website-provisioning work order, and future work (auto-PR the generated file into the charity's FFC-EX repo; surface `facebookUrl`/`linkedinUrl` + public contact fields through the sync allowlist; switch the template footer to consume the config).

## Test plan

- [x] `node scripts/generate-footer-config.mjs --sample` emits the full config
- [x] Missing-field record exits 1 listing every gap
- [x] `pnpm exec eslint` clean on new files; `pnpm run format` no-op
- [x] `pnpm run build` then `pnpm test`: 864/865 pass — sole failure is the known Windows-worktree husky executable-bit check, unrelated
- [x] New suite: 14 tests pass

Refs FreeForCharity/FFC-Cloudflare-Automation#682

🤖 Generated with [Claude Code](https://claude.com/claude-code)