### PR TITLE
feat(gate3): add semi-automated Gate-3 validation workflow

### DIFF
--- a/.github/workflows/gate3-validate.yml
+++ b/.github/workflows/gate3-validate.yml
@@ -1,0 +1,59 @@
+name: Gate 3 Auto-Validation
+
+# Semi-automates the Gate-3 "website validated" checklist
+# (docs/application-prerequisites-inventory.md §4b): dispatch with a
+# website-provisioning work-order issue number and the workflow runs the
+# machine-checkable items against the issue's "Live site:" URL, then posts a
+# PASS/FAIL/MANUAL verdict table as an issue comment. It never ticks boxes —
+# the sponsoring admin still ticks each checklist box on the work order.
+#
+# Uses the plain GITHUB_TOKEN (issues: write) — no environment gate needed
+# since it only reads public pages and comments on issues in this repo.
+
+on:
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: 'Work-order issue number (reads its "Live site:" URL)'
+        required: true
+        type: string
+      url:
+        description: 'Optional explicit URL (overrides the issue body URL)'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      # The script is dependency-free (plain node fetch), so no pnpm install.
+      - name: Run Gate-3 checks
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          ISSUE: ${{ inputs.issue_number }}
+          URL: ${{ inputs.url }}
+        run: |
+          set -o pipefail
+          if [ -n "$URL" ]; then
+            node scripts/gate3-validate.mjs --issue "$ISSUE" --url "$URL" | tee verdict.md
+          else
+            node scripts/gate3-validate.mjs --issue "$ISSUE" | tee verdict.md
+          fi
+
+      - name: Post verdict as issue comment
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE: ${{ inputs.issue_number }}
+        run: gh issue comment "$ISSUE" --repo "$GITHUB_REPOSITORY" --body-file verdict.md

--- a/__tests__/gate3-validate.test.js
+++ b/__tests__/gate3-validate.test.js
@@ -1,0 +1,262 @@
+/**
+ * Unit tests for the Gate-3 auto-validation checks (`scripts/gate3-validate.mjs`).
+ *
+ * Exercises every check function with a mocked `fetch` (no network) and locks
+ * in the verdict-table contract: automated Section-4b items report PASS/FAIL,
+ * human-judgment items always stay MANUAL, and the "Live site:" extraction
+ * matches the roadmap generator's marker format.
+ */
+
+let liveUrlFrom,
+  fetchIssueBody,
+  checkHttp,
+  checkHost,
+  checkFooter,
+  checkViewport,
+  extractRootRelativeRefs,
+  checkAssets,
+  runChecks,
+  buildVerdictRows,
+  buildVerdictTable
+
+beforeAll(async () => {
+  const mod = await import('../scripts/gate3-validate.mjs')
+  liveUrlFrom = mod.liveUrlFrom
+  fetchIssueBody = mod.fetchIssueBody
+  checkHttp = mod.checkHttp
+  checkHost = mod.checkHost
+  checkFooter = mod.checkFooter
+  checkViewport = mod.checkViewport
+  extractRootRelativeRefs = mod.extractRootRelativeRefs
+  checkAssets = mod.checkAssets
+  runChecks = mod.runChecks
+  buildVerdictRows = mod.buildVerdictRows
+  buildVerdictTable = mod.buildVerdictTable
+})
+
+const GOOD_HTML = `<!doctype html><html><head>
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Example Charity</title></head>
+<body><main>Welcome</main>
+<footer>Hosted by <a href="https://freeforcharity.org">Free For Charity</a>
+Example Charity Inc. EIN: 12-3456789</footer></body></html>`
+
+const mockResponse = ({ status = 200, url = '', body = '' } = {}) => ({
+  ok: status >= 200 && status < 300,
+  status,
+  url,
+  text: async () => body,
+  json: async () => JSON.parse(body || '{}'),
+})
+
+describe('liveUrlFrom', () => {
+  it('extracts the marked Live site URL (roadmap-generator format)', () => {
+    expect(liveUrlFrom('intro\nLive site: https://freeforcharity.github.io/FFC-EX-x/\n')).toBe(
+      'https://freeforcharity.github.io/FFC-EX-x/'
+    )
+    expect(liveUrlFrom('- Live URL: http://example.org/page')).toBe('http://example.org/page')
+  })
+
+  it('ignores unmarked links and the unfilled stub placeholder', () => {
+    expect(liveUrlFrom('See https://www.guidestar.org/profile/12-3456789')).toBeUndefined()
+    expect(
+      liveUrlFrom('Live site: (paste the https GitHub Pages URL here once the site loads)')
+    ).toBeUndefined()
+    expect(liveUrlFrom(null)).toBeUndefined()
+  })
+})
+
+describe('fetchIssueBody', () => {
+  it('requests the issue via the REST API with the token and returns the body', async () => {
+    const fetchFn = jest.fn(async () => mockResponse({ body: '{"body":"Live site: https://x/"}' }))
+    const body = await fetchIssueBody('FreeForCharity/FFC-IN-ffcadmin.org', 42, 'tok', fetchFn)
+    expect(body).toBe('Live site: https://x/')
+    const [url, init] = fetchFn.mock.calls[0]
+    expect(url).toBe('https://api.github.com/repos/FreeForCharity/FFC-IN-ffcadmin.org/issues/42')
+    expect(init.headers.Authorization).toBe('Bearer tok')
+  })
+
+  it('throws on a non-2xx API response', async () => {
+    const fetchFn = jest.fn(async () => mockResponse({ status: 404 }))
+    await expect(fetchIssueBody('o/r', 1, undefined, fetchFn)).rejects.toThrow('404')
+  })
+})
+
+describe('checkHttp', () => {
+  it('passes on HTTP 200 and captures the final URL and html', async () => {
+    const fetchFn = jest.fn(async () =>
+      mockResponse({ status: 200, url: 'https://o.github.io/r/', body: GOOD_HTML })
+    )
+    const res = await checkHttp('https://o.github.io/r', fetchFn)
+    expect(res.ok).toBe(true)
+    expect(res.finalUrl).toBe('https://o.github.io/r/')
+    expect(res.html).toContain('Free For Charity')
+  })
+
+  it('fails on non-200 status', async () => {
+    const fetchFn = jest.fn(async () => mockResponse({ status: 404 }))
+    const res = await checkHttp('https://o.github.io/r/', fetchFn)
+    expect(res.ok).toBe(false)
+    expect(res.status).toBe(404)
+  })
+
+  it('fails (not throws) on redirect loops / fetch errors', async () => {
+    const fetchFn = jest.fn(async () => {
+      throw new Error('redirect count exceeded')
+    })
+    const res = await checkHttp('https://loop.example/', fetchFn)
+    expect(res.ok).toBe(false)
+    expect(res.error).toMatch(/redirect count exceeded/)
+  })
+})
+
+describe('checkHost', () => {
+  it('recognizes github.io staging hosts', () => {
+    expect(checkHost('https://freeforcharity.github.io/FFC-EX-x/').isGithubIo).toBe(true)
+  })
+
+  it('flags custom domains as non-staging', () => {
+    const res = checkHost('https://examplecharity.org/')
+    expect(res.isGithubIo).toBe(false)
+    expect(res.host).toBe('examplecharity.org')
+  })
+
+  it('handles unparseable URLs', () => {
+    expect(checkHost('not a url').ok).toBe(false)
+  })
+})
+
+describe('checkFooter', () => {
+  it('passes when brand text, freeforcharity.org link, and EIN are all present', () => {
+    expect(checkFooter(GOOD_HTML).ok).toBe(true)
+  })
+
+  it('accepts EIN without a dash and compact brand spelling', () => {
+    const html = 'FreeForCharity — freeforcharity.org — EIN 123456789'
+    const res = checkFooter(html)
+    expect(res).toMatchObject({ ok: true, brand: true, link: true, ein: true })
+  })
+
+  it('reports which markers are missing', () => {
+    const res = checkFooter('<footer>Some Charity, EIN: 12-3456789</footer>')
+    expect(res.ok).toBe(false)
+    expect(res.brand).toBe(false)
+    expect(res.link).toBe(false)
+    expect(res.ein).toBe(true)
+  })
+})
+
+describe('checkViewport', () => {
+  it('detects the viewport meta tag', () => {
+    expect(checkViewport(GOOD_HTML).ok).toBe(true)
+    expect(checkViewport('<head><title>x</title></head>').ok).toBe(false)
+  })
+})
+
+describe('extractRootRelativeRefs / checkAssets', () => {
+  const HTML = `<link rel="stylesheet" href="/styles.css" />
+    <script src="/app.js"></script>
+    <img src="/img/logo.png" /><img src="/img/logo.png" />
+    <a href="/FFC-EX-x/about/">ok</a>
+    <script src="//cdn.example.com/x.js"></script>
+    <a href="https://example.org/abs">abs</a>`
+
+  it('collects deduped root-relative refs, excluding protocol-relative and absolute', () => {
+    const refs = extractRootRelativeRefs(HTML)
+    expect(refs).toEqual(['/styles.css', '/app.js', '/img/logo.png', '/FFC-EX-x/about/'])
+  })
+
+  it('fails when a root-relative asset 404s (broken basePath signal)', async () => {
+    const fetchFn = jest.fn(async (url) =>
+      mockResponse({ status: url.endsWith('/styles.css') ? 404 : 200, url })
+    )
+    const res = await checkAssets(HTML, 'https://o.github.io/FFC-EX-x/', fetchFn)
+    expect(res.ok).toBe(false)
+    expect(res.broken).toEqual(['/styles.css'])
+    // Root-relative refs must resolve against the ORIGIN, not the basePath.
+    expect(fetchFn).toHaveBeenCalledWith('https://o.github.io/styles.css', expect.anything())
+  })
+
+  it('checks at most 10 assets', async () => {
+    const many = Array.from({ length: 15 }, (_, i) => `<img src="/a${i}.png">`).join('')
+    const fetchFn = jest.fn(async (url) => mockResponse({ status: 200, url }))
+    const res = await checkAssets(many, 'https://o.github.io/', fetchFn)
+    expect(res.checked).toBe(10)
+    expect(fetchFn).toHaveBeenCalledTimes(10)
+  })
+
+  it('passes trivially when the page has no root-relative refs', async () => {
+    const fetchFn = jest.fn()
+    const res = await checkAssets('<a href="https://x.org/">x</a>', 'https://o.github.io/', fetchFn)
+    expect(res.ok).toBe(true)
+    expect(fetchFn).not.toHaveBeenCalled()
+  })
+})
+
+describe('verdict table (Section-4b mapping)', () => {
+  const goodFetch = (finalUrl) =>
+    jest.fn(async (url, init = {}) =>
+      init.method === 'HEAD'
+        ? mockResponse({ status: 200, url })
+        : mockResponse({ status: 200, url: finalUrl, body: GOOD_HTML })
+    )
+
+  it('marks automated items PASS and human-judgment items MANUAL on a healthy staging site', async () => {
+    const url = 'https://freeforcharity.github.io/FFC-EX-x/'
+    const results = await runChecks(url, goodFetch(url))
+    const rows = buildVerdictRows(results)
+    const byItem = Object.fromEntries(rows.map((r) => [r.item, r.status]))
+
+    expect(byItem["CI green on the charity's FFC-EX repo"]).toBe('MANUAL')
+    expect(byItem['Site loads at its GitHub Pages URL (HTTP 200, no redirect loops)']).toBe('PASS')
+    expect(byItem['FFC-standard footer present and populated']).toBe('PASS')
+    expect(byItem['All required sections/pages present per the chosen template']).toBe('MANUAL')
+    expect(byItem['Mobile responsive (spot-check at 375px)']).toBe('PASS')
+    expect(byItem['No browser console errors on any page']).toBe('MANUAL')
+    expect(byItem['Accessibility pass (axe clean or Lighthouse a11y ≥ 90)']).toBe('MANUAL')
+    expect(byItem['Content reviewed and approved by the charity']).toBe('MANUAL')
+    expect(byItem['basePath sanity (root-relative asset refs resolve)']).toBe('PASS')
+  })
+
+  it('notes a custom domain on the site-loads row', async () => {
+    const url = 'https://examplecharity.org/'
+    const results = await runChecks(url, goodFetch(url))
+    const row = buildVerdictRows(results).find((r) => r.item.startsWith('Site loads'))
+    expect(row.status).toBe('PASS')
+    expect(row.detail).toMatch(/custom domain/)
+  })
+
+  it('fails dependent rows when the page does not load', async () => {
+    const fetchFn = jest.fn(async () => mockResponse({ status: 404 }))
+    const results = await runChecks('https://o.github.io/missing/', fetchFn)
+    const rows = buildVerdictRows(results)
+    for (const item of ['Site loads', 'FFC-standard footer', 'Mobile responsive', 'basePath']) {
+      expect(rows.find((r) => r.item.startsWith(item)).status).toBe('FAIL')
+    }
+    // MANUAL items stay MANUAL regardless of load failures.
+    expect(rows.find((r) => r.item.startsWith('Content reviewed')).status).toBe('MANUAL')
+  })
+
+  it('renders a markdown table with a failure summary line', async () => {
+    const fetchFn = jest.fn(async (url, init = {}) =>
+      init.method === 'HEAD'
+        ? mockResponse({ status: 200, url })
+        : mockResponse({ status: 200, url, body: '<html><body>no footer</body></html>' })
+    )
+    const results = await runChecks('https://o.github.io/FFC-EX-x/', fetchFn)
+    const md = buildVerdictTable(results, { issueNumber: 123 })
+    expect(md).toContain('## Gate-3 auto-validation')
+    expect(md).toContain('work order #123')
+    expect(md).toContain('| Gate-3 item | Status | Detail |')
+    expect(md).toMatch(/automated check\(s\) FAILED/)
+    expect(md).toContain('Missing: "Free For Charity" text, freeforcharity.org link, EIN')
+  })
+
+  it('renders the all-clear summary when every automated check passes', async () => {
+    const url = 'https://freeforcharity.github.io/FFC-EX-x/'
+    const results = await runChecks(url, goodFetch(url))
+    const md = buildVerdictTable(results)
+    expect(md).toContain('**All automated checks passed.**')
+    expect(md).toMatch(/\d+ item\(s\) remain MANUAL/)
+  })
+})

--- a/docs/application-prerequisites-inventory.md
+++ b/docs/application-prerequisites-inventory.md
@@ -922,6 +922,26 @@ A charity's website is **validated** on its GitHub Pages default URL when
 Section 4a). Partial completion is not validated: the domain order form's
 attestation that "the website is validated" refers to this checklist.
 
+### Auto-validation (semi-automated)
+
+The machine-checkable subset of this checklist can be run automatically:
+dispatch the **Gate 3 Auto-Validation** workflow
+(`.github/workflows/gate3-validate.yml`, Actions tab → "Run workflow") with
+the work-order issue number. It reads the issue's `Live site:` URL, runs
+`scripts/gate3-validate.mjs` against the live page, and posts a
+PASS/FAIL/MANUAL verdict table as a comment on the work order.
+
+**What it covers:** HTTP 200 (redirect loops = FAIL), github.io staging-host
+sanity (custom domains are noted), the FFC footer markers (brand text,
+freeforcharity.org link, EIN), a viewport meta tag (mobile baseline only), and
+a broken-basePath scan (up to 10 root-relative asset refs checked for 404s).
+
+**What it does not cover:** CI status, required template sections, the full
+375px responsive spot-check, console errors, accessibility, and charity
+content approval — those rows are reported as MANUAL. The tool never ticks
+checklist boxes: the sponsoring admin (and, for content review, the charity)
+still ticks each box on the work order after verifying it.
+
 ---
 
 ## 5. Validation checks (FFC-run, after submission)

--- a/scripts/gate3-validate.mjs
+++ b/scripts/gate3-validate.mjs
@@ -1,0 +1,321 @@
+/**
+ * Gate-3 auto-validation (semi-automated Section-4b checklist).
+ *
+ * Given a website-provisioning work-order issue number (and/or an explicit
+ * URL), this script runs the machine-checkable subset of the Gate-3
+ * "website validated" checklist (docs/application-prerequisites-inventory.md
+ * §4b) against the charity's live site and emits a markdown verdict table:
+ *
+ *   - HTTP 200 on the "Live site:" URL (redirect loops / fetch errors = FAIL)
+ *   - Host sanity: github.io = staging (expected at Gate 3); custom domain noted
+ *   - FFC footer markers: "Free For Charity" text, freeforcharity.org link,
+ *     and an EIN pattern
+ *   - basePath sanity: up to 10 root-relative href/src asset refs fetched;
+ *     404s indicate a broken Next.js basePath
+ *   - viewport meta present (mobile baseline only)
+ *
+ * Items that need human judgment (content approval, accessibility, console
+ * errors, ...) are listed as MANUAL so reviewers see exactly what remains.
+ * The workflow .github/workflows/gate3-validate.yml posts the table as an
+ * issue comment. Plain node, no dependencies; network only to GitHub's REST
+ * API (issue lookup) and the target site.
+ *
+ * Usage:
+ *   node scripts/gate3-validate.mjs --issue 123 [--repo owner/name] [--url https://...]
+ *   node scripts/gate3-validate.mjs --url https://freeforcharity.github.io/FFC-EX-example/
+ */
+import { pathToFileURL } from 'url'
+
+export const DEFAULT_REPO = 'FreeForCharity/FFC-IN-ffcadmin.org'
+const MAX_ASSET_CHECKS = 10
+
+/**
+ * Extract the live site URL only when explicitly marked ("Live site: ...").
+ * Mirrors liveUrlFrom() in scripts/generate-roadmap-data.ts so both tools
+ * read the same work-order field.
+ */
+export function liveUrlFrom(body) {
+  if (!body) return undefined
+  const match = body.match(/^[ \t>*-]*live\s*(?:site|url)\s*[:：]\s*(https?:\/\/\S+)/im)
+  return match ? match[1] : undefined
+}
+
+/** Fetch the work-order issue body via the GitHub REST API. */
+export async function fetchIssueBody(repo, issueNumber, token, fetchFn = fetch) {
+  const res = await fetchFn(`https://api.github.com/repos/${repo}/issues/${issueNumber}`, {
+    headers: {
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+  })
+  if (!res.ok) throw new Error(`GitHub API issues/${issueNumber} -> ${res.status}`)
+  const issue = await res.json()
+  return issue.body || ''
+}
+
+/**
+ * HTTP check: 200 after following redirects. node's fetch throws on a
+ * redirect loop ("redirect count exceeded"), which we surface as a FAIL
+ * rather than a crash. Returns { ok, status, finalUrl, error?, html? }.
+ */
+export async function checkHttp(url, fetchFn = fetch) {
+  try {
+    const res = await fetchFn(url, { redirect: 'follow' })
+    const html = res.ok ? await res.text() : ''
+    return { ok: res.ok && res.status === 200, status: res.status, finalUrl: res.url || url, html }
+  } catch (err) {
+    return { ok: false, status: 0, finalUrl: url, html: '', error: err?.message || String(err) }
+  }
+}
+
+/** Host sanity: github.io is the expected Gate-3 staging host. */
+export function checkHost(url) {
+  try {
+    const host = new URL(url).hostname.toLowerCase()
+    const isGithubIo = host === 'github.io' || host.endsWith('.github.io')
+    return { ok: true, isGithubIo, host }
+  } catch {
+    return { ok: false, isGithubIo: false, host: '' }
+  }
+}
+
+/**
+ * FFC footer markers: brand text, a freeforcharity.org link, and an EIN.
+ * All three must be present for a PASS.
+ */
+export function checkFooter(html) {
+  const brand = /Free ?For ?Charity/i.test(html)
+  const link = /freeforcharity\.org/i.test(html)
+  const ein = /EIN[:\s]*\d{2}-?\d{7}/i.test(html)
+  return { ok: brand && link && ein, brand, link, ein }
+}
+
+/** Viewport meta present (mobile baseline only — not a full responsive check). */
+export function checkViewport(html) {
+  return { ok: /<meta[^>]+name=["']viewport["']/i.test(html) }
+}
+
+/**
+ * Collect root-relative href/src refs ("/style.css") from the page. On a
+ * GitHub Pages *project* site these resolve to the origin root instead of the
+ * repo's basePath, so 404s here are the classic broken-basePath signal.
+ * Protocol-relative ("//cdn...") refs are excluded. Deduped, capped later.
+ */
+export function extractRootRelativeRefs(html) {
+  const refs = new Set()
+  const re = /(?:href|src)=["'](\/[^"'\s>]*)["']/gi
+  let m
+  while ((m = re.exec(html)) !== null) {
+    const ref = m[1]
+    if (!ref.startsWith('//')) refs.add(ref)
+  }
+  return [...refs]
+}
+
+/**
+ * basePath sanity: fetch up to MAX_ASSET_CHECKS root-relative refs resolved
+ * against the final page URL and report any that 404. No refs = trivially ok
+ * (a correctly basePath'd export emits repo-prefixed absolute refs).
+ */
+export async function checkAssets(html, baseUrl, fetchFn = fetch) {
+  const refs = extractRootRelativeRefs(html).slice(0, MAX_ASSET_CHECKS)
+  const broken = []
+  for (const ref of refs) {
+    try {
+      const target = new URL(ref, baseUrl).href
+      const res = await fetchFn(target, { method: 'HEAD', redirect: 'follow' })
+      if (res.status === 404) broken.push(ref)
+    } catch {
+      broken.push(ref)
+    }
+  }
+  return { ok: broken.length === 0, checked: refs.length, broken }
+}
+
+/** Run every automated check against a live URL. */
+export async function runChecks(url, fetchFn = fetch) {
+  const http = await checkHttp(url, fetchFn)
+  const host = checkHost(http.finalUrl || url)
+  const footer = checkFooter(http.html)
+  const viewport = checkViewport(http.html)
+  const assets = http.ok
+    ? await checkAssets(http.html, http.finalUrl || url, fetchFn)
+    : { ok: false, checked: 0, broken: [] }
+  return { url, http, host, footer, viewport, assets }
+}
+
+const pass = (detail) => ({ status: 'PASS', detail })
+const fail = (detail) => ({ status: 'FAIL', detail })
+const manual = (detail) => ({ status: 'MANUAL', detail })
+
+/**
+ * Map check results onto the Section-4b checklist (same order and wording
+ * family as VALIDATION_CHECKLIST in scripts/lib/intake-issues.mjs). Items the
+ * script cannot verify stay MANUAL so humans see exactly what remains.
+ */
+export function buildVerdictRows(results) {
+  const { http, host, footer, viewport, assets } = results
+  const rows = []
+
+  rows.push({
+    item: "CI green on the charity's FFC-EX repo",
+    ...manual('Check the latest default-branch run on the FFC-EX repo.'),
+  })
+
+  if (!http.ok) {
+    rows.push({
+      item: 'Site loads at its GitHub Pages URL (HTTP 200, no redirect loops)',
+      ...fail(
+        http.error
+          ? `Fetch failed: ${http.error} (redirect loop or unreachable).`
+          : `HTTP ${http.status} at ${results.url}`
+      ),
+    })
+  } else {
+    const hostNote = host.isGithubIo
+      ? `HTTP 200 on staging host \`${host.host}\`.`
+      : `HTTP 200, but host \`${host.host}\` is a custom domain — Gate 3 validates the github.io staging URL.`
+    rows.push({
+      item: 'Site loads at its GitHub Pages URL (HTTP 200, no redirect loops)',
+      ...pass(hostNote),
+    })
+  }
+
+  if (!http.ok) {
+    rows.push({
+      item: 'FFC-standard footer present and populated',
+      ...fail('Page did not load; footer not checked.'),
+    })
+  } else {
+    const missing = []
+    if (!footer.brand) missing.push('"Free For Charity" text')
+    if (!footer.link) missing.push('freeforcharity.org link')
+    if (!footer.ein) missing.push('EIN')
+    rows.push({
+      item: 'FFC-standard footer present and populated',
+      ...(footer.ok
+        ? pass('Brand text, freeforcharity.org link, and EIN all found.')
+        : fail(`Missing: ${missing.join(', ')}. (Policy/social links still need a human check.)`)),
+    })
+  }
+
+  rows.push({
+    item: 'All required sections/pages present per the chosen template',
+    ...manual('Compare the site against the chosen template section list.'),
+  })
+
+  if (!http.ok) {
+    rows.push({
+      item: 'Mobile responsive (spot-check at 375px)',
+      ...fail('Page did not load; viewport meta not checked.'),
+    })
+  } else {
+    rows.push({
+      item: 'Mobile responsive (spot-check at 375px)',
+      ...(viewport.ok
+        ? pass('Viewport meta present (baseline only — the 375px spot-check is still manual).')
+        : fail('No viewport meta tag — the page cannot render responsively.')),
+    })
+  }
+
+  rows.push({
+    item: 'No browser console errors on any page',
+    ...manual('Open DevTools on each page and confirm a clean console.'),
+  })
+  rows.push({
+    item: 'Accessibility pass (axe clean or Lighthouse a11y ≥ 90)',
+    ...manual('Run axe or Lighthouse against the staging URL.'),
+  })
+  rows.push({
+    item: 'Content reviewed and approved by the charity',
+    ...manual('The charity ticks this box on the work order.'),
+  })
+
+  // Auxiliary automated signal (not a Section-4b line item, but a common
+  // failure mode on project-site staging URLs): broken basePath asset refs.
+  rows.push({
+    item: 'basePath sanity (root-relative asset refs resolve)',
+    ...(!http.ok
+      ? fail('Page did not load; assets not checked.')
+      : assets.ok
+        ? pass(
+            assets.checked === 0
+              ? 'No root-relative asset refs found (basePath-prefixed refs expected).'
+              : `${assets.checked} root-relative ref(s) checked, none 404.`
+          )
+        : fail(`404 on: ${assets.broken.join(', ')} — likely a broken Next.js basePath.`)),
+  })
+
+  return rows
+}
+
+const STATUS_EMOJI = { PASS: '✅', FAIL: '❌', MANUAL: '📝' }
+
+/** Render the verdict rows as the markdown comment body. */
+export function buildVerdictTable(results, { issueNumber } = {}) {
+  const rows = buildVerdictRows(results)
+  const failed = rows.filter((r) => r.status === 'FAIL').length
+  const manualLeft = rows.filter((r) => r.status === 'MANUAL').length
+  const lines = [
+    '## Gate-3 auto-validation',
+    '',
+    `Automated check of the machine-verifiable [Section-4b](https://github.com/${DEFAULT_REPO}/blob/main/docs/application-prerequisites-inventory.md#4b-the-website-validated-checklist-gate-3-definition) items against ${results.url}${issueNumber ? ` (work order #${issueNumber})` : ''}.`,
+    '',
+    '| Gate-3 item | Status | Detail |',
+    '| --- | --- | --- |',
+    ...rows.map((r) => `| ${r.item} | ${STATUS_EMOJI[r.status]} ${r.status} | ${r.detail} |`),
+    '',
+    failed > 0
+      ? `**${failed} automated check(s) FAILED** — fix these before ticking the corresponding boxes.`
+      : '**All automated checks passed.**',
+    `${manualLeft} item(s) remain MANUAL — this tool does not replace the human checklist; tick boxes on the work order as each item is verified.`,
+    '',
+    '_Posted by `.github/workflows/gate3-validate.yml` (`scripts/gate3-validate.mjs`)._',
+  ]
+  return lines.join('\n')
+}
+
+async function main() {
+  const args = process.argv.slice(2)
+  const opt = (name) => {
+    const i = args.indexOf(`--${name}`)
+    return i !== -1 ? args[i + 1] : undefined
+  }
+  const issueNumber = opt('issue')
+  let url = opt('url')
+  const repo = opt('repo') || process.env.GITHUB_REPOSITORY || DEFAULT_REPO
+
+  if (!url && !issueNumber) {
+    console.error('Usage: node scripts/gate3-validate.mjs --issue <number> [--url <url>]')
+    process.exit(2)
+  }
+  if (!url) {
+    const body = await fetchIssueBody(repo, issueNumber, process.env.GITHUB_TOKEN)
+    url = liveUrlFrom(body)
+    if (!url) {
+      // Still a useful outcome: tell the humans the work order has no URL yet.
+      console.log(
+        [
+          '## Gate-3 auto-validation',
+          '',
+          `No \`Live site:\` URL found on work order #${issueNumber} — nothing to validate yet.`,
+          'Paste the https GitHub Pages URL after "Live site:" on the issue body and re-run.',
+          '',
+          '_Posted by `.github/workflows/gate3-validate.yml` (`scripts/gate3-validate.mjs`)._',
+        ].join('\n')
+      )
+      return
+    }
+  }
+
+  const results = await runChecks(url)
+  console.log(buildVerdictTable(results, { issueNumber }))
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((err) => {
+    console.error(err)
+    process.exit(1)
+  })
+}


### PR DESCRIPTION
## Summary

Semi-automates the Gate-3 "website validated" checklist (docs §4b). A new `workflow_dispatch` workflow takes a website-provisioning work-order issue number, reads the issue's `Live site:` URL, runs the machine-checkable checks against the live site, and posts a PASS/FAIL/MANUAL verdict table as an issue comment — turning the fully-manual validation checklist into a semi-automated one. It never ticks checklist boxes; humans still tick each box on the work order.

- **`scripts/gate3-validate.mjs`** — dependency-free node script. Checks: HTTP 200 (redirect loops/fetch errors = FAIL), github.io staging-host sanity (custom domains noted), FFC footer markers (`Free For Charity` text + freeforcharity.org link + EIN pattern), viewport meta (mobile baseline only), and basePath sanity (up to 10 root-relative `href`/`src` refs HEAD-checked for 404s — the classic broken-Next.js-basePath signal). `Live site:` extraction mirrors `liveUrlFrom()` in `scripts/generate-roadmap-data.ts`. Human-judgment items (CI status, template sections, 375px spot-check, console errors, accessibility, charity content approval) are always listed MANUAL so reviewers see what remains.
- **`.github/workflows/gate3-validate.yml`** — `workflow_dispatch` (inputs: `issue_number`, optional `url` override), plain `GITHUB_TOKEN` with `issues: write`, posts the verdict via `gh issue comment --body-file`. No schedule in v1; no environment gate needed since it only comments on issues in this repo.
- **`__tests__/gate3-validate.test.js`** — 23 unit tests with mocked `fetch` (no network), matching the `intake-issues.test.js` dynamic-import convention.
- **`docs/application-prerequisites-inventory.md` §4b** — new "Auto-validation (semi-automated)" subsection: how to dispatch it and exactly what it does/doesn't cover.

## Test plan

- [x] `pnpm exec jest __tests__/gate3-validate.test.js` — 23/23 pass
- [x] Full suite after `pnpm build`: 926/927 pass (sole failure is the known Windows-worktree husky executable-bit test, unrelated)
- [x] `pnpm run format:check`, `pnpm run lint`, `pnpm run type-check` — clean
- [ ] After merge: dispatch **Gate 3 Auto-Validation** against a real work order and confirm the verdict comment lands

Refs FreeForCharity/FFC-Cloudflare-Automation#697 (overnight block 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
