### PR TITLE
feat: add run-site skill to build, serve, and drive ffcadmin.org

### DIFF
--- a/.claude/skills/run-site/.gitignore
+++ b/.claude/skills/run-site/.gitignore
@@ -1,0 +1,1 @@
+screenshots/

--- a/.claude/skills/run-site/SKILL.md
+++ b/.claude/skills/run-site/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: run-site
+description: Build, run, and drive this FFC static site. Use when asked to start, build, preview, screenshot, or interact with the site, or verify a page renders. Static Next.js export driven with headless Chromium via .claude/skills/run-site/driver.mjs.
+---
+
+This repo is a Next.js **static export** (`output: 'export'` → `out/`). "Running
+it" means building the export, serving `out/` over HTTP, and driving a headless
+Chromium against it with `.claude/skills/run-site/driver.mjs` — which navigates
+routes, screenshots each full page, and fails on real errors (bad HTTP status,
+uncaught page errors, or same-origin request failures).
+
+All paths below are relative to the repo root.
+
+## Prerequisites
+
+No `apt-get` needed in the Claude Code web container: Node and a Chromium build
+are already present. The driver launches the pre-installed browser at
+`/opt/pw-browsers/chromium` (override with `CHROME_PATH=...`). **In that
+container** you do **not** run `npx playwright install` — the repo's pinned
+Playwright may want a different browser build than the container ships, and
+pointing at the existing one avoids the mismatch. On a local machine or CI
+without a pre-installed browser, run `npx playwright install chromium` once, or
+set `CHROME_PATH` to a system Chrome/Chromium.
+
+## Setup
+
+```bash
+npm install
+```
+
+## Build
+
+```bash
+npm run build      # static export → out/. Do not cancel.
+```
+
+## Run (agent path)
+
+Serve the export in the background, wait for the port, then drive it:
+
+```bash
+# 1. Serve out/ on :3000 (this is `npx serve out -l 3000`)
+nohup npx serve out -l 3000 >/tmp/preview.log 2>&1 &
+echo $! > /tmp/preview.pid
+timeout 30 bash -c 'until curl -sf http://localhost:3000 >/dev/null; do sleep 1; done'
+
+# 2. Drive it — screenshots the default route set (/)
+node .claude/skills/run-site/driver.mjs
+
+# 3. Stop the server when done
+kill $(cat /tmp/preview.pid)
+```
+
+Screenshots (full-page) land in `.claude/skills/run-site/screenshots/<slug>.png`.
+**Open them** — a green run only means nothing threw; look at the image to
+confirm the page rendered.
+
+### driver.mjs usage
+
+| invocation                                             | what it does                                       |
+| ------------------------------------------------------ | -------------------------------------------------- |
+| `node .../driver.mjs`                                  | Smoke the default route set (`/`, or `ROUTES=...`) |
+| `node .../driver.mjs / /privacy-policy/`               | Screenshot specific routes                         |
+| `ROUTES="/,/about/,/contact/" node .../driver.mjs`     | Override the default route set                     |
+| `EXPECT="Some text" node .../driver.mjs /`             | Also assert the text is present in the HTML        |
+| `BASE_URL=http://localhost:3000 node .../driver.mjs /` | Override the server origin (e.g. `npm run dev`)    |
+| `CHROME_PATH=/path/to/chrome node .../driver.mjs`      | Use a different Chromium binary                    |
+
+Exit code is 0 only when every route is clean, so it works in a script.
+
+## Run (human path)
+
+```bash
+npm run dev        # → http://localhost:3000 with Turbopack HMR. Ctrl-C to stop.
+```
+
+On its own this is useless in a headless container, since there is no window to
+view. Point the driver at it with `BASE_URL=http://localhost:3000` when
+iterating on a component, because it rebuilds on save.
+
+## Test
+
+```bash
+npm run lint       # eslint
+npm run build      # verify the static export
+npm run test       # jest unit/component tests — not the browser
+npm run test:e2e   # playwright e2e — needs the pinned browser; see gotcha below
+```
+
+## Gotchas
+
+- **Third-party embeds that fail are not bugs.** Any third-party host the sandbox
+  proxy blocks (`ERR_CONNECTION_RESET`) is counted and reported as
+  "N third-party blocked" — the driver does **not** fail on them; it only fails
+  on same-origin problems. Those embeds render blank in screenshots as a result.
+- **`ERR_ABORTED` request failures are prefetches, not bugs.** Next.js `<Link>`
+  prefetches the RSC payload and aborts those requests on navigate. The driver
+  drops any `requestfailed` whose error text contains `ERR_ABORTED` (regardless
+  of host), so they never count against a route.
+- **Trailing slashes matter.** The export writes `out/<route>/index.html`, so hit
+  `/privacy-policy/`, not `/privacy-policy`.
+- **The repo's Playwright browser build ≠ the container's.** `npm run test:e2e`
+  and any bare `chromium.launch()` may try a build the container doesn't have and
+  error with "Executable doesn't exist … run npx playwright install". Do not
+  install; pass `executablePath: '/opt/pw-browsers/chromium'` (the driver does).
+
+## Troubleshooting
+
+- **`browserType.launch: Executable doesn't exist at …chrome-headless-shell`**:
+  Playwright version/browser mismatch. Use the driver (it sets `executablePath`)
+  or export `CHROME_PATH=/opt/pw-browsers/chromium`.
+- **`EADDRINUSE` on :3000**: a previous server is still up. Stop it by pidfile
+  (`kill $(cat /tmp/preview.pid)`) or port (`fuser -k 3000/tcp`). Avoid
+  `pkill -f 'serve'` — that substring also matches the shell running it and kills
+  your own command.
+- **A route is slow to settle**: navigation is capped at 30s and the post-load
+  `networkidle` wait at 5s (ignored on timeout), so a blocked third-party request
+  delays a route by at most ~5s rather than hanging it. A route that exceeds the
+  30s nav cap fails with a timeout.

--- a/.claude/skills/run-site/SKILL.md
+++ b/.claude/skills/run-site/SKILL.md
@@ -13,8 +13,11 @@ All paths below are relative to the repo root.
 
 ## Prerequisites
 
-No `apt-get` needed in the Claude Code web container: Node and a Chromium build
-are already present. The driver launches the pre-installed browser at
+This repo is pinned to **pnpm** (`packageManager: pnpm@9`, `pnpm-lock.yaml`) —
+use `pnpm`, not `npm`, so installs honor the lockfile and stay reproducible.
+
+No `apt-get` needed in the Claude Code web container: Node, pnpm, and a Chromium
+build are already present. The driver launches the pre-installed browser at
 `/opt/pw-browsers/chromium` (override with `CHROME_PATH=...`). **In that
 container** you do **not** run `npx playwright install` — the repo's pinned
 Playwright may want a different browser build than the container ships, and
@@ -25,13 +28,13 @@ set `CHROME_PATH` to a system Chrome/Chromium.
 ## Setup
 
 ```bash
-npm install
+pnpm install
 ```
 
 ## Build
 
 ```bash
-npm run build      # static export → out/. Do not cancel.
+pnpm run build      # static export → out/. Do not cancel.
 ```
 
 ## Run (agent path)
@@ -39,8 +42,8 @@ npm run build      # static export → out/. Do not cancel.
 Serve the export in the background, wait for the port, then drive it:
 
 ```bash
-# 1. Serve out/ on :3000 (this is `npx serve out -l 3000`)
-nohup npx serve out -l 3000 >/tmp/preview.log 2>&1 &
+# 1. Serve out/ on :3000 (this is `pnpm dlx serve out -l 3000`)
+nohup pnpm dlx serve out -l 3000 >/tmp/preview.log 2>&1 &
 echo $! > /tmp/preview.pid
 timeout 30 bash -c 'until curl -sf http://localhost:3000 >/dev/null; do sleep 1; done'
 
@@ -63,7 +66,7 @@ confirm the page rendered.
 | `node .../driver.mjs / /privacy-policy/`               | Screenshot specific routes                         |
 | `ROUTES="/,/about/,/contact/" node .../driver.mjs`     | Override the default route set                     |
 | `EXPECT="Some text" node .../driver.mjs /`             | Also assert the text is present in the HTML        |
-| `BASE_URL=http://localhost:3000 node .../driver.mjs /` | Override the server origin (e.g. `npm run dev`)    |
+| `BASE_URL=http://localhost:3000 node .../driver.mjs /` | Override the server origin (e.g. `pnpm run dev`)   |
 | `CHROME_PATH=/path/to/chrome node .../driver.mjs`      | Use a different Chromium binary                    |
 
 Exit code is 0 only when every route is clean, so it works in a script.
@@ -71,7 +74,7 @@ Exit code is 0 only when every route is clean, so it works in a script.
 ## Run (human path)
 
 ```bash
-npm run dev        # → http://localhost:3000 with Turbopack HMR. Ctrl-C to stop.
+pnpm run dev        # → http://localhost:3000 with Turbopack HMR. Ctrl-C to stop.
 ```
 
 On its own this is useless in a headless container, since there is no window to
@@ -81,10 +84,10 @@ iterating on a component, because it rebuilds on save.
 ## Test
 
 ```bash
-npm run lint       # eslint
-npm run build      # verify the static export
-npm run test       # jest unit/component tests — not the browser
-npm run test:e2e   # playwright e2e — needs the pinned browser; see gotcha below
+pnpm run lint       # eslint
+pnpm run build      # verify the static export
+pnpm run test       # jest unit/component tests — not the browser
+pnpm run test:e2e   # playwright e2e — needs the pinned browser; see gotcha below
 ```
 
 ## Gotchas
@@ -99,7 +102,7 @@ npm run test:e2e   # playwright e2e — needs the pinned browser; see gotcha bel
   of host), so they never count against a route.
 - **Trailing slashes matter.** The export writes `out/<route>/index.html`, so hit
   `/privacy-policy/`, not `/privacy-policy`.
-- **The repo's Playwright browser build ≠ the container's.** `npm run test:e2e`
+- **The repo's Playwright browser build ≠ the container's.** `pnpm run test:e2e`
   and any bare `chromium.launch()` may try a build the container doesn't have and
   error with "Executable doesn't exist … run npx playwright install". Do not
   install; pass `executablePath: '/opt/pw-browsers/chromium'` (the driver does).

--- a/.claude/skills/run-site/SKILL.md
+++ b/.claude/skills/run-site/SKILL.md
@@ -92,10 +92,12 @@ pnpm run test:e2e   # playwright e2e — needs the pinned browser; see gotcha be
 
 ## Gotchas
 
-- **Third-party embeds that fail are not bugs.** Any third-party host the sandbox
-  proxy blocks (`ERR_CONNECTION_RESET`) is counted and reported as
-  "N third-party blocked" — the driver does **not** fail on them; it only fails
-  on same-origin problems. Those embeds render blank in screenshots as a result.
+- **Cross-origin request failures are not counted as bugs.** Any failed request
+  to an origin other than the page's (a third-party embed, CDN, analytics, etc.)
+  is counted and reported as "N third-party failed" — the driver does **not**
+  fail the run on them; it only fails on same-origin problems. In this sandbox
+  these are usually blocked embeds (`ERR_CONNECTION_RESET`), which render blank
+  in screenshots as a result.
 - **`ERR_ABORTED` request failures are prefetches, not bugs.** Next.js `<Link>`
   prefetches the RSC payload and aborts those requests on navigate. The driver
   drops any `requestfailed` whose error text contains `ERR_ABORTED` (regardless

--- a/.claude/skills/run-site/SKILL.md
+++ b/.claude/skills/run-site/SKILL.md
@@ -42,8 +42,8 @@ pnpm run build      # static export → out/. Do not cancel.
 Serve the export in the background, wait for the port, then drive it:
 
 ```bash
-# 1. Serve out/ on :3000 (this is `pnpm dlx serve out -l 3000`)
-nohup pnpm dlx serve out -l 3000 >/tmp/preview.log 2>&1 &
+# 1. Serve out/ on :3000 (this is `pnpm exec serve out -l 3000`)
+nohup pnpm exec serve out -l 3000 >/tmp/preview.log 2>&1 &
 echo $! > /tmp/preview.pid
 timeout 30 bash -c 'until curl -sf http://localhost:3000 >/dev/null; do sleep 1; done'
 

--- a/.claude/skills/run-site/driver.mjs
+++ b/.claude/skills/run-site/driver.mjs
@@ -55,7 +55,7 @@ const CHROME = resolveChrome()
 const here = dirname(fileURLToPath(import.meta.url))
 const shotDir = resolve(here, 'screenshots')
 
-// Default preview origin: `npm run preview` serves the export on :3000.
+// Default origin: the static export served on :3000 (see SKILL.md for how).
 const BASE_URL = (process.env.BASE_URL || 'http://localhost:3000').replace(/\/$/, '')
 const EXPECT = process.env.EXPECT || ''
 const VIEWPORT = { width: 1280, height: 800 }

--- a/.claude/skills/run-site/driver.mjs
+++ b/.claude/skills/run-site/driver.mjs
@@ -12,7 +12,8 @@
  * that throws or 404s makes the run exit non-zero; blocked third-party
  * requests are counted but never fail the run.
  *
- * Prereqs: `npm run build` then a server on BASE_URL (see SKILL.md).
+ * Prereqs: a freshly built export served on BASE_URL (see SKILL.md for the
+ * repo's build + serve commands).
  *
  * Usage:
  *   node .claude/skills/run-site/driver.mjs                 # smoke the default route set
@@ -77,8 +78,11 @@ const FAIL = '\x1b[31m✗\x1b[0m'
 
 async function main() {
   await mkdir(shotDir, { recursive: true })
+  // Chromium's setuid sandbox can't run as root (the common container case),
+  // so pass --no-sandbox only then; a normal local user keeps the sandbox.
+  const isRoot = typeof process.getuid === 'function' && process.getuid() === 0
   const browser = await chromium.launch({
-    args: ['--no-sandbox'],
+    args: isRoot ? ['--no-sandbox'] : [],
     ...(CHROME ? { executablePath: CHROME } : {}),
   })
   const context = await browser.newContext({ viewport: VIEWPORT })
@@ -90,8 +94,16 @@ async function main() {
     // `http-status/` would be mistaken for a URL and crash `new URL()`.
     const url = /^https?:\/\//.test(path) ? path : `${BASE_URL}${rel}`
     // Classify by the target's own origin, not BASE_URL — an absolute-URL
-    // arg has its own origin, and BASE_URL wouldn't match it.
-    const origin = new URL(url).origin
+    // arg has its own origin, and BASE_URL wouldn't match it. Guard the parse
+    // so a malformed BASE_URL/route fails this route, not the whole run.
+    let origin
+    try {
+      origin = new URL(url).origin
+    } catch {
+      failures++
+      process.stdout.write(`${FAIL} ${path} — invalid URL "${url}"\n`)
+      continue
+    }
     const sameOrigin = (u) => {
       try {
         return new URL(u).origin === origin

--- a/.claude/skills/run-site/driver.mjs
+++ b/.claude/skills/run-site/driver.mjs
@@ -114,7 +114,7 @@ async function main() {
     const page = await context.newPage()
     const pageErrors = []
     const localFails = [] // same-origin resource failures — real bugs
-    const extBlocks = [] // third-party hosts blocked by the sandbox — informational
+    const extBlocks = [] // cross-origin (third-party) request failures — informational
     page.on('pageerror', (e) => pageErrors.push(String(e)))
     page.on('requestfailed', (r) => {
       const err = r.failure()?.errorText || ''
@@ -163,7 +163,7 @@ async function main() {
     }
 
     if (!ok) failures++
-    const note = extBlocks.length ? ` (${extBlocks.length} third-party blocked)` : ''
+    const note = extBlocks.length ? ` (${extBlocks.length} third-party failed)` : ''
     process.stdout.write(
       `${ok ? PASS : FAIL} ${path}${detail ? ` — ${detail}` : ''}${note} -> ${shotRel}\n`
     )

--- a/.claude/skills/run-site/driver.mjs
+++ b/.claude/skills/run-site/driver.mjs
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+/*
+ * driver.mjs — headless-Chromium harness for an FFC static-export site.
+ *
+ * Site-agnostic: works for any FFC static-export site (Next.js
+ * `output: 'export'`). It drives Chromium through Playwright's
+ * API via `@playwright/test` (the package the repo already depends on) — pointed
+ * at the container's pre-installed browser via executablePath, not a
+ * Playwright-bundled download. It navigates one or more routes against a
+ * running server, screenshots each, and reports same-origin request
+ * failures, bad HTTP responses (>=400), and uncaught page errors. A page
+ * that throws or 404s makes the run exit non-zero; blocked third-party
+ * requests are counted but never fail the run.
+ *
+ * Prereqs: `npm run build` then a server on BASE_URL (see SKILL.md).
+ *
+ * Usage:
+ *   node .claude/skills/run-site/driver.mjs                 # smoke the default route set
+ *   node .claude/skills/run-site/driver.mjs / /privacy-policy/   # specific routes
+ *   BASE_URL=http://localhost:3000 node .../driver.mjs /    # override server origin
+ *   ROUTES="/,/about/,/contact/" node .../driver.mjs        # override default route set
+ *   EXPECT="Some heading" node .../driver.mjs /             # assert text is present
+ *
+ * Screenshots land in .claude/skills/run-site/screenshots/<slug>.png
+ * Exit code: 0 = every route clean, 1 = any route failed.
+ */
+
+import { chromium } from '@playwright/test'
+import { mkdir } from 'node:fs/promises'
+import { existsSync, statSync, accessSync, constants } from 'node:fs'
+import { dirname, resolve, relative } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+// The repo's Playwright pins a browser build that may not match the one
+// pre-installed in the container. Prefer the container's stable chromium
+// symlink so we never need `npx playwright install`. Override with
+// CHROME_PATH if needed — validated up front so a bad path fails loudly
+// here instead of as an opaque Playwright launch error later.
+function resolveChrome() {
+  const override = process.env.CHROME_PATH
+  if (override) {
+    try {
+      if (!statSync(override).isFile()) throw new Error('not a file')
+      accessSync(override, constants.X_OK)
+    } catch {
+      console.error(`CHROME_PATH="${override}" is not an executable file.`)
+      process.exit(1)
+    }
+    return override
+  }
+  return ['/opt/pw-browsers/chromium'].find((p) => existsSync(p)) || undefined
+}
+const CHROME = resolveChrome()
+
+const here = dirname(fileURLToPath(import.meta.url))
+const shotDir = resolve(here, 'screenshots')
+
+// Default preview origin: `npm run preview` serves the export on :3000.
+const BASE_URL = (process.env.BASE_URL || 'http://localhost:3000').replace(/\/$/, '')
+const EXPECT = process.env.EXPECT || ''
+const VIEWPORT = { width: 1280, height: 800 }
+
+// Default route set: `/` only — the one route every site has. Override with
+// ROUTES="/a/,/b/" or pass routes as args to cover more of a multi-page site.
+const DEFAULT_ROUTES = (process.env.ROUTES || '/')
+  .split(',')
+  .map((r) => r.trim())
+  .filter(Boolean)
+
+const routes = process.argv.slice(2)
+const targets = routes.length ? routes : DEFAULT_ROUTES
+
+const slug = (p) => (p.replace(/^\/|\/$/g, '') || 'home').replace(/[^a-z0-9]+/gi, '-')
+
+const PASS = '\x1b[32m✓\x1b[0m'
+const FAIL = '\x1b[31m✗\x1b[0m'
+
+async function main() {
+  await mkdir(shotDir, { recursive: true })
+  const browser = await chromium.launch({
+    args: ['--no-sandbox'],
+    ...(CHROME ? { executablePath: CHROME } : {}),
+  })
+  const context = await browser.newContext({ viewport: VIEWPORT })
+  let failures = 0
+
+  for (const path of targets) {
+    const rel = path.startsWith('/') ? path : `/${path}`
+    // Only a real scheme counts as absolute — otherwise a route like
+    // `http-status/` would be mistaken for a URL and crash `new URL()`.
+    const url = /^https?:\/\//.test(path) ? path : `${BASE_URL}${rel}`
+    // Classify by the target's own origin, not BASE_URL — an absolute-URL
+    // arg has its own origin, and BASE_URL wouldn't match it.
+    const origin = new URL(url).origin
+    const sameOrigin = (u) => {
+      try {
+        return new URL(u).origin === origin
+      } catch {
+        return false
+      }
+    }
+    const page = await context.newPage()
+    const pageErrors = []
+    const localFails = [] // same-origin resource failures — real bugs
+    const extBlocks = [] // third-party hosts blocked by the sandbox — informational
+    page.on('pageerror', (e) => pageErrors.push(String(e)))
+    page.on('requestfailed', (r) => {
+      const err = r.failure()?.errorText || ''
+      if (err.includes('ERR_ABORTED')) return // aborted <Link> prefetches are normal
+      if (sameOrigin(r.url())) localFails.push(`${r.url()} (${err})`)
+      else extBlocks.push(r.url())
+    })
+    page.on('response', (r) => {
+      if (sameOrigin(r.url()) && r.status() >= 400)
+        localFails.push(`${r.url()} (HTTP ${r.status()})`)
+    })
+
+    const shot = resolve(shotDir, `${slug(path)}.png`)
+    const shotRel = relative(process.cwd(), shot)
+    let ok = true
+    let detail = ''
+    try {
+      const res = await page.goto(url, { waitUntil: 'load', timeout: 30000 })
+      // Best-effort quiet-network wait: blocked third-party embeds can keep
+      // the network busy indefinitely, so cap it instead of failing on it.
+      await page.waitForLoadState('networkidle', { timeout: 5000 }).catch(() => {})
+      const status = res?.status() ?? 0
+      if (status >= 400) {
+        ok = false
+        detail = `HTTP ${status}`
+      }
+      if (EXPECT && !(await page.content()).includes(EXPECT)) {
+        ok = false
+        detail = `${detail} missing text "${EXPECT}"`.trim()
+      }
+      await page.screenshot({ path: shot, fullPage: true })
+      if (pageErrors.length) {
+        ok = false
+        detail = `${detail} pageerror: ${pageErrors[0]}`.trim()
+      }
+      if (localFails.length) {
+        ok = false
+        detail = `${detail} same-origin fail: ${localFails[0]}`.trim()
+      }
+    } catch (e) {
+      ok = false
+      detail = String(e).split('\n')[0]
+      // Best-effort artifact even when navigation failed, so the printed
+      // screenshot path points at something on a failing route.
+      await page.screenshot({ path: shot, fullPage: true }).catch(() => {})
+    }
+
+    if (!ok) failures++
+    const note = extBlocks.length ? ` (${extBlocks.length} third-party blocked)` : ''
+    process.stdout.write(
+      `${ok ? PASS : FAIL} ${path}${detail ? ` — ${detail}` : ''}${note} -> ${shotRel}\n`
+    )
+    await page.close()
+  }
+
+  await browser.close()
+  process.stdout.write(
+    `\n${failures ? FAIL : PASS} ${targets.length - failures}/${targets.length} routes clean\n`
+  )
+  // Set exitCode rather than process.exit() so stdout flushes fully first.
+  process.exitCode = failures ? 1 : 0
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exitCode = 1
+})


### PR DESCRIPTION
## What

Adds the universal **`run-site`** skill (`.claude/skills/run-site/`) to ffcadmin.org — build the static export, serve `out/`, and drive it with headless Chromium for smoke-testing + screenshots. Part of the cross-repo effort to make `run-site` available in every FFC website repo.

## Files

- `.claude/skills/run-site/driver.mjs` — Playwright-Chromium harness (imports `chromium` from `@playwright/test`, points at the container's pre-installed browser, classifies same-origin failures as real vs. third-party blocked as informational).
- `.claude/skills/run-site/SKILL.md` — agent-facing man page. Serve step uses `npx serve out -l 3000` because this repo has **no `preview` script** (`next start` doesn't serve an `output: 'export'` build).
- `.claude/skills/run-site/.gitignore` — screenshots not committed.

## Verified in-container

`npm install` → `npm run build` (with the `generate-sites-alerts.mjs` prestep) → `npx serve out` → `node .claude/skills/run-site/driver.mjs` → **1/1 route clean**, homepage screenshot rendered.

ffcadmin.org already carries the standard admin agent set (dns-audit, onboarding, pr-reviewer, site-health, cross-repo-sync, copilot-review-cycle), so this PR only adds the missing `run-site` skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8MTPYKQ1FDQbuoXGKYjfW)_