### PR TITLE
feat: emit shared SiteConfig-shaped partial from the footer-config bridge

### DIFF
--- a/__tests__/generate-footer-config.test.js
+++ b/__tests__/generate-footer-config.test.js
@@ -1,79 +1,112 @@
 /**
- * Unit tests for the footer-config bridge (scripts/generate-footer-config.mjs).
+ * Unit tests for the site-config bridge (scripts/generate-footer-config.mjs).
  *
- * The transform is pure — a validated WHMCS application record in, the
- * FFC-standard footer config out — so these tests lock in the happy-path
- * mapping (org name, EIN, GuideStar link, social URLs, policy stack,
- * copyright) and the loud failure when required fields are missing (missing
+ * The transform is pure — a validated WHMCS application record in, a
+ * siteConfig PARTIAL in the shared SiteConfig shape out (template
+ * convergence, FreeForCharity/FFC-Cloudflare-Automation#693) — so these
+ * tests lock in the happy-path mapping (name, EIN, description, guidestar,
+ * social, the always-present supportedBy attribution), the manual-fill
+ * checklist, and the loud failure when required fields are missing (missing
  * data = application not validated for footer generation).
  */
 
-let buildFooterConfig, validateApplication, selectRecord
-let REQUIRED_FIELDS, POLICY_LINKS, SAMPLE_APPLICATION
+let buildSiteConfigPartial, validateApplication, selectRecord
+let REQUIRED_FIELDS, MANUAL_FIELDS_BASE, SUPPORTED_BY, SAMPLE_APPLICATION
 
 beforeAll(async () => {
   const mod = await import('../scripts/generate-footer-config.mjs')
-  buildFooterConfig = mod.buildFooterConfig
+  buildSiteConfigPartial = mod.buildSiteConfigPartial
   validateApplication = mod.validateApplication
   selectRecord = mod.selectRecord
   REQUIRED_FIELDS = mod.REQUIRED_FIELDS
-  POLICY_LINKS = mod.POLICY_LINKS
+  MANUAL_FIELDS_BASE = mod.MANUAL_FIELDS_BASE
+  SUPPORTED_BY = mod.SUPPORTED_BY
   SAMPLE_APPLICATION = mod.SAMPLE_APPLICATION
 })
 
-describe('buildFooterConfig — happy path', () => {
-  it('maps a validated application onto the FFC footer shape', () => {
+describe('buildSiteConfigPartial — happy path', () => {
+  it('maps a validated application onto the shared SiteConfig shape', () => {
     const now = new Date('2026-07-11T12:00:00.000Z')
-    const config = buildFooterConfig(SAMPLE_APPLICATION, { now })
+    const out = buildSiteConfigPartial(SAMPLE_APPLICATION, { now })
 
-    expect(config.source).toMatchObject({
+    expect(out.source).toEqual({
       applicationId: 'ffc-90',
       system: 'WHMCS',
       generatedBy: 'scripts/generate-footer-config.mjs',
-    })
-    expect(config.organization).toEqual({
-      legalName: 'Helping Hands Shelter',
-      ein: '12-3456789',
+      generatedAt: '2026-07-11T12:00:00.000Z',
       charityStage: '501c3',
-      missionStatement: 'We provide shelter, food, and job placement to families in crisis.',
     })
-    expect(config.endorsements).toEqual({
-      guidestarProfileUrl: 'https://www.guidestar.org/profile/12-3456789',
-      einLine: 'Helping Hands Shelter EIN: 12-3456789',
-    })
-    expect(config.socialLinks).toEqual([
-      {
-        platform: 'facebook',
-        label: 'Facebook',
-        url: 'https://www.facebook.com/helpinghandsshelter',
+    // The partial's keys are named and nested exactly as in the template's
+    // typed SiteConfig (src/lib/site.config.ts) — directly transcribable.
+    expect(out.siteConfig).toEqual({
+      name: 'Helping Hands Shelter',
+      description: 'We provide shelter, food, and job placement to families in crisis.',
+      social: [
+        { label: 'Facebook', href: 'https://www.facebook.com/helpinghandsshelter' },
+        { label: 'LinkedIn', href: 'https://www.linkedin.com/company/helping-hands-shelter/' },
+      ],
+      ein: '12-3456789',
+      guidestar: {
+        profileUrl: 'https://www.guidestar.org/profile/12-3456789',
+        // Only the public profile URL is collected — the direct "shared
+        // profile" link stays a manual fill (kept as '' so the guidestar
+        // object retains the template's full shape).
+        directProfileUrl: '',
       },
-      {
-        platform: 'linkedin',
-        label: 'LinkedIn',
-        url: 'https://www.linkedin.com/company/helping-hands-shelter/',
+      supportedBy: {
+        name: 'Free For Charity',
+        url: 'https://freeforcharity.org',
+        hubUrl: 'https://freeforcharity.org/hub/',
       },
-    ])
-    expect(config.policyLinks).toEqual(POLICY_LINKS)
-    expect(config.copyright).toEqual({
-      holder: 'Helping Hands Shelter',
-      year: 2026,
-      line: '© 2026 All Rights Are Reserved by Helping Hands Shelter a US 501c3 Non Profit',
-      projectOf: { name: 'Free For Charity', url: 'https://freeforcharity.org' },
     })
-    // Contact details are PII the sync never surfaces — emitted as explicit
-    // volunteer-fill placeholders, not silently omitted.
-    expect(config.contact).toEqual({ email: null, phone: null, addressLines: [] })
   })
 
-  it('covers the FFC-standard policy stack routes', () => {
-    expect(POLICY_LINKS.map((l) => l.href)).toEqual([
-      '/free-for-charity-donation-policy',
-      '/privacy-policy',
-      '/cookie-policy',
-      '/terms-of-service',
-      '/vulnerability-disclosure-policy',
-      '/security-acknowledgements',
+  it('lists every SiteConfig key the application cannot supply in manualFields', () => {
+    const out = buildSiteConfigPartial(SAMPLE_APPLICATION)
+    // The sample record supplies description and social, so only the base
+    // manual-fill list applies.
+    expect(out.manualFields).toEqual(MANUAL_FIELDS_BASE)
+    expect(out.manualFields.map((f) => f.key)).toEqual([
+      'contactEmail',
+      'phone',
+      'addresses',
+      'guidestar.directProfileUrl',
+      'integrations',
+      'url',
+      'tagline',
     ])
+    // Every manual field carries a note telling the volunteer where to get it.
+    for (const f of out.manualFields) {
+      expect(typeof f.note).toBe('string')
+      expect(f.note.length).toBeGreaterThan(0)
+    }
+    // Omitted-key contract: manual keys are NOT emitted in the partial (the
+    // one exception, guidestar.directProfileUrl, is '' to keep the object
+    // shape) — so a volunteer never transcribes a placeholder as real data.
+    expect(out.siteConfig).not.toHaveProperty('contactEmail')
+    expect(out.siteConfig).not.toHaveProperty('phone')
+    expect(out.siteConfig).not.toHaveProperty('addresses')
+    expect(out.siteConfig).not.toHaveProperty('integrations')
+    expect(out.siteConfig).not.toHaveProperty('url')
+    expect(out.siteConfig).not.toHaveProperty('tagline')
+  })
+
+  it('ALWAYS emits the FFC supportedBy attribution (footer standard, never from the record)', () => {
+    // Even a record that (maliciously or accidentally) carries its own
+    // supportedBy cannot repoint the attribution.
+    const record = {
+      ...SAMPLE_APPLICATION,
+      supportedBy: { name: 'Evil Corp', url: 'https://evil.example.com', hubUrl: 'x' },
+    }
+    const out = buildSiteConfigPartial(record)
+    expect(out.siteConfig.supportedBy).toEqual({
+      name: 'Free For Charity',
+      url: 'https://freeforcharity.org',
+      hubUrl: 'https://freeforcharity.org/hub/',
+    })
+    expect(out.siteConfig.supportedBy).toEqual(SUPPORTED_BY)
+    // And it is never on the manual-fill list — nothing to fill by hand.
+    expect(out.manualFields.map((f) => f.key)).not.toContain('supportedBy')
   })
 
   it('omits social links the record does not carry and rejects off-host URLs', () => {
@@ -82,24 +115,27 @@ describe('buildFooterConfig — happy path', () => {
       facebookUrl: undefined,
       linkedinUrl: 'https://evil.example.com/spoof', // not linkedin.com -> dropped
     }
-    const config = buildFooterConfig(record)
-    expect(config.socialLinks).toEqual([])
+    const out = buildSiteConfigPartial(record)
+    expect(out.siteConfig.social).toEqual([])
+    // With no usable page URLs, social joins the manual-fill checklist.
+    expect(out.manualFields.some((f) => f.key === 'social')).toBe(true)
   })
 
-  it('omits missionStatement when the sync record has no mission excerpt', () => {
+  it('omits description (and flags it manual) when the record has no mission excerpt', () => {
     const record = { ...SAMPLE_APPLICATION }
     delete record.missionExcerpt
-    const config = buildFooterConfig(record)
-    expect(config.organization).not.toHaveProperty('missionStatement')
+    const out = buildSiteConfigPartial(record)
+    expect(out.siteConfig).not.toHaveProperty('description')
+    expect(out.manualFields.some((f) => f.key === 'description')).toBe(true)
   })
 })
 
-describe('buildFooterConfig — missing data fails loudly', () => {
+describe('buildSiteConfigPartial — missing data fails loudly', () => {
   it('throws listing EVERY missing required field (missing = not validated)', () => {
     const record = { id: 'ffc-91', charityStage: '501c3' }
-    expect(() => buildFooterConfig(record)).toThrow(/not validated/)
+    expect(() => buildSiteConfigPartial(record)).toThrow(/not validated/)
     try {
-      buildFooterConfig(record)
+      buildSiteConfigPartial(record)
     } catch (err) {
       // All three gaps reported at once, so a volunteer sees the full picture.
       expect(err.message).toMatch(/missing "charityName"/)
@@ -110,7 +146,7 @@ describe('buildFooterConfig — missing data fails loudly', () => {
 
   it('rejects a pre-501c3 application (footer asserts US 501c3 status)', () => {
     const record = { ...SAMPLE_APPLICATION, charityStage: 'pre-501c3' }
-    expect(() => buildFooterConfig(record)).toThrow(/pre-501c3/)
+    expect(() => buildSiteConfigPartial(record)).toThrow(/pre-501c3/)
   })
 
   it('rejects a record with NO charityStage — never fail-open into a 501c3 assertion', () => {
@@ -118,7 +154,7 @@ describe('buildFooterConfig — missing data fails loudly', () => {
     delete record.charityStage
     const problems = validateApplication(record)
     expect(problems.some((p) => /missing "charityStage"/.test(p))).toBe(true)
-    expect(() => buildFooterConfig(record)).toThrow(/charityStage/)
+    expect(() => buildSiteConfigPartial(record)).toThrow(/charityStage/)
   })
 
   it('rejects a malformed EIN', () => {

--- a/docs/footer-bridge.md
+++ b/docs/footer-bridge.md
@@ -1,19 +1,24 @@
-# Footer-Config Bridge (WHMCS → FFC-EX footer)
+# Site-Config Bridge (WHMCS → FFC-EX `siteConfig` partial)
 
 Gate 3 of the gated charity journey requires each charity site's FFC-standard footer to be
 generated from **validated** WHMCS application data — not hand-typed. The bridge is
 `scripts/generate-footer-config.mjs`: a pure transform (no network calls) that turns one
-application record from the existing WHMCS sync (`scripts/whmcs-applications.mjs`) into a footer
-config file for the charity's FFC-EX repo. The footer component lives in
-[FFC-IN-Footer_Only_Template](https://github.com/FreeForCharity/FFC-IN-Footer_Only_Template); both
-site templates render the same block (endorsements/EIN, quick links + policy stack, contact,
-social icons, copyright).
+application record from the existing WHMCS sync (`scripts/whmcs-applications.mjs`) into a
+**`siteConfig` partial** for the charity's FFC-EX repo.
 
-> **Consumption status (today):** neither template reads this JSON file yet — both
-> FFC-IN-FFC_Single_Page_Template and FFC-IN-Footer_Only_Template hardcode their footer values in
-> `src/lib/site.config.ts`, which has a different shape. Until template consumption lands (see
-> Future work), the generated config is the **source document a volunteer transcribes from**, not
-> a file the site loads.
+The partial uses the canonical shared shape both FFC site templates are converging on
+([template convergence, FreeForCharity/FFC-Cloudflare-Automation#693](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/693)):
+the typed `SiteConfig` in
+[FFC-IN-FFC_Single_Page_Template](https://github.com/FreeForCharity/FFC-IN-FFC_Single_Page_Template)'s
+`src/lib/site.config.ts`. Every emitted key is named and nested exactly as in that type, so the
+output is **directly transcribable** — and, once
+[FFC-IN-Footer_Only_Template](https://github.com/FreeForCharity/FFC-IN-Footer_Only_Template)
+adopts the same shared shape, the one generated artifact serves **both** templates.
+
+> **Consumption status (today):** no template imports this JSON file yet — both templates read
+> their values from `src/lib/site.config.ts` in the charity repo. Until direct consumption lands
+> (see Future work), the generated partial is the **source document a volunteer transcribes
+> from**, not a file the site loads.
 
 ## What it does
 
@@ -25,52 +30,82 @@ social icons, copyright).
   asserts US 501(c)(3) status — a record that does not carry the stage explicitly is not
   validated). Anything missing means the application is **not validated** for footer generation:
   the script exits non-zero and lists every gap. It never emits a partial footer.
-- **Output**: the footer config JSON on stdout, or `--output <file>` — provenance (`source`),
-  `organization` (legal name, EIN, stage, mission), `endorsements` (GuideStar profile URL + EIN
-  line), `contact` (volunteer-fill placeholders; see below), `socialLinks` (charity Facebook and
-  LinkedIn **page** URLs, host-checked), the six-link FFC policy stack, and the `copyright` line.
+- **Output** (stdout, or `--output <file>`): a JSON object with three keys —
+  - `source` — provenance: which validated application the partial derives from (id, system,
+    generator, timestamp, and the validated `charityStage` the 501(c)(3) assertion rests on).
+  - `manualFields` — every `SiteConfig` key the application could **not** supply, each with a
+    note telling the volunteer where to get the value (see below).
+  - `siteConfig` — the partial itself, in the shared `SiteConfig` shape.
 
-Contact details (email, phone, address) are PII the WHMCS sync deliberately never surfaces, so
-they are emitted as explicit `null`/empty placeholders for the provisioning volunteer to fill from
-the charity's public website. The charity Facebook/LinkedIn **page** URLs collected by the
-hardened onboarding forms (fields `facebook-page` / `linkedin-page`) are surfaced by the sync as
-`facebookUrl` / `linkedinUrl` and flow straight into `socialLinks`; only applications that predate
-those fields need volunteer fill-in for social links.
+### Field mapping (application record → `siteConfig`)
+
+| Application record          | `siteConfig` key       | Notes                                                                                             |
+| --------------------------- | ---------------------- | ------------------------------------------------------------------------------------------------- |
+| `charityName`               | `name`                 | Public organization legal name                                                                    |
+| `missionExcerpt`            | `description`          | Omitted (and flagged manual) when the application predates the mission field                      |
+| `ein`                       | `ein`                  | Validated NN-NNNNNNN                                                                              |
+| `facebookUrl`/`linkedinUrl` | `social[]`             | `{ label, href }` entries; labels match the template's icon set; host-checked, dropped if invalid |
+| `candidUrl`                 | `guidestar.profileUrl` | `guidestar.directProfileUrl` is emitted as `''` and flagged manual                                |
+| _(constant)_                | `supportedBy`          | **Always** FFC: `{ name, url, hubUrl }` — the permanent footer attribution, never from the record |
+
+### Manual fields
+
+Contact details (email, phone, address) are PII the WHMCS sync deliberately never surfaces, and
+some `SiteConfig` keys are simply not collected at application time. Those keys are **omitted**
+from the partial (never emitted as placeholder values) and itemized in `manualFields` so the
+provisioning volunteer knows exactly what to fill by hand:
+
+- `contactEmail`, `phone`, `addresses` — from the charity's public website
+- `guidestar.directProfileUrl` — the Candid "shared profile" direct link
+- `integrations` — per-charity Zeffy / Idealist / SociableKit / Microsoft Forms endpoints
+- `url` — the site's canonical production URL (set at provisioning/cutover)
+- `tagline` — agreed with the charity
+- `description` / `social` — only when the application record does not carry them
+
+The charity Facebook/LinkedIn **page** URLs collected by the hardened onboarding forms (fields
+`facebook-page` / `linkedin-page`) are surfaced by the sync as `facebookUrl` / `linkedinUrl` and
+flow straight into `social`; only applications that predate those fields need volunteer fill-in
+for social links.
 
 ## How a volunteer uses it (website-provisioning work order)
 
 1. Open the charity's `kind:intake` work-order issue; note the application id (`ffc-<clientId>`).
 2. Get the application record: run the **WHMCS Intake** workflow with dry-run enabled and copy the
    record from the log, or save the JSON array to a file.
-3. Generate the config (from the FFC-IN-ffcadmin.org repo root):
+3. Generate the partial (from the FFC-IN-ffcadmin.org repo root):
 
    ```bash
    node scripts/generate-footer-config.mjs --input applications.json --id ffc-90 \
-     --output footer.config.json
+     --output site.config.partial.json
    ```
 
    Try it without WHMCS data: `node scripts/generate-footer-config.mjs --sample`
 
 4. If it fails, the listed gaps are onboarding gaps — send the application back for completion in
    WHMCS rather than guessing values.
-5. Fill the `contact` placeholders (and any missing social links) from the charity's public
-   website, then **attach the generated JSON to the work-order issue** (paste it in a comment or
-   attach the file). The provisioning volunteer transcribes those values into the charity repo's
-   `src/lib/site.config.ts` — the file both templates actually read today. Do **not** commit the
-   JSON into the charity repo expecting the footer to pick it up; no template consumes it yet.
+5. Work through `manualFields`, gathering each value from the charity's public website (or the
+   work order), then **transcribe the `siteConfig` object into the charity repo's
+   `src/lib/site.config.ts`** — key names and nesting match one-for-one — and/or **attach the
+   generated JSON to the work-order issue** (paste it in a comment or attach the file) so the
+   provisioning volunteer has the validated source document. Do **not** commit the JSON into the
+   charity repo expecting the footer to pick it up; no template consumes it directly yet. Never
+   change or drop `supportedBy` — it is the permanent FFC footer attribution required on every
+   supported charity site.
 
 ## Future work
 
 - **Auto-PR the generated values** into the charity's FFC-EX repo from the work-order workflow, so
   Gate 3's footer requirement is fully mechanical (generate → validate → PR → review → merge).
 - **Surface the remaining public contact fields** from the hardened onboarding forms through the
-  sync's allowlist so the volunteer fill-in step disappears entirely (the social page URLs already
+  sync's allowlist so the volunteer fill-in step shrinks further (the social page URLs already
   flow through).
-- **Template consumption — both templates**: switch the footer components of
-  [FFC-IN-Footer_Only_Template](https://github.com/FreeForCharity/FFC-IN-Footer_Only_Template) and
-  [FFC-IN-FFC_Single_Page_Template](https://github.com/FreeForCharity/FFC-IN-FFC_Single_Page_Template)
-  from their hardcoded `src/lib/site.config.ts` values to reading this config shape (or generate
-  `site.config.ts` from it), so one generated artifact drives every charity site and the
-  transcription step in Step 5 disappears.
+- **Direct consumption — both templates**: once
+  [FFC-IN-Footer_Only_Template](https://github.com/FreeForCharity/FFC-IN-Footer_Only_Template)
+  adopts the shared `SiteConfig` shape
+  ([FreeForCharity/FFC-Cloudflare-Automation#693](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/693)),
+  have the templates import the generated partial (or generate `site.config.ts` from it) so one
+  artifact drives every charity site and the transcription step in Step 5 disappears.
 
-Refs: FreeForCharity/FFC-Cloudflare-Automation#682 (part of epic #676).
+Refs: FreeForCharity/FFC-Cloudflare-Automation#682 (part of epic #676);
+FreeForCharity/FFC-Cloudflare-Automation#693 (template convergence — this bridge emits the shared
+shape as phase 2).

--- a/scripts/generate-footer-config.mjs
+++ b/scripts/generate-footer-config.mjs
@@ -1,25 +1,30 @@
 #!/usr/bin/env node
 /**
- * Footer-config bridge (Gate 3 of the gated charity journey): turn ONE
+ * Site-config bridge (Gate 3 of the gated charity journey): turn ONE
  * validated WHMCS application record — the PII-safe shape produced by
- * scripts/whmcs-applications.mjs (`buildApplicationRecords`) — into the
- * FFC-standard footer config for a charity's FFC-EX site (the footer component
- * lives in FFC-IN-Footer_Only_Template; both site templates render the same
- * block: endorsements/EIN, policy links, contact, social icons, copyright).
- * NOTE: no template consumes this JSON yet — volunteers transcribe it into the
- * charity repo's src/lib/site.config.ts (see docs/footer-bridge.md).
+ * scripts/whmcs-applications.mjs (`buildApplicationRecords`) — into a
+ * `siteConfig` PARTIAL for the charity's FFC-EX site.
+ *
+ * The emitted `siteConfig` object uses the canonical shared shape both FFC
+ * site templates are converging on (template convergence,
+ * FreeForCharity/FFC-Cloudflare-Automation#693): the typed `SiteConfig` in
+ * FFC-IN-FFC_Single_Page_Template's src/lib/site.config.ts. Every key is
+ * directly transcribable into that file — same names, same nesting — so a
+ * volunteer copies values across without translating between shapes.
+ * Keys the application data cannot supply are omitted and itemized in
+ * `manualFields` (see docs/footer-bridge.md).
  *
  * Pure transform, no network calls: the WHMCS sync already fetched the data.
  * Missing required fields mean the application is NOT validated for footer
  * generation, so the script fails loudly and lists every gap instead of
- * emitting a half-empty footer.
+ * emitting a half-empty config.
  *
  * Usage:
  *   node scripts/generate-footer-config.mjs --input application.json
  *   cat application.json | node scripts/generate-footer-config.mjs
  *   node scripts/generate-footer-config.mjs --sample            # demo record
  *   node scripts/generate-footer-config.mjs --input apps.json --id ffc-90
- *   ... --output footer.config.json                             # else stdout
+ *   ... --output site.config.partial.json                       # else stdout
  *
  * Input is a single application record, or an array of them (e.g. the
  * WHMCS_DRY_RUN output) plus --id to pick one.
@@ -43,22 +48,75 @@ export const REQUIRED_FIELDS = [
 ]
 
 /**
- * Optional record fields the footer uses when present. `facebookUrl` and
+ * Optional record fields the config uses when present. `facebookUrl` and
  * `linkedinUrl` are the charity PAGE URLs from the hardened onboarding forms
  * (fields `facebook-page` / `linkedin-page`, never board-member profiles),
  * surfaced by the WHMCS sync's PII-safe allowlist. Exported for unit testing.
  */
 export const OPTIONAL_FIELDS = ['missionExcerpt', 'facebookUrl', 'linkedinUrl', 'submittedAt']
 
-/** The FFC-standard policy stack every charity site footer links to. */
-export const POLICY_LINKS = [
-  { name: 'Donation Policy', href: '/free-for-charity-donation-policy' },
-  { name: 'Privacy Policy', href: '/privacy-policy' },
-  { name: 'Cookie Policy', href: '/cookie-policy' },
-  { name: 'Terms of Service', href: '/terms-of-service' },
-  { name: 'Vulnerability Disclosure Policy', href: '/vulnerability-disclosure-policy' },
-  { name: 'Security Acknowledgement', href: '/security-acknowledgements' },
+/**
+ * Permanent "Supported by" attribution required by the FFC footer standard on
+ * every supported charity site (SiteConfig.supportedBy). These values are
+ * intentionally FFC's, forever — never derived from the application record and
+ * never a rebrand target. Exported for unit testing.
+ */
+export const SUPPORTED_BY = Object.freeze({
+  name: 'Free For Charity',
+  url: 'https://freeforcharity.org',
+  hubUrl: 'https://freeforcharity.org/hub/',
+})
+
+/**
+ * SiteConfig keys the WHMCS application can never supply. Always present in
+ * the output's `manualFields` so the provisioning volunteer knows exactly what
+ * to fill by hand (from the charity's public website or the work order).
+ * Exported for unit testing.
+ */
+export const MANUAL_FIELDS_BASE = [
+  {
+    key: 'contactEmail',
+    note: 'PII the WHMCS sync never surfaces — take the public contact email from the charity website',
+  },
+  {
+    key: 'phone',
+    note: 'PII the WHMCS sync never surfaces — fill { display, tel } from the charity website',
+  },
+  {
+    key: 'addresses',
+    note: 'PII the WHMCS sync never surfaces — fill [{ label, lines, mapUrl }] from the charity website',
+  },
+  {
+    key: 'guidestar.directProfileUrl',
+    note: 'Candid "shared profile" direct link — the application only carries the public profile URL',
+  },
+  {
+    key: 'integrations',
+    note: 'per-charity Zeffy / Idealist / SociableKit / Microsoft Forms endpoints — not collected at application time',
+  },
+  {
+    key: 'url',
+    note: "the site's canonical production URL — set when the FFC-EX repo/domain is provisioned",
+  },
+  {
+    key: 'tagline',
+    note: 'short slogan for the default <title> — not collected by the application; agree it with the charity',
+  },
 ]
+
+/** Accept only a real https/http URL on the expected social host, else ''. */
+function sanitizeSocialUrl(raw, hostRe) {
+  if (!raw) return ''
+  let u
+  try {
+    u = new URL(String(raw).trim())
+  } catch {
+    return ''
+  }
+  if (u.protocol !== 'https:' && u.protocol !== 'http:') return ''
+  if (!hostRe.test(u.hostname)) return ''
+  return u.toString()
+}
 
 /**
  * Documented sample record for testing/demo (--sample). Mirrors the exact
@@ -79,20 +137,6 @@ export const SAMPLE_APPLICATION = {
   submittedAt: '2026-07-11T00:00:00.000Z',
   facebookUrl: 'https://www.facebook.com/helpinghandsshelter',
   linkedinUrl: 'https://www.linkedin.com/company/helping-hands-shelter/',
-}
-
-/** Accept only a real https/http URL on the expected social host, else ''. */
-function sanitizeSocialUrl(raw, hostRe) {
-  if (!raw) return ''
-  let u
-  try {
-    u = new URL(String(raw).trim())
-  } catch {
-    return ''
-  }
-  if (u.protocol !== 'https:' && u.protocol !== 'http:') return ''
-  if (!hostRe.test(u.hostname)) return ''
-  return u.toString()
 }
 
 /**
@@ -126,11 +170,21 @@ export function validateApplication(record) {
 }
 
 /**
- * Pure transform: validated application record -> FFC footer config. Throws
- * with the full problem list when the record is not validated. Exported for
- * unit testing.
+ * Pure transform: validated application record -> siteConfig partial in the
+ * shared SiteConfig shape (template convergence,
+ * FreeForCharity/FFC-Cloudflare-Automation#693). Throws with the full problem
+ * list when the record is not validated. Exported for unit testing.
+ *
+ * Output contract:
+ *   - `source`       provenance: which validated application this derives from
+ *                    (including the validated charityStage the 501(c)(3)
+ *                    copyright assertion rests on).
+ *   - `manualFields` every SiteConfig key the application could not supply,
+ *                    each with a note telling the volunteer where to get it.
+ *   - `siteConfig`   the partial itself — keys named and nested exactly as in
+ *                    the template's typed SiteConfig, ready to transcribe.
  */
-export function buildFooterConfig(record, { now = new Date() } = {}) {
+export function buildSiteConfigPartial(record, { now = new Date() } = {}) {
   const problems = validateApplication(record)
   if (problems.length > 0) {
     throw new Error(
@@ -139,45 +193,60 @@ export function buildFooterConfig(record, { now = new Date() } = {}) {
     )
   }
   const legalName = String(record.charityName).trim()
-  const socialLinks = []
+
+  // SiteConfig.social — icon in the template footer resolves by `label`, so
+  // the labels here must match the template's known set exactly.
+  const social = []
   const facebook = sanitizeSocialUrl(record.facebookUrl, /(^|\.)facebook\.com$/i)
-  if (facebook) socialLinks.push({ platform: 'facebook', label: 'Facebook', url: facebook })
+  if (facebook) social.push({ label: 'Facebook', href: facebook })
   const linkedin = sanitizeSocialUrl(record.linkedinUrl, /(^|\.)linkedin\.com$/i)
-  if (linkedin) socialLinks.push({ platform: 'linkedin', label: 'LinkedIn', url: linkedin })
+  if (linkedin) social.push({ label: 'LinkedIn', href: linkedin })
+
+  const mission = String(record.missionExcerpt ?? '').trim()
+
+  const manualFields = [...MANUAL_FIELDS_BASE]
+  if (!mission) {
+    manualFields.push({
+      key: 'description',
+      note: 'no mission excerpt on the application — write the <meta description> from the charity website',
+    })
+  }
+  if (social.length === 0) {
+    manualFields.push({
+      key: 'social',
+      note: 'no valid Facebook/LinkedIn PAGE URL on the application — fill [{ label, href }] from the charity public presence',
+    })
+  }
 
   return {
-    // Provenance: which validated application this footer derives from.
+    // Provenance: which validated application this partial derives from.
     source: {
       applicationId: String(record.id || ''),
       system: 'WHMCS',
       generatedBy: 'scripts/generate-footer-config.mjs',
       generatedAt: now.toISOString(),
-    },
-    organization: {
-      legalName,
-      ein: record.ein,
-      // Required + validated above — never defaulted (the footer legally
-      // asserts 501(c)(3) status).
+      // Required + validated above — never defaulted (the footer's copyright
+      // line legally asserts 501(c)(3) status).
       charityStage: record.charityStage,
-      ...(record.missionExcerpt ? { missionStatement: record.missionExcerpt } : {}),
     },
-    // Column 1 of the FFC footer: transparency endorsements.
-    endorsements: {
-      guidestarProfileUrl: record.candidUrl,
-      einLine: `${legalName} EIN: ${record.ein}`,
-    },
-    // Column 3: contact + social. Contact details are PII the WHMCS sync
-    // deliberately never surfaces; the provisioning volunteer fills these
-    // from the charity's public website before committing the file.
-    contact: { email: null, phone: null, addressLines: [] },
-    socialLinks,
-    // Column 2: the FFC-standard policy stack (same routes on every site).
-    policyLinks: POLICY_LINKS,
-    copyright: {
-      holder: legalName,
-      year: now.getFullYear(),
-      line: `© ${now.getFullYear()} All Rights Are Reserved by ${legalName} a US 501c3 Non Profit`,
-      projectOf: { name: 'Free For Charity', url: 'https://freeforcharity.org' },
+    // SiteConfig keys the application cannot supply — the volunteer's
+    // fill-by-hand checklist. Everything else transcribes verbatim.
+    manualFields,
+    // The partial: key names and nesting match the template's SiteConfig
+    // (src/lib/site.config.ts) exactly. Keys listed in manualFields are
+    // omitted, EXCEPT guidestar.directProfileUrl which is emitted as '' so
+    // the guidestar object keeps the template's full shape.
+    siteConfig: {
+      name: legalName,
+      ...(mission ? { description: mission } : {}),
+      social,
+      ein: record.ein,
+      guidestar: {
+        profileUrl: record.candidUrl,
+        directProfileUrl: '',
+      },
+      // FFC footer standard: always present, always these values.
+      supportedBy: { ...SUPPORTED_BY },
     },
   }
 }
@@ -233,11 +302,11 @@ async function main() {
     }
     record = selectRecord(JSON.parse(raw), args.id)
   }
-  const config = buildFooterConfig(record)
+  const config = buildSiteConfigPartial(record)
   const json = `${JSON.stringify(config, null, 2)}\n`
   if (args.output) {
     fs.writeFileSync(args.output, json)
-    console.error(`footer config written to ${args.output}`)
+    console.error(`site.config partial written to ${args.output}`)
   } else {
     process.stdout.write(json)
   }


### PR DESCRIPTION
## Summary

Phase 2 of template convergence: `scripts/generate-footer-config.mjs` previously emitted a bespoke footer JSON shape that no template consumes. It now emits a **`siteConfig` partial** in the canonical shared shape both FFC site templates are converging on — the typed `SiteConfig` in FFC-IN-FFC_Single_Page_Template's `src/lib/site.config.ts`, including the required `supportedBy` key added by FreeForCharity/FFC-IN-FFC_Single_Page_Template#394 — so every emitted key is directly transcribable into (and eventually importable by) the charity repo's `site.config.ts`.

### Field mapping
| Application record | `siteConfig` key |
| --- | --- |
| `charityName` | `name` |
| `missionExcerpt` | `description` (omitted + flagged manual when absent) |
| `ein` | `ein` |
| `facebookUrl` / `linkedinUrl` | `social[{label,href}]` (host-checked) |
| `candidUrl` | `guidestar.profileUrl` (`directProfileUrl` emitted `''` + flagged manual) |
| _(constant)_ | `supportedBy` — **always** `{ name: 'Free For Charity', url: 'https://freeforcharity.org', hubUrl: 'https://freeforcharity.org/hub/' }`, never from the record |

### What else
- Keys the application cannot supply are **omitted** and itemized in a `manualFields` checklist (`contactEmail`, `phone`, `addresses`, `guidestar.directProfileUrl`, `integrations`, `url`, `tagline`; plus `description`/`social` when the record lacks them) so the volunteer knows exactly what to fill by hand.
- Fail-closed validation from #598 unchanged: `charityStage` required and `501c3`, EIN format check, loud full-gap listing — never a half-empty config. Provenance (`source`) now carries the validated `charityStage`.
- `docs/footer-bridge.md` rewritten: the output is a site.config partial consumable by BOTH templates once Footer-Only adopts the shared shape; volunteer workflow = generate → transcribe into the charity repo's `site.config.ts` (or attach to the work order).
- `scripts/whmcs-applications.mjs` untouched.

## Test plan
- [x] `pnpm run format` / `pnpm run lint` / `pnpm run type-check` clean
- [x] `pnpm exec jest __tests__/generate-footer-config.test.js` — 13/13 pass (happy-path shape, manual-fields contract, supportedBy always present and not overridable by the record, missing-field/pre-501c3/malformed-EIN failure paths, selectRecord)
- [x] `pnpm run build` + full `pnpm test` — 903/904 pass; sole failure is the known Windows-worktree husky executable-bit check
- [x] `node scripts/generate-footer-config.mjs --sample` emits the documented shape

Refs FreeForCharity/FFC-Cloudflare-Automation#693 (phase 2: bridge alignment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)