### PR TITLE
feat: objective 'website validated' checklist + per-charity gate pipeline view

### DIFF
--- a/.github/ISSUE_TEMPLATE/charity-intake.yml
+++ b/.github/ISSUE_TEMPLATE/charity-intake.yml
@@ -486,6 +486,31 @@ body:
         - label: Letter/attestation from a sponsoring institution
         - label: Active community of 10+ named participants
 
+  # ---- Validation checklist (Gate 3) ----------------------------------------
+  - type: markdown
+    attributes:
+      value: |
+        ### Validation checklist (completed during the build — leave unticked when submitting)
+        This work order is done when the site is **objectively validated** on its free GitHub
+        Pages URL (Gate 3 of the gated journey — see
+        [the prerequisites inventory, Section 4b](https://github.com/FreeForCharity/FFC-IN-ffcadmin.org/blob/main/docs/application-prerequisites-inventory.md)). The
+        sponsoring admin ticks these boxes as each check passes; the charity ticks the final
+        content-review box.
+  - type: checkboxes
+    id: validation-checklist
+    attributes:
+      label: Validation checklist — all boxes ticked = validated → the charity may order its domain
+      description: Objective definition of "website validated" (Gate 3). Ticked during the build, not at intake.
+      options:
+        - label: CI green on the charity's FFC-EX repo (latest default-branch run passing)
+        - label: Site loads at its GitHub Pages URL (HTTP 200, no redirect loops)
+        - label: FFC-standard footer present and populated from the approved application data (org legal name, EIN, policy links, social links)
+        - label: All required sections/pages present per the chosen template
+        - label: Mobile responsive (spot-check at 375px — no horizontal scroll, nav usable)
+        - label: No browser console errors on any page
+        - label: Accessibility pass (axe clean or Lighthouse accessibility score ≥ 90)
+        - label: Content reviewed and approved by the charity
+
   # ---- Acknowledgements ----------------------------------------------------
   - type: checkboxes
     id: acknowledgements

--- a/__tests__/pipeline-stage.test.ts
+++ b/__tests__/pipeline-stage.test.ts
@@ -1,0 +1,103 @@
+import { deriveStage, groupByStage, PIPELINE_STAGES } from '@/app/pipeline/pipelineData'
+import type { RoadmapEntry, RoadmapStatus } from '@/app/roadmap/roadmapData'
+
+function entry(overrides: Partial<RoadmapEntry>): RoadmapEntry {
+  return {
+    issueNumber: 1,
+    charityName: 'Example Org',
+    missionExcerpt: '',
+    status: 'intake',
+    charityStage: 'pre-501c3',
+    missionCategory: 'general',
+    serviceTier: 'Tier 1',
+    readinessScore: 0,
+    readinessTier: 'Foundational',
+    submittedAt: '',
+    updatedAt: '',
+    sponsor: null,
+    plusOne: 0,
+    issueUrl: 'https://example.org',
+    ...overrides,
+  }
+}
+
+describe('deriveStage', () => {
+  it('maps application review statuses to "applied"', () => {
+    expect(deriveStage(entry({ status: 'intake' }))).toBe('applied')
+    expect(deriveStage(entry({ status: 'needs-info' }))).toBe('applied')
+  })
+
+  it('maps approved-but-not-building statuses to "approved"', () => {
+    expect(deriveStage(entry({ status: 'needs-admin' }))).toBe('approved')
+    // On-hold labels don't record which gate the stall happened at, so the
+    // derivation keeps the most conservative in-flight reading.
+    expect(deriveStage(entry({ status: 'on-hold' }))).toBe('approved')
+  })
+
+  it('maps in-flight build statuses to "building"', () => {
+    expect(deriveStage(entry({ status: 'sponsored' }))).toBe('building')
+    expect(deriveStage(entry({ status: 'active-build' }))).toBe('building')
+  })
+
+  it('a live site still on its GitHub Pages default URL is "validated"', () => {
+    const e = entry({
+      status: 'live',
+      liveUrl: 'https://freeforcharity.github.io/FFC-EX-example/',
+    })
+    expect(deriveStage(e)).toBe('validated')
+  })
+
+  it('a live site on a custom domain is "domain"', () => {
+    expect(deriveStage(entry({ status: 'live', liveUrl: 'https://example.org' }))).toBe('domain')
+    expect(deriveStage(entry({ status: 'live', liveUrl: 'https://www.example.org/' }))).toBe(
+      'domain'
+    )
+  })
+
+  it('does not mistake a github.io lookalike domain for GitHub Pages', () => {
+    expect(deriveStage(entry({ status: 'live', liveUrl: 'https://evilgithub.io' }))).toBe('domain')
+    expect(deriveStage(entry({ status: 'live', liveUrl: 'https://github.io.example.org' }))).toBe(
+      'domain'
+    )
+  })
+
+  it('a live entry with a malformed or missing URL falls back to "domain"', () => {
+    expect(deriveStage(entry({ status: 'live', liveUrl: 'not a url' }))).toBe('domain')
+    expect(deriveStage(entry({ status: 'live' }))).toBe('domain')
+  })
+
+  it('graduated charities map to the most advanced supported stage', () => {
+    expect(deriveStage(entry({ status: 'graduated' }))).toBe('domain')
+  })
+
+  it('covers every roadmap status', () => {
+    const statuses: RoadmapStatus[] = [
+      'intake',
+      'needs-info',
+      'needs-admin',
+      'active-build',
+      'sponsored',
+      'live',
+      'on-hold',
+      'graduated',
+    ]
+    for (const status of statuses) {
+      const stage = deriveStage(entry({ status }))
+      expect(PIPELINE_STAGES.some((s) => s.id === stage)).toBe(true)
+    }
+  })
+})
+
+describe('groupByStage', () => {
+  it('returns every stage key even when empty, entries sorted by name', () => {
+    const groups = groupByStage([
+      entry({ charityName: 'Zeta', status: 'intake' }),
+      entry({ charityName: 'Alpha', status: 'intake' }),
+      entry({ charityName: 'Mid', status: 'needs-admin' }),
+    ])
+    expect(Object.keys(groups).sort()).toEqual([...PIPELINE_STAGES.map((s) => s.id)].sort())
+    expect(groups.applied.map((e) => e.charityName)).toEqual(['Alpha', 'Zeta'])
+    expect(groups.approved.map((e) => e.charityName)).toEqual(['Mid'])
+    expect(groups.email).toEqual([]) // email stage not derivable yet (future work)
+  })
+})

--- a/docs/application-prerequisites-inventory.md
+++ b/docs/application-prerequisites-inventory.md
@@ -128,8 +128,8 @@ submission). The **Glossary** at the end defines the terms.
    GuideStar/Candid seal (Section 6), and FFC-supported org accounts (Section 7).
 6. **Gated service delivery** (Section 4a) — the four gates, in order: charity
    application fully approved → website application approved → website built and
-   **validated on its GitHub Pages URL** → only then the **domain** (register or
-   transfer), with email after the domain.
+   **validated on its GitHub Pages URL** (objective checklist in Section 4b) →
+   only then the **domain** (register or transfer), with email after the domain.
 7. **Service-delivery lifecycle** (Section 8) — legacy WordPress-era flow, kept
    for reference.
 
@@ -861,7 +861,9 @@ work orders** for website provisioning only.
    default URL** (e.g. `https://freeforcharity.github.io/FFC-EX-yourcharity/`)
    — **no custom domain yet**. This is the stage the **GitHub
    website-provisioning issue** drives: the issue is created after Gate 2 and
-   the build runs entirely on the free default URL.
+   the build runs entirely on the free default URL. **"Validated" is defined
+   objectively by the checklist in Section 4b** — every box ticked, not a
+   feeling.
 4. **Gate 4 — Only now does FFC spend money on the domain.** The domain is
    **registered or transferred in Cloudflare** (its own WHMCS order) and
    pointed at the already-validated site. Those order forms require the live
@@ -882,6 +884,39 @@ nonprofit grants) is provisioned once the domain exists, and remains gated on
 - **Clean separation of systems:** WHMCS holds the applications, approvals, and
   orders (system of record); GitHub holds the engineering work orders that
   build the website.
+
+---
+
+## 4b. The "website validated" checklist (Gate 3 definition)
+
+Section 4a stays authoritative for the **flow** — the four gates and their
+order. This section defines one word inside it: what **"validated"** at Gate 3
+objectively means. The same checklist is embedded as tickable items in the
+website-provisioning work order
+(`.github/ISSUE_TEMPLATE/charity-intake.yml`), where the sponsoring admin
+ticks each box as it passes and the charity ticks the final content-review
+box.
+
+A charity's website is **validated** on its GitHub Pages default URL when
+**every** box below is ticked:
+
+- [ ] **CI green** on the charity's FFC-EX repo (latest default-branch run
+      passing)
+- [ ] **Site loads at its GitHub Pages URL** (HTTP 200, no redirect loops)
+- [ ] **FFC-standard footer present and populated from the approved
+      application data** — org legal name, EIN, policy links, social links
+      (the Gate 1 application auto-generates this data; see Section 4a)
+- [ ] **All required sections/pages present** per the chosen template
+- [ ] **Mobile responsive** — spot-check at 375px: no horizontal scroll,
+      navigation usable
+- [ ] **No browser console errors** on any page
+- [ ] **Accessibility pass** — axe clean or Lighthouse accessibility score
+      ≥ 90
+- [ ] **Content reviewed and approved by the charity**
+
+**All boxes ticked = validated → the charity may order its domain** (Gate 4,
+Section 4a). Partial completion is not validated: the domain order form's
+attestation that "the website is validated" refers to this checklist.
 
 ---
 

--- a/src/app/pipeline/page.tsx
+++ b/src/app/pipeline/page.tsx
@@ -1,0 +1,126 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import Breadcrumbs from '@/components/Breadcrumbs'
+import { loadRoadmap } from '../roadmap/roadmapData'
+import { PIPELINE_STAGES, groupByStage } from './pipelineData'
+
+export const metadata: Metadata = {
+  title: 'Charity Pipeline',
+  description:
+    'Which gate of the FFC journey each charity is at — applied, approved, website building, validated, domain live, email — so stalls are visible at a glance.',
+  keywords:
+    'Free For Charity pipeline, charity gates, nonprofit website pipeline, FFC delivery stages, charity journey',
+  alternates: { canonical: 'https://ffcadmin.org/pipeline/' },
+  openGraph: {
+    type: 'website',
+    title: 'The FFC Charity Pipeline — every charity, by gate',
+    description:
+      'See which gate of the gated FFC journey each charity is at, from application through validated website to live domain.',
+    url: 'https://ffcadmin.org/pipeline/',
+  },
+}
+
+export default function PipelinePage() {
+  const data = loadRoadmap()
+  const groups = groupByStage(data.entries)
+  const total = data.entries.length
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Breadcrumbs items={[{ label: 'Home', href: '/' }, { label: 'Pipeline' }]} />
+
+      {/* Hero */}
+      <div className="bg-ffc-gradient text-white">
+        <div className="mx-auto max-w-5xl px-4 py-16 sm:px-6 lg:px-8">
+          <h1 className="text-3xl font-bold md:text-4xl">The FFC Charity Pipeline</h1>
+          <p className="mt-3 max-w-3xl text-lg text-teal-50">
+            Every charity FFC is helping, grouped by the gate it is at in the gated journey: applied
+            → approved → website building → validated → domain → email. A charity sitting in one
+            column too long is a stall worth investigating.
+          </p>
+        </div>
+      </div>
+
+      <main className="mx-auto max-w-7xl space-y-10 px-4 py-12 sm:px-6 lg:px-8">
+        {/* Stage summary strip */}
+        <section
+          aria-label="Stage totals"
+          className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6"
+        >
+          {PIPELINE_STAGES.map((stage) => (
+            <a
+              key={stage.id}
+              href={`#${stage.id}`}
+              className="rounded-xl border border-gray-200 bg-white p-4 text-center hover:border-teal-300"
+            >
+              <div className="text-2xl font-bold text-teal-700">{groups[stage.id].length}</div>
+              <div className="mt-1 text-sm font-semibold text-gray-700">{stage.label}</div>
+            </a>
+          ))}
+        </section>
+
+        {PIPELINE_STAGES.map((stage) => (
+          <section key={stage.id} id={stage.id} className="scroll-mt-24">
+            <div className="flex items-baseline gap-3">
+              <h2 className="text-2xl font-bold text-gray-900">{stage.label}</h2>
+              <span className="text-sm font-semibold text-gray-500">{groups[stage.id].length}</span>
+            </div>
+            <p className="mt-1 max-w-3xl text-gray-600">{stage.description}</p>
+
+            {groups[stage.id].length === 0 ? (
+              <p className="mt-4 rounded-lg border border-dashed border-gray-300 bg-white p-4 text-sm text-gray-500">
+                No charities at this stage right now.
+              </p>
+            ) : (
+              <ul className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                {groups[stage.id].map((entry) => (
+                  <li
+                    key={`${entry.issueNumber}-${entry.charityName}`}
+                    className="rounded-xl border border-gray-200 bg-white p-4"
+                  >
+                    <div className="font-semibold text-gray-900">{entry.charityName}</div>
+                    <div className="mt-1 text-sm text-gray-500">{stage.label}</div>
+                    <div className="mt-2 flex flex-wrap gap-3 text-sm">
+                      {entry.issueNumber > 0 && (
+                        <a
+                          href={entry.issueUrl}
+                          className="font-medium text-teal-700 hover:underline"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          Intake issue #{entry.issueNumber}
+                        </a>
+                      )}
+                      {entry.liveUrl && (
+                        <a
+                          href={entry.liveUrl}
+                          className="font-medium text-teal-700 hover:underline"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          Live site
+                        </a>
+                      )}
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+        ))}
+
+        <p className="text-center text-sm text-gray-400">
+          {total} {total === 1 ? 'charity' : 'charities'} tracked.{' '}
+          {data.generatedAt
+            ? `Data generated ${new Date(data.generatedAt).toLocaleString('en-US')}.`
+            : 'Pipeline data not yet generated.'}{' '}
+          Sourced from the same snapshot as the{' '}
+          <Link href="/roadmap" className="text-teal-700 hover:underline">
+            public roadmap
+          </Link>
+          .
+        </p>
+      </main>
+    </div>
+  )
+}

--- a/src/app/pipeline/pipelineData.ts
+++ b/src/app/pipeline/pipelineData.ts
@@ -1,0 +1,136 @@
+/**
+ * Per-charity gate pipeline — pure stage derivation (v1).
+ *
+ * Maps each roadmap entry (see `src/app/roadmap/roadmapData.ts`, generated
+ * from this repo's `kind:intake` issues + the live-portfolio CSV) onto the
+ * gated charity journey of `docs/application-prerequisites-inventory.md`
+ * Section 4a: applied → approved → building → validated → domain → email.
+ *
+ * Kept free of `fs` (same split as `roadmapFilter.ts`) so unit tests and any
+ * future client component can import it; only the page touches `loadRoadmap()`.
+ *
+ * What the data actually supports today (and what it doesn't):
+ *
+ * - applied    — `status:intake` / `status:needs-info` labels on the work order.
+ * - approved   — `status:needs-admin`: the application is approved and the
+ *                charity is waiting for a sponsoring admin. `status:on-hold`
+ *                also lands here: delivery is paused and the labels don't
+ *                record which gate it stalled at, so we keep the most
+ *                conservative in-flight reading.
+ * - building   — `status:sponsored` / `status:active-build`: the
+ *                website-provisioning work order is being executed (Gate 3 in
+ *                progress).
+ * - validated  — `status:live` with a `github.io` live URL: the site passed
+ *                validation on its free GitHub Pages default URL but has no
+ *                custom domain yet. FUTURE WORK: derive this from the Gate 3
+ *                validation checklist in the work order (or a dedicated
+ *                `status:validated` label) instead of the URL heuristic.
+ * - domain     — `status:live` with a custom-domain live URL (the WHMCS domain
+ *                product isn't in the roadmap snapshot, so the live custom
+ *                domain is the observable signal). `status:graduated` also
+ *                maps here — it is beyond every stage this data can model.
+ * - email      — NOT DERIVABLE YET: the roadmap snapshot carries no
+ *                Microsoft 365 / email-product signal from WHMCS. FUTURE WORK:
+ *                extend the WHMCS sync (`scripts/whmcs-applications.mjs`) to
+ *                surface an email-product-Active flag per charity.
+ */
+import type { RoadmapEntry } from '../roadmap/roadmapData'
+
+export type PipelineStage = 'applied' | 'approved' | 'building' | 'validated' | 'domain' | 'email'
+
+export interface PipelineStageInfo {
+  id: PipelineStage
+  label: string
+  description: string
+}
+
+/** The gates of Section 4a, in journey order (display order of the page). */
+export const PIPELINE_STAGES: readonly PipelineStageInfo[] = [
+  {
+    id: 'applied',
+    label: 'Applied',
+    description: 'Application received and under review, or waiting on more information.',
+  },
+  {
+    id: 'approved',
+    label: 'Approved',
+    description:
+      'Application approved (Gate 1); waiting for a sponsoring admin or delivery is on hold.',
+  },
+  {
+    id: 'building',
+    label: 'Website building',
+    description:
+      'A sponsoring admin is executing the website-provisioning work order (Gate 3 in progress).',
+  },
+  {
+    id: 'validated',
+    label: 'Validated',
+    description:
+      'Site validated on its free GitHub Pages URL — no custom domain yet. Cleared to order a domain (Gate 4).',
+  },
+  {
+    id: 'domain',
+    label: 'Domain live',
+    description: 'Site live on its own custom domain, registered or transferred in Cloudflare.',
+  },
+  {
+    id: 'email',
+    label: 'Email',
+    description:
+      'Organizational email provisioned after the domain. Not yet derivable from the sync data — shown for the full journey.',
+  },
+] as const
+
+/** True when a live URL is still the free GitHub Pages default URL. */
+function isGitHubPagesUrl(liveUrl: string): boolean {
+  try {
+    const host = new URL(liveUrl).hostname.toLowerCase()
+    return host === 'github.io' || host.endsWith('.github.io')
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Derive the journey gate a charity is at from its roadmap entry.
+ * See the module comment for exactly which signals back each stage.
+ */
+export function deriveStage(entry: RoadmapEntry): PipelineStage {
+  switch (entry.status) {
+    case 'intake':
+    case 'needs-info':
+      return 'applied'
+    case 'needs-admin':
+    case 'on-hold':
+      return 'approved'
+    case 'sponsored':
+    case 'active-build':
+      return 'building'
+    case 'live':
+    case 'graduated':
+      // Graduated is beyond every stage this data models; a live entry sits at
+      // "validated" until its live URL leaves the free github.io default.
+      if (entry.status === 'live' && entry.liveUrl && isGitHubPagesUrl(entry.liveUrl)) {
+        return 'validated'
+      }
+      return 'domain'
+  }
+}
+
+/** Group entries by derived stage; every stage key is present (possibly empty). */
+export function groupByStage(entries: RoadmapEntry[]): Record<PipelineStage, RoadmapEntry[]> {
+  const groups: Record<PipelineStage, RoadmapEntry[]> = {
+    applied: [],
+    approved: [],
+    building: [],
+    validated: [],
+    domain: [],
+    email: [],
+  }
+  for (const entry of entries) groups[deriveStage(entry)].push(entry)
+  for (const stage of Object.keys(groups) as PipelineStage[]) {
+    groups[stage].sort((a, b) => a.charityName.localeCompare(b.charityName))
+  }
+  return groups
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -196,6 +196,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     // for arbitrary queries), and noindexed URLs don't belong in a sitemap.
     // Public roadmap & intake program
     { url: `${SITE_URL}/roadmap/`, lastModified: now, changeFrequency: 'daily', priority: 0.9 },
+    { url: `${SITE_URL}/pipeline/`, lastModified: now, changeFrequency: 'daily', priority: 0.7 },
     {
       url: `${SITE_URL}/roadmap/submit/`,
       lastModified: now,

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -136,6 +136,11 @@ export const operateMenu: NavMenu = {
           description: 'All FFC-managed domains with health and migration status.',
         },
         {
+          label: 'Charity Pipeline',
+          href: '/pipeline',
+          description: 'Which gate each charity is at — applied through validated, domain, email.',
+        },
+        {
           label: 'Documentation',
           href: '/documentation',
           description: 'Project documentation and reference materials.',


### PR DESCRIPTION
## Summary

Implements two sub-issues of the gated-journey epic (FreeForCharity/FFC-Cloudflare-Automation#676):

### 1. Objective "website validated" checklist (Refs FreeForCharity/FFC-Cloudflare-Automation#680)

Gate 3 pivoted on "validated" with no written definition. This PR authors it:

- **`.github/ISSUE_TEMPLATE/charity-intake.yml`** — new tickable "Validation checklist" checkboxes section in the website-provisioning work order: CI green on the FFC-EX repo, site loads at its GitHub Pages URL (HTTP 200), FFC-standard footer populated from approved application data (legal name, EIN, policy links, social links), all required sections per template, mobile responsive at 375px, no console errors, accessibility pass (axe / Lighthouse a11y ≥ 90), content reviewed by the charity. All boxes ticked = validated → the charity may order its domain.
- **`docs/application-prerequisites-inventory.md`** — same checklist as new **Section 4b**; Section 4a stays authoritative for the flow and its Gate 3 now points at 4b for the definition (also cross-referenced from the "At a glance" journey list).

### 2. Per-charity gate pipeline view (Refs FreeForCharity/FFC-Cloudflare-Automation#683)

New `/pipeline` page grouping every charity by the journey gate it is at, so stalls are visible at a glance.

- **`src/app/pipeline/pipelineData.ts`** — pure, fs-free stage derivation (`roadmapFilter.ts` pattern) over the roadmap snapshot:
  - applied ← `status:intake` / `status:needs-info`
  - approved ← `status:needs-admin` (and `status:on-hold`, the most conservative in-flight reading)
  - building ← `status:sponsored` / `status:active-build`
  - validated ← `status:live` with a `github.io` live URL (URL heuristic; a checklist-driven or `status:validated`-label signal is documented as future work)
  - domain ← `status:live` on a custom domain (and `status:graduated`)
  - email ← **not derivable yet** — the WHMCS sync carries no email-product signal; documented as future work in the module comment
- **`src/app/pipeline/page.tsx`** — stage summary strip + charities grouped by stage (name, stage, intake-issue link, live-site link), following the roadmap page style.
- Added to the Operate ▸ Operations nav menu (Sites List precedent) and the sitemap.

## Test plan

- [x] `pnpm run format` / `lint` / `type-check` — clean (one pre-existing warning in `scripts/lib/intake-issues.mjs`)
- [x] `pnpm run build` — static export succeeds, `/pipeline` prerendered
- [x] `pnpm test` — 865/866 pass; the one failure is the known pre-existing husky executable-bit check on Windows worktrees (not touched by this PR; CI on Linux runs it green)
- [x] New unit tests in `__tests__/pipeline-stage.test.ts` cover every roadmap status, the GitHub Pages URL heuristic (incl. lookalike domains and malformed URLs), and grouping/sorting

Refs FreeForCharity/FFC-Cloudflare-Automation#680
Refs FreeForCharity/FFC-Cloudflare-Automation#683
(cross-repo, so linked with Refs — close the sub-issues manually on merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)