### PR TITLE
feat(pipeline): derive validated stage from the Gate-3 checklist

### DIFF
--- a/__tests__/pipeline-stage.test.ts
+++ b/__tests__/pipeline-stage.test.ts
@@ -1,4 +1,10 @@
-import { deriveStage, groupByStage, PIPELINE_STAGES } from '@/app/pipeline/pipelineData'
+import {
+  deriveStage,
+  groupByStage,
+  parseValidationChecklist,
+  validationProgress,
+  PIPELINE_STAGES,
+} from '@/app/pipeline/pipelineData'
 import type { RoadmapEntry, RoadmapStatus } from '@/app/roadmap/roadmapData'
 
 function entry(overrides: Partial<RoadmapEntry>): RoadmapEntry {
@@ -39,10 +45,78 @@ describe('deriveStage', () => {
     expect(deriveStage(entry({ status: 'active-build' }))).toBe('building')
   })
 
-  it('a live site still on its GitHub Pages default URL is "validated"', () => {
+  it('a live site still on its GitHub Pages default URL is "validated" (no checklist data)', () => {
     const e = entry({
       status: 'live',
       liveUrl: 'https://freeforcharity.github.io/FFC-EX-example/',
+    })
+    expect(deriveStage(e)).toBe('validated')
+  })
+
+  it('a fully ticked Gate-3 checklist means "validated"', () => {
+    // With the checklist all ticked, the entry is validated even without any
+    // live URL recorded yet — the checklist is the objective Gate-3 signal.
+    expect(deriveStage(entry({ status: 'live', validationTicked: 8, validationTotal: 8 }))).toBe(
+      'validated'
+    )
+    expect(
+      deriveStage(
+        entry({
+          status: 'live',
+          liveUrl: 'https://freeforcharity.github.io/FFC-EX-example/',
+          validationTicked: 8,
+          validationTotal: 8,
+        })
+      )
+    ).toBe('validated')
+  })
+
+  it('a partially ticked checklist keeps a live-labelled entry at "building"', () => {
+    // The label says live, but Gate 3 is objectively unfinished: the checklist
+    // wins over both the label and the github.io-URL heuristic.
+    const e = entry({
+      status: 'live',
+      liveUrl: 'https://freeforcharity.github.io/FFC-EX-example/',
+      validationTicked: 6,
+      validationTotal: 8,
+    })
+    expect(deriveStage(e)).toBe('building')
+  })
+
+  it('a fully ticked checklist promotes an in-build entry to "validated"', () => {
+    expect(
+      deriveStage(entry({ status: 'active-build', validationTicked: 8, validationTotal: 8 }))
+    ).toBe('validated')
+    expect(
+      deriveStage(entry({ status: 'sponsored', validationTicked: 8, validationTotal: 8 }))
+    ).toBe('validated')
+    // Mid-checklist builds stay at "building".
+    expect(
+      deriveStage(entry({ status: 'active-build', validationTicked: 3, validationTotal: 8 }))
+    ).toBe('building')
+  })
+
+  it('a live custom domain is "domain" regardless of checklist state', () => {
+    // The domain gate is past validation; a live custom domain is the
+    // observable signal that it was cleared.
+    expect(
+      deriveStage(
+        entry({
+          status: 'live',
+          liveUrl: 'https://example.org',
+          validationTicked: 8,
+          validationTotal: 8,
+        })
+      )
+    ).toBe('domain')
+  })
+
+  it('ignores degenerate checklist data (total 0) and falls back to the URL heuristic', () => {
+    const e = entry({
+      status: 'live',
+      liveUrl: 'https://freeforcharity.github.io/FFC-EX-example/',
+      validationTicked: 0,
+      validationTotal: 0,
     })
     expect(deriveStage(e)).toBe('validated')
   })
@@ -95,6 +169,112 @@ describe('deriveStage', () => {
       const stage = deriveStage(entry({ status }))
       expect(PIPELINE_STAGES.some((s) => s.id === stage)).toBe(true)
     }
+  })
+})
+
+describe('parseValidationChecklist (generator parsing)', () => {
+  const body = (items: string) =>
+    [
+      '_Auto-created from an FFC application for **Example Org**._',
+      '',
+      '### Charity name',
+      '',
+      'Example Org',
+      '',
+      '### Validation checklist (Gate 3)',
+      '',
+      '_All boxes ticked = **validated**._',
+      '',
+      items,
+      '',
+      'Live site: (paste the https GitHub Pages URL here once the site loads)',
+    ].join('\n')
+
+  it('counts ticked vs total items in the validation section', () => {
+    expect(
+      parseValidationChecklist(body('- [x] CI green\n- [X] Site loads\n- [ ] Footer'))
+    ).toEqual({
+      ticked: 2,
+      total: 3,
+    })
+    expect(parseValidationChecklist(body('- [ ] CI green\n- [ ] Site loads'))).toEqual({
+      ticked: 0,
+      total: 2,
+    })
+    expect(parseValidationChecklist(body('- [x] CI green\n- [x] Site loads'))).toEqual({
+      ticked: 2,
+      total: 2,
+    })
+  })
+
+  it('returns null for bodies without a checklist (backward compatibility)', () => {
+    expect(parseValidationChecklist(null)).toBeNull()
+    expect(parseValidationChecklist(undefined)).toBeNull()
+    expect(parseValidationChecklist('')).toBeNull()
+    // Pre-checklist stub: fields but no validation section.
+    expect(parseValidationChecklist('### Charity name\n\nExample Org\n')).toBeNull()
+    // A heading with no checkbox items under it is not a checklist.
+    expect(
+      parseValidationChecklist('### Validation checklist (Gate 3)\n\nnothing here\n')
+    ).toBeNull()
+  })
+
+  it('does not count checkboxes outside the validation section', () => {
+    const b = [
+      '### To-dos',
+      '',
+      '- [x] unrelated ticked box',
+      '',
+      '### Validation checklist (Gate 3)',
+      '',
+      '- [ ] CI green',
+      '- [x] Site loads',
+    ].join('\n')
+    expect(parseValidationChecklist(b)).toEqual({ ticked: 1, total: 2 })
+  })
+
+  it('stops at the next same-level heading and survives CRLF bodies', () => {
+    const b =
+      '### Validation checklist (Gate 3)\r\n\r\n- [x] CI green\r\n- [ ] Footer\r\n\r\n### Notes\r\n\r\n- [x] not part of the checklist\r\n'
+    expect(parseValidationChecklist(b)).toEqual({ ticked: 1, total: 2 })
+  })
+
+  it('parses the real work-order stub from intake-issues.mjs (contract test)', async () => {
+    // Read-only import of the stub generator: locks the generator-side parser
+    // to the exact body shape `stubBody` embeds (checklist last, unticked).
+    const { stubBody, VALIDATION_CHECKLIST } = await import('../scripts/lib/intake-issues.mjs')
+    const stub = stubBody(
+      { id: 'ffc-90', charityName: 'Example Org', serviceTier: 'Tier 3' },
+      'FreeForCharity/FFC-IN-ffcadmin.org'
+    )
+    expect(parseValidationChecklist(stub)).toEqual({
+      ticked: 0,
+      total: VALIDATION_CHECKLIST.length,
+    })
+    // Ticking boxes the way GitHub's checkbox UI does is reflected in the count.
+    const twoTicked = stub.replace('- [ ]', '- [x]').replace('- [ ]', '- [x]')
+    expect(parseValidationChecklist(twoTicked)).toEqual({
+      ticked: 2,
+      total: VALIDATION_CHECKLIST.length,
+    })
+  })
+})
+
+describe('validationProgress', () => {
+  it('returns the snapshot checklist counts when present', () => {
+    expect(validationProgress(entry({ validationTicked: 6, validationTotal: 8 }))).toEqual({
+      ticked: 6,
+      total: 8,
+    })
+  })
+
+  it('returns null for entries without checklist data or with a degenerate total', () => {
+    expect(validationProgress(entry({}))).toBeNull()
+    expect(validationProgress(entry({ validationTicked: 0, validationTotal: 0 }))).toBeNull()
+  })
+
+  it('treats a missing ticked count as zero', () => {
+    expect(validationProgress(entry({ validationTotal: 8 }))).toEqual({ ticked: 0, total: 8 })
   })
 })
 

--- a/scripts/generate-roadmap-data.ts
+++ b/scripts/generate-roadmap-data.ts
@@ -25,6 +25,7 @@ import { parse as parseCsv } from 'csv-parse/sync'
 import { computeReadiness } from '../src/lib/readiness/scoring'
 import { emptyIntake } from '../src/lib/readiness/defaults'
 import { parseIntakeIssue, parseIssueForm } from '../src/lib/readiness/parseIntake'
+import { parseValidationChecklist } from '../src/app/pipeline/pipelineData'
 import type {
   RoadmapData,
   RoadmapEntry,
@@ -180,6 +181,11 @@ function toEntry(issue: GhIssue): RoadmapEntry {
   // labelled status:live), so the portfolio dedup below can suppress the
   // matching domain even before the issue is flipped to live.
   const liveUrl = liveUrlFrom(issue.body)
+  // Gate-3 validation checklist progress (ticked/total) from the work-order
+  // body — lets the pipeline derive "validated" from the checklist itself
+  // instead of the github.io-URL heuristic. Null (omitted) for pre-checklist
+  // stubs, keeping the snapshot shape backward compatible.
+  const validation = parseValidationChecklist(issue.body)
   const form = parseIssueForm(issue.body ?? '')
   const candidUrl = cleanCandidUrl(form.get('candid / guidestar profile url'))
   const ein = cleanEin(form.get('ein'))
@@ -199,6 +205,9 @@ function toEntry(issue: GhIssue): RoadmapEntry {
     plusOne: issue.reactions?.['+1'] ?? 0,
     issueUrl: issue.html_url,
     ...(liveUrl ? { liveUrl } : {}),
+    ...(validation
+      ? { validationTicked: validation.ticked, validationTotal: validation.total }
+      : {}),
     ...(candidUrl ? { candidUrl } : {}),
     ...(ein ? { ein } : {}),
   }

--- a/src/app/pipeline/page.tsx
+++ b/src/app/pipeline/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 import Breadcrumbs from '@/components/Breadcrumbs'
 import { loadRoadmap } from '../roadmap/roadmapData'
-import { PIPELINE_STAGES, groupByStage } from './pipelineData'
+import { PIPELINE_STAGES, groupByStage, validationProgress } from './pipelineData'
 
 export const metadata: Metadata = {
   title: 'Charity Pipeline',
@@ -79,7 +79,19 @@ export default function PipelinePage() {
                     className="rounded-xl border border-gray-200 bg-white p-4"
                   >
                     <div className="font-semibold text-gray-900">{entry.charityName}</div>
-                    <div className="mt-1 text-sm text-gray-500">{stage.label}</div>
+                    <div className="mt-1 text-sm text-gray-500">
+                      {stage.label}
+                      {(() => {
+                        const progress = validationProgress(entry)
+                        // Gate-3 checklist progress for charities mid-checklist;
+                        // a complete checklist is already expressed by the stage.
+                        return progress && progress.ticked < progress.total ? (
+                          <span className="ml-2 rounded bg-amber-50 px-1.5 py-0.5 text-xs font-medium text-amber-700">
+                            validation {progress.ticked}/{progress.total}
+                          </span>
+                        ) : null
+                      })()}
+                    </div>
                     <div className="mt-2 flex flex-wrap gap-3 text-sm">
                       {entry.issueNumber > 0 && (
                         <a

--- a/src/app/pipeline/pipelineData.ts
+++ b/src/app/pipeline/pipelineData.ts
@@ -19,12 +19,16 @@
  *                conservative in-flight reading.
  * - building   — `status:sponsored` / `status:active-build`: the
  *                website-provisioning work order is being executed (Gate 3 in
- *                progress).
- * - validated  — `status:live` with a `github.io` live URL: the site passed
- *                validation on its free GitHub Pages default URL but has no
- *                custom domain yet. FUTURE WORK: derive this from the Gate 3
- *                validation checklist in the work order (or a dedicated
- *                `status:validated` label) instead of the URL heuristic.
+ *                progress). A live-labelled entry whose Gate-3 checklist is
+ *                only partially ticked also sits here — the checklist, not the
+ *                label, is the objective Gate-3 signal.
+ * - validated  — the Gate-3 validation checklist on the work order (embedded by
+ *                `scripts/lib/intake-issues.mjs` `stubBody`, parsed by
+ *                `scripts/generate-roadmap-data.ts` into
+ *                `validationTicked`/`validationTotal`) is FULLY ticked and the
+ *                site has no custom domain yet. Entries without checklist data
+ *                (pre-checklist stubs, portfolio rows) fall back to the older
+ *                heuristic: `status:live` with a `github.io` live URL.
  * - domain     — `status:live` with a custom-domain live URL (the WHMCS domain
  *                product isn't in the roadmap snapshot, so the live custom
  *                domain is the observable signal). `status:graduated` also
@@ -67,7 +71,7 @@ export const PIPELINE_STAGES: readonly PipelineStageInfo[] = [
     id: 'validated',
     label: 'Validated',
     description:
-      'Site validated on its free GitHub Pages URL — no custom domain yet. Cleared to order a domain (Gate 4).',
+      'Gate-3 validation checklist fully ticked on the work order — no custom domain yet. Cleared to order a domain (Gate 4).',
   },
   {
     id: 'domain',
@@ -92,29 +96,98 @@ function isGitHubPagesUrl(liveUrl: string): boolean {
   }
 }
 
+/** Ticked vs total items of a Gate-3 validation checklist. */
+export interface ValidationProgress {
+  ticked: number
+  total: number
+}
+
+/**
+ * Parse the Gate-3 validation checklist out of a work-order issue body.
+ *
+ * The checklist lives under the `### Validation checklist (Gate 3)` heading
+ * that `scripts/lib/intake-issues.mjs` (`stubBody`) embeds last in every
+ * work-order stub. The section runs from that heading to the next heading of
+ * the same-or-higher level (in practice: end of body). Returns the ticked/total
+ * counts, or `null` when the body has no checklist section or the section has
+ * no checkbox items — pre-checklist stubs and portfolio entries stay `null` so
+ * consumers can fall back to older heuristics.
+ *
+ * Used by `scripts/generate-roadmap-data.ts` at snapshot-generation time; kept
+ * here (fs-free) so the parsing contract is unit-testable alongside the stage
+ * derivation that consumes its output.
+ */
+export function parseValidationChecklist(
+  body: string | null | undefined
+): ValidationProgress | null {
+  if (!body) return null
+  const normalized = body.replace(/\r\n/g, '\n')
+  const headingMatch = /^(#{2,4})\s+Validation checklist.*$/im.exec(normalized)
+  if (!headingMatch) return null
+  const level = headingMatch[1].length
+  const rest = normalized.slice(headingMatch.index + headingMatch[0].length)
+  // Section ends at the next heading of the same or higher level, else at EOF.
+  const nextHeading = new RegExp(`^#{1,${level}}\\s`, 'm').exec(rest)
+  const section = nextHeading ? rest.slice(0, nextHeading.index) : rest
+  const boxes = section.match(/^\s*[-*+]\s+\[( |x|X)\]/gm) ?? []
+  if (boxes.length === 0) return null
+  const ticked = boxes.filter((b) => /\[[xX]\]$/.test(b)).length
+  return { ticked, total: boxes.length }
+}
+
+/**
+ * The entry's Gate-3 checklist progress, when the snapshot carries it.
+ * `null` for entries generated before the checklist fields existed (backward
+ * compatibility) and for portfolio/self entries that never had a work order.
+ */
+export function validationProgress(entry: RoadmapEntry): ValidationProgress | null {
+  if (typeof entry.validationTotal !== 'number' || entry.validationTotal <= 0) return null
+  return { ticked: entry.validationTicked ?? 0, total: entry.validationTotal }
+}
+
+/** True when the work order carries a checklist and every box is ticked. */
+function checklistComplete(entry: RoadmapEntry): boolean | null {
+  const progress = validationProgress(entry)
+  return progress ? progress.ticked >= progress.total : null
+}
+
 /**
  * Derive the journey gate a charity is at from its roadmap entry.
  * See the module comment for exactly which signals back each stage.
  */
 export function deriveStage(entry: RoadmapEntry): PipelineStage {
   switch (entry.status) {
+    case 'sponsored':
+    case 'active-build':
+      // A fully ticked Gate-3 checklist means the site is validated even if
+      // the status label hasn't been flipped yet — the checklist is the
+      // objective signal (docs Section 4b), the label follows it.
+      return checklistComplete(entry) === true ? 'validated' : 'building'
     case 'intake':
     case 'needs-info':
       return 'applied'
     case 'needs-admin':
     case 'on-hold':
       return 'approved'
-    case 'sponsored':
-    case 'active-build':
-      return 'building'
     case 'live':
     case 'graduated':
-      // Graduated is beyond every stage this data models; a live entry sits at
-      // "validated" until its live URL leaves the free github.io default.
-      if (entry.status === 'live' && entry.liveUrl && isGitHubPagesUrl(entry.liveUrl)) {
-        return 'validated'
+      // Graduated is beyond every stage this data models, and a live custom
+      // domain always means the domain gate was passed.
+      if (entry.status === 'graduated' || (entry.liveUrl && !isGitHubPagesUrl(entry.liveUrl))) {
+        return 'domain'
       }
-      return 'domain'
+      // No custom domain yet: the Gate-3 checklist decides validated vs still
+      // building. Entries without checklist data keep the older heuristic — a
+      // live entry on its github.io default URL counts as validated, and a
+      // live entry without any URL falls through to "domain" as before.
+      switch (checklistComplete(entry)) {
+        case true:
+          return 'validated'
+        case false:
+          return 'building'
+        default:
+          return entry.liveUrl ? 'validated' : 'domain'
+      }
     default:
       // The status union is exhaustive at compile time, but the entries come
       // from a generated JSON snapshot: a status label this build doesn't know

--- a/src/app/roadmap/roadmapData.ts
+++ b/src/app/roadmap/roadmapData.ts
@@ -48,6 +48,14 @@ export interface RoadmapEntry {
   plusOne: number
   issueUrl: string
   liveUrl?: string
+  /**
+   * Gate-3 validation checklist progress parsed from the work-order issue body
+   * (ticked / total items). Absent for entries whose issue predates the
+   * embedded checklist and for portfolio entries without a work order — the
+   * pipeline stage derivation falls back to its URL heuristic then.
+   */
+  validationTicked?: number
+  validationTotal?: number
   /** Public Candid/GuideStar profile URL (donor transparency), when supplied. */
   candidUrl?: string
   /** EIN (public for registered charities), when supplied. */


### PR DESCRIPTION
Refs FreeForCharity/FFC-Cloudflare-Automation#697 (overnight block 2)

## Summary

Wires the Gate-3 validation checklist (embedded in every work-order issue by `scripts/lib/intake-issues.mjs` `stubBody`) into the pipeline stage derivation, resolving the FUTURE WORK marker in `src/app/pipeline/pipelineData.ts`.

- **Generator** (`scripts/generate-roadmap-data.ts`): parses the `### Validation checklist (Gate 3)` section of each intake issue body via a new pure `parseValidationChecklist()` and emits optional `validationTicked` / `validationTotal` on roadmap entries. Entries without a checklist (pre-checklist stubs, portfolio rows) keep the existing shape — fully backward compatible.
- **Stage derivation** (`src/app/pipeline/pipelineData.ts`): `validated` = ALL checklist items ticked. A live-labelled entry mid-checklist sits at `building` (the checklist, not the label, is the objective Gate-3 signal); an in-build entry with a complete checklist is promoted to `validated`; a live custom domain is `domain` regardless. Entries without checklist data fall back to the existing github.io-URL heuristic unchanged.
- **UI** (`src/app/pipeline/page.tsx`): cards show a `validation X/Y` badge for charities mid-checklist.
- **Data**: `public/data/roadmap.json` deliberately NOT hand-committed — refreshes land via the scheduled `build-roadmap-data.yml` PR workflow (`data/roadmap` branch), which will pick up the new fields on its next run once work-order issues gain the checklist.

## Test plan

- [x] New stage tests: checklist complete / partial / absent (fallback) paths, custom-domain precedence, degenerate totals, in-build promotion
- [x] New generator parsing tests incl. a contract test against the real `stubBody` from `scripts/lib/intake-issues.mjs` (read-only import)
- [x] `pnpm lint`, `pnpm format:check`, `pnpm type-check` clean; full jest suite green after `pnpm build` (sole failure is the known Windows-only husky execute-bit check, passes in CI)
- [x] Generator run end-to-end against live repo issues (109 entries, no shape regressions; 0 checklists found = matches reality, no issue body carries the block yet)
- [x] Dev-server render check: mid-checklist entry shows `validation 6/8` in the building column; an 8/8 entry lands in Validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)