### PR TITLE
feat: fleet audit — footer-standard compliance + site health probe

### DIFF
--- a/.github/workflows/fleet-audit.yml
+++ b/.github/workflows/fleet-audit.yml
@@ -1,0 +1,47 @@
+name: Fleet Audit
+
+# One polite probe pass over every live charity site FFC serves
+# (FreeForCharity/FFC-Cloudflare-Automation#697, overnight blocks 10+11):
+# site health (HTTP status, redirect chain, HTTPS) plus FFC footer-standard
+# compliance. Read-only external GETs only — plain GITHUB_TOKEN, no
+# environment gate, manual dispatch only.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  fleet-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      - name: Run fleet audit
+        run: node scripts/fleet-audit.mjs
+
+      - name: Publish job summary
+        if: always()
+        run: |
+          if [ -f docs/fleet-audit-report.md ]; then
+            cat docs/fleet-audit-report.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Fleet audit produced no report." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload audit artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fleet-audit
+          path: |
+            docs/fleet-audit.json
+            docs/fleet-audit-report.md
+          if-no-files-found: error

--- a/__tests__/fleet-audit.test.js
+++ b/__tests__/fleet-audit.test.js
@@ -1,0 +1,298 @@
+/**
+ * Unit tests for the fleet audit script (scripts/fleet-audit.mjs).
+ *
+ * The audit's parsing and verdict logic is pure — CSV in, fleet out; HTML
+ * body in, footer checks out; probe results in, summary/report out — so
+ * these tests lock in the fleet-selection filter, every footer-standard
+ * check, error classification, and the report rendering, all with mocked
+ * data (no network).
+ */
+
+let parseCsv, selectFleet, analyzeFooter, isCompliant, classifyError
+let buildNotes, buildSummary, buildMarkdownReport
+
+beforeAll(async () => {
+  const mod = await import('../scripts/fleet-audit.mjs')
+  parseCsv = mod.parseCsv
+  selectFleet = mod.selectFleet
+  analyzeFooter = mod.analyzeFooter
+  isCompliant = mod.isCompliant
+  classifyError = mod.classifyError
+  buildNotes = mod.buildNotes
+  buildSummary = mod.buildSummary
+  buildMarkdownReport = mod.buildMarkdownReport
+})
+
+// ---------------------------------------------------------------------------
+// CSV parsing
+// ---------------------------------------------------------------------------
+
+describe('parseCsv', () => {
+  it('parses header-keyed records', () => {
+    const recs = parseCsv('A,B\n1,2\n3,4\n')
+    expect(recs).toEqual([
+      { A: '1', B: '2' },
+      { A: '3', B: '4' },
+    ])
+  })
+
+  it('handles quoted fields containing commas and escaped quotes', () => {
+    const recs = parseCsv('A,B,C\n"hello, world","say ""hi""",plain\n')
+    expect(recs[0]).toEqual({ A: 'hello, world', B: 'say "hi"', C: 'plain' })
+  })
+
+  it('handles CRLF line endings and missing trailing newline', () => {
+    const recs = parseCsv('A,B\r\n1,2\r\n3,4')
+    expect(recs).toHaveLength(2)
+    expect(recs[1]).toEqual({ A: '3', B: '4' })
+  })
+
+  it('fills missing trailing columns with empty strings', () => {
+    const recs = parseCsv('A,B,C\n1,2\n')
+    expect(recs[0]).toEqual({ A: '1', B: '2', C: '' })
+  })
+
+  it('parses the real committed sites_list.csv without column drift', () => {
+    const { readFileSync } = require('fs')
+    const { join } = require('path')
+    const recs = parseCsv(readFileSync(join(__dirname, '..', 'docs', 'sites_list.csv'), 'utf8'))
+    expect(recs.length).toBeGreaterThan(100)
+    // Every record must expose the columns the fleet filter depends on.
+    for (const key of ['Domain', 'Site Health', 'Left FFC', 'Is Staging', 'Section', 'Status']) {
+      expect(Object.keys(recs[0])).toContain(key)
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Fleet selection
+// ---------------------------------------------------------------------------
+
+describe('selectFleet', () => {
+  const base = {
+    Domain: 'example.org',
+    Section: 'Cloudflare-Only',
+    Status: 'Active',
+    'Site Health': 'Live',
+    'Left FFC': '',
+    'Is Staging': '',
+    'Host Category': 'GitHub Pages',
+    'Work Tier': '4 - Done / Stable',
+  }
+
+  it('includes a live, active charity site', () => {
+    const fleet = selectFleet([base])
+    expect(fleet).toHaveLength(1)
+    expect(fleet[0]).toMatchObject({ domain: 'example.org', hostCategory: 'GitHub Pages' })
+  })
+
+  it('excludes sites that are not Live', () => {
+    expect(selectFleet([{ ...base, 'Site Health': 'Unreachable' }])).toHaveLength(0)
+    expect(selectFleet([{ ...base, 'Site Health': 'Redirect' }])).toHaveLength(0)
+  })
+
+  it('excludes orgs that left FFC, staging rows, and for-profit sites', () => {
+    expect(selectFleet([{ ...base, 'Left FFC': 'Yes' }])).toHaveLength(0)
+    expect(selectFleet([{ ...base, 'Is Staging': 'Yes' }])).toHaveLength(0)
+    expect(selectFleet([{ ...base, Section: 'For-Profit' }])).toHaveLength(0)
+  })
+
+  it('excludes expired, cancelled, fraud, and transferred-away domains', () => {
+    for (const status of ['Expired', 'Cancelled', 'Fraud', 'Transferred Away']) {
+      expect(selectFleet([{ ...base, Status: status }])).toHaveLength(0)
+    }
+  })
+
+  it('lowercases and sorts domains', () => {
+    const fleet = selectFleet([
+      { ...base, Domain: 'ZEBRA.org' },
+      { ...base, Domain: 'alpha.org' },
+    ])
+    expect(fleet.map((f) => f.domain)).toEqual(['alpha.org', 'zebra.org'])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Footer-standard analysis
+// ---------------------------------------------------------------------------
+
+const COMPLIANT_HTML = `
+  <footer>
+    <p>Supported by <a href="https://freeforcharity.org">Free For Charity</a></p>
+    <a href="https://freeforcharity.org/hub">FFC Hub</a>
+    <p>EIN: 46-2471893</p>
+  </footer>`
+
+describe('analyzeFooter', () => {
+  it('passes every check on a compliant footer', () => {
+    const f = analyzeFooter(COMPLIANT_HTML)
+    expect(f).toEqual({
+      footerMarker: true,
+      ffcLink: true,
+      hubLink: true,
+      ein: true,
+      supportedBy: true,
+    })
+    expect(isCompliant(f)).toBe(true)
+  })
+
+  it('matches the marker with and without spaces, case-insensitively', () => {
+    expect(analyzeFooter('freeforcharity').footerMarker).toBe(true)
+    expect(analyzeFooter('FREE FOR CHARITY').footerMarker).toBe(true)
+    expect(analyzeFooter('Free ForCharity').footerMarker).toBe(true)
+  })
+
+  it('requires the FFC link to be an actual href, not prose', () => {
+    expect(analyzeFooter('visit freeforcharity.org sometime').ffcLink).toBe(false)
+    expect(analyzeFooter('<a href="https://www.freeforcharity.org/">x</a>').ffcLink).toBe(true)
+  })
+
+  it('matches EIN with and without the hyphen', () => {
+    expect(analyzeFooter('EIN: 46-2471893').ein).toBe(true)
+    expect(analyzeFooter('EIN 462471893').ein).toBe(true)
+    expect(analyzeFooter('EIN: pending').ein).toBe(false)
+  })
+
+  it('detects the hub link only when the /hub path is present', () => {
+    expect(analyzeFooter('href="https://freeforcharity.org/"').hubLink).toBe(false)
+    expect(analyzeFooter('href="https://freeforcharity.org/hub"').hubLink).toBe(true)
+  })
+
+  it('fails closed on an empty or footer-less body', () => {
+    const f = analyzeFooter('<html><body><h1>Charity</h1></body></html>')
+    expect(isCompliant(f)).toBe(false)
+    expect(isCompliant(analyzeFooter(''))).toBe(false)
+    expect(isCompliant(null)).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Error classification
+// ---------------------------------------------------------------------------
+
+describe('classifyError', () => {
+  it('classifies timeouts', () => {
+    const err = new Error('timeout')
+    err.name = 'TimeoutError'
+    expect(classifyError(err)).toEqual({ reason: 'timeout', tls: false })
+  })
+
+  it('classifies TLS certificate failures from the error cause code', () => {
+    const err = new TypeError('fetch failed')
+    err.cause = Object.assign(new Error('certificate has expired'), {
+      code: 'CERT_HAS_EXPIRED',
+    })
+    const out = classifyError(err)
+    expect(out.tls).toBe(true)
+    expect(out.reason).toContain('CERT_HAS_EXPIRED')
+  })
+
+  it('classifies DNS failures via the cause code', () => {
+    const err = new TypeError('fetch failed')
+    err.cause = Object.assign(new Error('getaddrinfo ENOTFOUND'), { code: 'ENOTFOUND' })
+    expect(classifyError(err)).toEqual({ reason: 'enotfound', tls: false })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Notes, summary, and report rendering
+// ---------------------------------------------------------------------------
+
+const site = (overrides = {}) => ({
+  domain: 'example.org',
+  section: 'Cloudflare-Only',
+  status: 'Active',
+  hostCategory: 'GitHub Pages',
+  workTier: '4 - Done / Stable',
+  ok: true,
+  httpStatus: 200,
+  httpsOk: true,
+  finalUrl: 'https://example.org/',
+  redirectChain: [{ url: 'https://example.org/', status: 200 }],
+  footer: analyzeFooter(COMPLIANT_HTML),
+  error: null,
+  retried: false,
+  ...overrides,
+})
+
+describe('buildNotes', () => {
+  it('is empty for a healthy compliant site', () => {
+    expect(buildNotes(site())).toBe('')
+  })
+
+  it('lists exactly the missing footer checks', () => {
+    const s = site({ footer: analyzeFooter('<p>Supported by Free For Charity</p>') })
+    expect(buildNotes(s)).toBe('missing: FFC link, hub link, EIN')
+  })
+
+  it('reports unreachable sites and redirect destinations', () => {
+    expect(buildNotes(site({ ok: false, error: 'enotfound', httpStatus: null }))).toContain(
+      'unreachable: enotfound'
+    )
+    const redirected = site({
+      finalUrl: 'https://www.example.org/',
+      redirectChain: [
+        { url: 'https://example.org/', status: 301 },
+        { url: 'https://www.example.org/', status: 200 },
+      ],
+    })
+    expect(buildNotes(redirected)).toContain('redirects to https://www.example.org/')
+  })
+
+  it('flags a non-HTTPS final URL', () => {
+    const s = site({
+      httpsOk: false,
+      finalUrl: 'http://example.org/',
+      redirectChain: [
+        { url: 'https://example.org/', status: 301 },
+        { url: 'http://example.org/', status: 200 },
+      ],
+    })
+    expect(buildNotes(s)).toContain('final URL is not HTTPS')
+  })
+})
+
+describe('buildSummary / buildMarkdownReport', () => {
+  const makeSites = () => [
+    site(),
+    site({ domain: 'missing-footer.org', footer: analyzeFooter('<h1>hi</h1>') }),
+    site({
+      domain: 'down.org',
+      ok: false,
+      httpStatus: null,
+      httpsOk: null,
+      finalUrl: null,
+      redirectChain: null,
+      footer: null,
+      error: 'timeout',
+    }),
+  ]
+
+  it('counts totals, reachable, down, compliant, and per-check passes', () => {
+    const summary = buildSummary(makeSites())
+    expect(summary).toMatchObject({ total: 3, reachable: 2, down: 1, compliant: 1 })
+    expect(summary.checks.footerMarker).toBe(1)
+    expect(summary.checks.ein).toBe(1)
+  })
+
+  it('renders summary counts, a prominent down-sites section, and both report sections', () => {
+    const md = buildMarkdownReport(makeSites(), '2026-07-11')
+    expect(md).toContain('# FFC Fleet Audit Report')
+    expect(md).toContain('generated on 2026-07-11')
+    expect(md).toContain('**Sites audited:** 3')
+    expect(md).toContain('**Footer-standard compliant:** 1 / 2')
+    expect(md).toContain('## Down or broken sites (action needed)')
+    expect(md).toContain('| down.org | unreachable: timeout |')
+    expect(md).toContain('## Section A — FFC footer-standard compliance')
+    expect(md).toContain('## Section B — Site health')
+    // Compliant row: all footer cells yes.
+    expect(md).toContain('| example.org | 200 | yes | yes | yes | yes | yes |  |')
+    // Down row uses em-dash placeholders instead of misleading "no"s.
+    expect(md).toContain('| down.org | DOWN | — | — | — | — | — |')
+  })
+
+  it('omits the down-sites section when everything is up', () => {
+    const md = buildMarkdownReport([site()], '2026-07-11')
+    expect(md).not.toContain('## Down or broken sites')
+  })
+})

--- a/docs/fleet-audit-report.md
+++ b/docs/fleet-audit-report.md
@@ -1,0 +1,201 @@
+# FFC Fleet Audit Report
+
+> **Point-in-time snapshot** generated on 2026-07-12.
+> Re-run with `node scripts/fleet-audit.mjs` or the **Fleet Audit** workflow
+> (`.github/workflows/fleet-audit.yml`, workflow_dispatch). The fleet is every
+> live charity site in `docs/sites_list.csv` (Site Health = Live, still with
+> FFC, not staging, not for-profit).
+
+## Summary
+
+- **Sites audited:** 85
+- **Reachable:** 84 / 85
+- **Down / broken:** 1
+- **Footer-standard compliant:** 0 / 84 reachable sites
+- Individual checks (of 84 reachable): FFC marker 23, FFC link 17, hub link 2, EIN 15, "Supported by" 7
+
+## Down or broken sites (action needed)
+
+| Charity             | Problem                                                               |
+| ------------------- | --------------------------------------------------------------------- |
+| sporting2impact.org | unreachable: tls-error (ERR_SSL_PACKET_LENGTH_TOO_LONG); needed retry |
+
+## Section A — FFC footer-standard compliance
+
+| Charity                                   | Status | HTTPS | Footer marker | Supported by | EIN | Hub link | Notes                                                                 |
+| ----------------------------------------- | ------ | ----- | ------------- | ------------ | --- | -------- | --------------------------------------------------------------------- |
+| aariasblueelephant.org                    | 200    | yes   | no            | no           | yes | no       | missing: FFC marker, FFC link, hub link, "Supported by"               |
+| amargraves.org                            | 200    | yes   | no            | no           | no  | no       | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| ambofoundation.org                        | 200    | yes   | no            | no           | no  | no       | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| avengedfastpitch.org                      | 200    | yes   | no            | no           | no  | no       | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| bearupinternationalministries.org         | 200    | yes   | no            | no           | no  | no       | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| bintobetter.org                           | 200    | yes   | no            | no           | no  | no       | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| bowiesblessings.org                       | 200    | yes   | no            | no           | no  | no       | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| browncanyonranch.org                      | 200    | yes   | no            | no           | no  | no       | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| canadatokeywestcoastalrun.org             | 200    | yes   | yes           | no           | no  | no       | missing: hub link, EIN, "Supported by"                                |
+| clarasbridge.org                          | 200    | yes   | yes           | no           | yes | yes      | missing: "Supported by"                                               |
+| compassionstl.org                         | 200    | yes   | yes           | no           | no  | no       | missing: hub link, EIN, "Supported by"                                |
+| coronadonationalforestheritagesociety.org | 200    | yes   | yes           | no           | yes | no       | missing: hub link, "Supported by"                                     |
+| craftedraise.org                          | 200    | yes   | no            | no           | no  | no       | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| ctvip.org                                 | 200    | yes   | no            | no           | no  | no       | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| cucu-il.org                               | 200    | yes   | no            | no           | no  | no       | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| cvrs-us.org                               | 200    | yes   | no            | no           | no  | no       | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| database.onlineimpacts.org                | 200    | yes   | no            | no           | no  | no       | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| dropletsoflove.org                        | 200    | yes   | no            | no           | no  | no       | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| educationandempowerment.org               | 200    | yes   | no            | no           | no  | no       | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| empowerconnectfoundation.org              | 200    | yes   | no            | no           | no  | no       | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| exceptionalridersprogram.org              | 200    | yes   | no            | no           | no  | no       | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| facinggiantsnc.org                        | 200    | yes   | no            | no           | no  | no       | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| falloutshelterecovillage.org              | 200    | yes   | no            | no           | no  | no       | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| fencingtogether.org                       | 200    | yes   | no            | no           | yes | no       | missing: FFC marker, FFC link, hub link, "Supported by"               |
+| ffcadmin.org                              | 200    | yes   | yes           | no           | yes | no       | missing: hub link, "Supported by"                                     |
+| ffctools.onlineimpacts.org                | 200    | yes   | yes           | no           | no  | no       | missing: hub link, EIN, "Supported by"                                |
+| ffcworkingsite2.org                       | 200    | yes   | yes           | no           | yes | yes      | missing: "Supported by"                                               |
+| freedomrisingusa.org                      | 200    | yes   | yes           | no           | no  | no       | missing: FFC link, hub link, EIN, "Supported by"                      |
+| garrisonareacaregivers.org                | 200    | yes   | no            | no           | no  | no       | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| graftonareahistory.org                    | 200    | yes   | no            | no           | no  | no       | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| greenrecon.org                            | 200    | yes   | no            | no           | no  | no       | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| harmonycenterfoundation.org               | 200    | yes   | no            | no           | no  | no       | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| hclwellness.org                           | 200    | yes   | yes           | no           | no  | no       | missing: FFC link, hub link, EIN, "Supported by"                      |
+| heroes2others.org                         | 200    | yes   | no            | no           | no  | no       | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| homesforchange.org                        | 200    | yes   | no            | no           | no  | no       | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| jwvpost619.org                            | 200    | yes   | no            | no           | no  | no       | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| kainkaryasri.org                          | 200    | yes   | no            | no           | no  | no       | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| kierstensride.org                         | 200    | yes   | no            | yes          | no  | no       | missing: FFC marker, FFC link, hub link, EIN                          |
+| kittencoveinc.org                         | 200    | yes   | no            | no           | no  | no       | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| ksgf.org                                  | 200    | yes   | no            | no           | no  | no       | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| legioninthewoods.org                      | 200    | yes   | yes           | no           | no  | no       | missing: FFC link, hub link, EIN, "Supported by"                      |
+| letsdanceactivities.org                   | 200    | yes   | no            | no           | no  | no       | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| letsleadwise.org                          | 200    | yes   | no            | no           | yes | no       | missing: FFC marker, FFC link, hub link, "Supported by"               |
+| letspiritlead.org                         | 200    | yes   | yes           | yes          | no  | no       | missing: hub link, EIN                                                |
+| lifelessonslearned.us.org                 | 200    | yes   | no            | no           | no  | no       | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| lovemustwin.org                           | 200    | yes   | no            | no           | no  | no       | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| makeacalendarinvite.org                   | 200    | yes   | no            | no           | no  | no       | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| mitchellnchistory.org                     | 200    | yes   | yes           | no           | no  | no       | missing: hub link, EIN, "Supported by"                                |
+| my-missions.org                           | 200    | yes   | no            | no           | no  | no       | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| myservicehours.org                        | 200    | yes   | no            | no           | no  | no       | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| nittanypost245.org                        | 200    | yes   | yes           | no           | no  | no       | missing: FFC link, hub link, EIN, "Supported by"                      |
+| nj4israel.org                             | 200    | yes   | no            | no           | no  | no       | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| nochaos.org                               | 200    | yes   | no            | no           | no  | no       | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| nolef.onlineimpacts.org                   | 200    | yes   | no            | no           | no  | no       | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| nottinghampc.org                          | 200    | yes   | no            | yes          | no  | no       | missing: FFC marker, FFC link, hub link, EIN                          |
+| onlineimpacts.org                         | 200    | yes   | no            | yes          | no  | no       | missing: FFC marker, FFC link, hub link, EIN                          |
+| operationhomesforheroes.org               | 200    | yes   | no            | no           | no  | no       | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| pagbooster.org                            | 200    | yes   | yes           | yes          | yes | no       | missing: hub link                                                     |
+| pfplus.org                                | 200    | yes   | no            | no           | yes | no       | missing: FFC marker, FFC link, hub link, "Supported by"               |
+| phoenixartsandadvocacy.org                | 200    | yes   | yes           | no           | yes | no       | missing: hub link, "Supported by"                                     |
+| ptuganda.org                              | 200    | yes   | no            | no           | no  | no       | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| rebirthsdc.org                            | 200    | yes   | no            | no           | no  | no       | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| restoredradiancefoundation.org            | 200    | yes   | yes           | no           | yes | no       | missing: hub link, "Supported by"                                     |
+| savewatersaveplanet.org                   | 200    | yes   | no            | no           | no  | no       | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| slopestohope.org                          | 200    | yes   | yes           | no           | no  | no       | missing: FFC link, hub link, EIN, "Supported by"                      |
+| southamptonfriends.org                    | 200    | yes   | no            | no           | no  | no       | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| sporting2impact.org                       | DOWN   | no    | —             | —            | —   | —        | unreachable: tls-error (ERR_SSL_PACKET_LENGTH_TOO_LONG); needed retry |
+| tamkeensports.org                         | 200    | yes   | no            | no           | yes | no       | missing: FFC marker, FFC link, hub link, "Supported by"               |
+| tasteandseelocal.org                      | 200    | yes   | no            | no           | no  | no       | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| technologyadoptionbarriers.org            | 200    | yes   | no            | no           | no  | no       | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| technologymonastery.org                   | 200    | yes   | yes           | yes          | no  | no       | missing: FFC link, hub link, EIN                                      |
+| theafghanistanaffairs.org                 | 200    | yes   | yes           | no           | yes | no       | missing: hub link, "Supported by"                                     |
+| thebirf.org                               | 200    | yes   | no            | no           | yes | no       | missing: FFC marker, FFC link, hub link, "Supported by"               |
+| thedeviators.org                          | 200    | yes   | no            | no           | no  | no       | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| theeverythingproject.org                  | 200    | yes   | yes           | no           | no  | no       | missing: hub link, EIN, "Supported by"                                |
+| thegracehouseinc.org                      | 200    | yes   | no            | yes          | no  | no       | missing: FFC marker, FFC link, hub link, EIN                          |
+| thekccf.org                               | 200    | yes   | no            | no           | yes | no       | missing: FFC marker, FFC link, hub link, "Supported by"               |
+| thestudiovisit.org                        | 200    | yes   | no            | no           | no  | no       | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| thewayofyeshuaministries.org              | 200    | yes   | yes           | no           | no  | no       | missing: hub link, EIN, "Supported by"                                |
+| transferca.org                            | 200    | yes   | no            | no           | no  | no       | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| turksotx.org                              | 200    | yes   | no            | no           | no  | no       | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| veterans.onlineimpacts.org                | 200    | yes   | no            | no           | no  | no       | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| wamhelp.org                               | 200    | yes   | yes           | no           | no  | no       | missing: hub link, EIN, "Supported by"                                |
+| www.wonderseedstudios.org                 | 200    | yes   | yes           | no           | no  | no       | missing: hub link, EIN, "Supported by"                                |
+| youngfatherscare.org                      | 200    | yes   | no            | no           | no  | no       | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+
+## Section B — Site health
+
+| Charity                                   | HTTP status | HTTPS | Final URL                                          | Redirect hops | Notes                                                                 |
+| ----------------------------------------- | ----------- | ----- | -------------------------------------------------- | ------------- | --------------------------------------------------------------------- |
+| aariasblueelephant.org                    | 200         | yes   | https://aariasblueelephant.org/                    | 0             | missing: FFC marker, FFC link, hub link, "Supported by"               |
+| amargraves.org                            | 200         | yes   | https://amargraves.org/                            | 0             | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| ambofoundation.org                        | 200         | yes   | https://ambofoundation.org/                        | 0             | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| avengedfastpitch.org                      | 200         | yes   | https://avengedfastpitch.org/                      | 0             | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| bearupinternationalministries.org         | 200         | yes   | https://bearupinternationalministries.org/         | 0             | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| bintobetter.org                           | 200         | yes   | https://bintobetter.org/                           | 0             | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| bowiesblessings.org                       | 200         | yes   | https://bowiesblessings.org/                       | 0             | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| browncanyonranch.org                      | 200         | yes   | https://browncanyonranch.org/                      | 0             | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| canadatokeywestcoastalrun.org             | 200         | yes   | https://canadatokeywestcoastalrun.org/             | 0             | missing: hub link, EIN, "Supported by"                                |
+| clarasbridge.org                          | 200         | yes   | https://clarasbridge.org/                          | 0             | missing: "Supported by"                                               |
+| compassionstl.org                         | 200         | yes   | https://compassionstl.org/                         | 0             | missing: hub link, EIN, "Supported by"                                |
+| coronadonationalforestheritagesociety.org | 200         | yes   | https://coronadonationalforestheritagesociety.org/ | 0             | missing: hub link, "Supported by"                                     |
+| craftedraise.org                          | 200         | yes   | https://craftedraise.org/                          | 0             | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| ctvip.org                                 | 200         | yes   | https://ctvip.org/                                 | 0             | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| cucu-il.org                               | 200         | yes   | https://cucu-il.org/                               | 0             | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| cvrs-us.org                               | 200         | yes   | https://cvrs-us.org/                               | 0             | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| database.onlineimpacts.org                | 200         | yes   | https://database.onlineimpacts.org/                | 0             | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| dropletsoflove.org                        | 200         | yes   | https://dropletsoflove.org/                        | 0             | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| educationandempowerment.org               | 200         | yes   | https://educationandempowerment.org/               | 0             | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| empowerconnectfoundation.org              | 200         | yes   | https://empowerconnectfoundation.org/              | 0             | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| exceptionalridersprogram.org              | 200         | yes   | https://exceptionalridersprogram.org/              | 0             | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| facinggiantsnc.org                        | 200         | yes   | https://facinggiantsnc.org/                        | 0             | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| falloutshelterecovillage.org              | 200         | yes   | https://falloutshelterecovillage.org/              | 0             | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| fencingtogether.org                       | 200         | yes   | https://fencingtogether.org/                       | 0             | missing: FFC marker, FFC link, hub link, "Supported by"               |
+| ffcadmin.org                              | 200         | yes   | https://ffcadmin.org/                              | 0             | missing: hub link, "Supported by"                                     |
+| ffctools.onlineimpacts.org                | 200         | yes   | https://ffctools.onlineimpacts.org/                | 0             | missing: hub link, EIN, "Supported by"                                |
+| ffcworkingsite2.org                       | 200         | yes   | https://ffcworkingsite2.org/                       | 0             | missing: "Supported by"                                               |
+| freedomrisingusa.org                      | 200         | yes   | https://freedomrisingusa.org/                      | 0             | missing: FFC link, hub link, EIN, "Supported by"                      |
+| garrisonareacaregivers.org                | 200         | yes   | https://garrisonareacaregivers.org/                | 0             | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| graftonareahistory.org                    | 200         | yes   | https://graftonareahistory.org/                    | 0             | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| greenrecon.org                            | 200         | yes   | https://greenrecon.org/                            | 0             | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| harmonycenterfoundation.org               | 200         | yes   | https://harmonycenterfoundation.org/               | 0             | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| hclwellness.org                           | 200         | yes   | https://hclwellness.org/                           | 0             | missing: FFC link, hub link, EIN, "Supported by"                      |
+| heroes2others.org                         | 200         | yes   | https://heroes2others.org/                         | 0             | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| homesforchange.org                        | 200         | yes   | https://homesforchange.org/                        | 0             | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| jwvpost619.org                            | 200         | yes   | https://jwvpost619.org/                            | 0             | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| kainkaryasri.org                          | 200         | yes   | https://kainkaryasri.org/                          | 0             | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| kierstensride.org                         | 200         | yes   | https://kierstensride.org/                         | 0             | missing: FFC marker, FFC link, hub link, EIN                          |
+| kittencoveinc.org                         | 200         | yes   | https://kittencoveinc.org/                         | 0             | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| ksgf.org                                  | 200         | yes   | https://ksgf.org/                                  | 0             | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| legioninthewoods.org                      | 200         | yes   | https://legioninthewoods.org/                      | 0             | missing: FFC link, hub link, EIN, "Supported by"                      |
+| letsdanceactivities.org                   | 200         | yes   | https://letsdanceactivities.org/                   | 0             | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| letsleadwise.org                          | 200         | yes   | https://letsleadwise.org/                          | 0             | missing: FFC marker, FFC link, hub link, "Supported by"               |
+| letspiritlead.org                         | 200         | yes   | https://letspiritlead.org/                         | 0             | missing: hub link, EIN                                                |
+| lifelessonslearned.us.org                 | 200         | yes   | https://lifelessonslearned.us.org/                 | 0             | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| lovemustwin.org                           | 200         | yes   | https://lovemustwin.org/                           | 0             | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| makeacalendarinvite.org                   | 200         | yes   | https://makeacalendarinvite.org/                   | 0             | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| mitchellnchistory.org                     | 200         | yes   | https://mitchellnchistory.org/                     | 0             | missing: hub link, EIN, "Supported by"                                |
+| my-missions.org                           | 200         | yes   | https://my-missions.org/                           | 0             | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| myservicehours.org                        | 200         | yes   | https://myservicehours.org/                        | 0             | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| nittanypost245.org                        | 200         | yes   | https://nittanypost245.org/                        | 0             | missing: FFC link, hub link, EIN, "Supported by"                      |
+| nj4israel.org                             | 200         | yes   | https://nj4israel.org/                             | 0             | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| nochaos.org                               | 200         | yes   | https://nochaos.org/                               | 0             | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| nolef.onlineimpacts.org                   | 200         | yes   | https://nolef.onlineimpacts.org/                   | 0             | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| nottinghampc.org                          | 200         | yes   | https://nottinghampc.org/                          | 0             | missing: FFC marker, FFC link, hub link, EIN                          |
+| onlineimpacts.org                         | 200         | yes   | https://onlineimpacts.org/                         | 0             | missing: FFC marker, FFC link, hub link, EIN                          |
+| operationhomesforheroes.org               | 200         | yes   | https://operationhomesforheroes.org/               | 0             | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| pagbooster.org                            | 200         | yes   | https://pagbooster.org/                            | 0             | missing: hub link                                                     |
+| pfplus.org                                | 200         | yes   | https://pfplus.org/                                | 0             | missing: FFC marker, FFC link, hub link, "Supported by"               |
+| phoenixartsandadvocacy.org                | 200         | yes   | https://phoenixartsandadvocacy.org/                | 0             | missing: hub link, "Supported by"                                     |
+| ptuganda.org                              | 200         | yes   | https://ptuganda.org/                              | 0             | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| rebirthsdc.org                            | 200         | yes   | https://rebirthsdc.org/                            | 0             | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| restoredradiancefoundation.org            | 200         | yes   | https://restoredradiancefoundation.org/            | 0             | missing: hub link, "Supported by"                                     |
+| savewatersaveplanet.org                   | 200         | yes   | https://savewatersaveplanet.org/                   | 0             | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| slopestohope.org                          | 200         | yes   | https://slopestohope.org/                          | 0             | missing: FFC link, hub link, EIN, "Supported by"                      |
+| southamptonfriends.org                    | 200         | yes   | https://southamptonfriends.org/                    | 0             | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| sporting2impact.org                       | DOWN        | no    | —                                                  | 0             | unreachable: tls-error (ERR_SSL_PACKET_LENGTH_TOO_LONG); needed retry |
+| tamkeensports.org                         | 200         | yes   | https://tamkeensports.org/                         | 0             | missing: FFC marker, FFC link, hub link, "Supported by"               |
+| tasteandseelocal.org                      | 200         | yes   | https://tasteandseelocal.org/                      | 0             | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| technologyadoptionbarriers.org            | 200         | yes   | https://technologyadoptionbarriers.org/            | 0             | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| technologymonastery.org                   | 200         | yes   | https://technologymonastery.org/                   | 0             | missing: FFC link, hub link, EIN                                      |
+| theafghanistanaffairs.org                 | 200         | yes   | https://theafghanistanaffairs.org/                 | 0             | missing: hub link, "Supported by"                                     |
+| thebirf.org                               | 200         | yes   | https://thebirf.org/                               | 0             | missing: FFC marker, FFC link, hub link, "Supported by"               |
+| thedeviators.org                          | 200         | yes   | https://thedeviators.org/                          | 0             | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| theeverythingproject.org                  | 200         | yes   | https://theeverythingproject.org/                  | 0             | missing: hub link, EIN, "Supported by"                                |
+| thegracehouseinc.org                      | 200         | yes   | https://thegracehouseinc.org/                      | 0             | missing: FFC marker, FFC link, hub link, EIN                          |
+| thekccf.org                               | 200         | yes   | https://thekccf.org/                               | 0             | missing: FFC marker, FFC link, hub link, "Supported by"               |
+| thestudiovisit.org                        | 200         | yes   | https://thestudiovisit.org/                        | 0             | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| thewayofyeshuaministries.org              | 200         | yes   | https://thewayofyeshuaministries.org/              | 0             | missing: hub link, EIN, "Supported by"                                |
+| transferca.org                            | 200         | yes   | https://transferca.org/                            | 0             | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| turksotx.org                              | 200         | yes   | https://turksotx.org/                              | 0             | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| veterans.onlineimpacts.org                | 200         | yes   | https://veterans.onlineimpacts.org/                | 0             | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |
+| wamhelp.org                               | 200         | yes   | https://wamhelp.org/                               | 0             | missing: hub link, EIN, "Supported by"                                |
+| www.wonderseedstudios.org                 | 200         | yes   | https://www.wonderseedstudios.org/                 | 0             | missing: hub link, EIN, "Supported by"                                |
+| youngfatherscare.org                      | 200         | yes   | https://youngfatherscare.org/                      | 0             | missing: FFC marker, FFC link, hub link, EIN, "Supported by"          |

--- a/scripts/fleet-audit.mjs
+++ b/scripts/fleet-audit.mjs
@@ -1,0 +1,399 @@
+#!/usr/bin/env node
+/**
+ * Fleet audit: one polite probe pass over every live charity site FFC serves
+ * (FreeForCharity/FFC-Cloudflare-Automation#697, overnight blocks 10+11).
+ *
+ * Source of truth for the fleet is docs/sites_list.csv — the same committed
+ * snapshot the /sites-list dashboard renders. "Live charity site" means:
+ * Site Health is "Live", the org has not left FFC, the row is not a staging
+ * host, the section is not For-Profit, and the domain status is not
+ * Expired / Cancelled / Fraud / Transferred Away.
+ *
+ * For each site the script issues read-only GETs (250ms pacing, 10s timeout,
+ * one retry) following redirects manually so the chain is recorded, then
+ * checks the final HTML body against the FFC footer standard:
+ *   - "Free For Charity" marker text
+ *   - a link to freeforcharity.org
+ *   - a link to the hub (freeforcharity.org/hub)
+ *   - an EIN in the standard footer format
+ *   - the "Supported by" attribution phrasing
+ *
+ * Outputs (paths overridable with --json / --md):
+ *   docs/fleet-audit.json       machine-readable results (not committed;
+ *                               uploaded as a workflow artifact)
+ *   docs/fleet-audit-report.md  human-readable two-section report
+ *
+ * Pure helpers (CSV parsing, fleet selection, footer analysis, report
+ * rendering) are exported for unit tests; only the probe loop touches the
+ * network, and only when the script is invoked directly.
+ */
+import { readFileSync, writeFileSync } from 'fs'
+import { fileURLToPath, pathToFileURL } from 'url'
+import { dirname, join } from 'path'
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url))
+const CSV_PATH = join(SCRIPT_DIR, '..', 'docs', 'sites_list.csv')
+
+export const REQUEST_TIMEOUT_MS = 10_000
+export const PACING_MS = 250
+export const MAX_REDIRECTS = 8
+const USER_AGENT = 'FFC-Fleet-Audit/1.0 (+https://ffcadmin.org/sites-list/)'
+
+// ---------------------------------------------------------------------------
+// CSV parsing (RFC 4180 subset: quoted fields, escaped quotes, CRLF).
+// Dependency-free so the workflow can run this script with plain node.
+// ---------------------------------------------------------------------------
+
+/** Parse CSV text into an array of records keyed by the header row. */
+export function parseCsv(text) {
+  const rows = []
+  let row = []
+  let field = ''
+  let inQuotes = false
+  for (let i = 0; i < text.length; i++) {
+    const c = text[i]
+    if (inQuotes) {
+      if (c === '"') {
+        if (text[i + 1] === '"') {
+          field += '"'
+          i++
+        } else {
+          inQuotes = false
+        }
+      } else {
+        field += c
+      }
+    } else if (c === '"') {
+      inQuotes = true
+    } else if (c === ',') {
+      row.push(field)
+      field = ''
+    } else if (c === '\n' || c === '\r') {
+      if (c === '\r' && text[i + 1] === '\n') i++
+      row.push(field)
+      field = ''
+      if (row.length > 1 || row[0] !== '') rows.push(row)
+      row = []
+    } else {
+      field += c
+    }
+  }
+  if (field !== '' || row.length > 0) {
+    row.push(field)
+    if (row.length > 1 || row[0] !== '') rows.push(row)
+  }
+  if (rows.length === 0) return []
+  const header = rows[0].map((h) => h.trim())
+  return rows.slice(1).map((cols) => {
+    const rec = {}
+    header.forEach((h, idx) => {
+      rec[h] = (cols[idx] || '').trim()
+    })
+    return rec
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Fleet selection
+// ---------------------------------------------------------------------------
+
+const EXCLUDED_STATUSES = new Set(['expired', 'cancelled', 'fraud', 'transferred away'])
+
+/**
+ * Select the live charity fleet from sites_list.csv records: sites FFC
+ * currently serves to the public on behalf of a charity.
+ */
+export function selectFleet(records) {
+  return records
+    .filter(
+      (r) =>
+        (r['Site Health'] || '') === 'Live' &&
+        (r['Left FFC'] || '') !== 'Yes' &&
+        (r['Is Staging'] || '') !== 'Yes' &&
+        (r['Section'] || '') !== 'For-Profit' &&
+        !EXCLUDED_STATUSES.has((r['Status'] || '').toLowerCase())
+    )
+    .map((r) => ({
+      domain: (r['Domain'] || '').toLowerCase(),
+      section: r['Section'] || '',
+      status: r['Status'] || '',
+      hostCategory: r['Host Category'] || '',
+      workTier: r['Work Tier'] || '',
+    }))
+    .filter((r) => r.domain)
+    .sort((a, b) => a.domain.localeCompare(b.domain))
+}
+
+// ---------------------------------------------------------------------------
+// Footer-standard analysis (pure)
+// ---------------------------------------------------------------------------
+
+/** Check an HTML body against the FFC footer standard. */
+export function analyzeFooter(html) {
+  const body = html || ''
+  return {
+    footerMarker: /Free ?For ?Charity/i.test(body),
+    ffcLink: /href\s*=\s*["'][^"']*freeforcharity\.org/i.test(body),
+    hubLink: /freeforcharity\.org\/hub/i.test(body),
+    ein: /EIN[:\s]*\d{2}-?\d{7}/i.test(body),
+    supportedBy: /Supported by/i.test(body),
+  }
+}
+
+/** A site is footer-compliant when every footer-standard check passes. */
+export function isCompliant(footer) {
+  return Boolean(
+    footer &&
+    footer.footerMarker &&
+    footer.ffcLink &&
+    footer.hubLink &&
+    footer.ein &&
+    footer.supportedBy
+  )
+}
+
+/** Classify a fetch/TLS error into a short machine-friendly reason. */
+export function classifyError(err) {
+  const cause = err && err.cause ? err.cause : err
+  const code = (cause && cause.code) || ''
+  const name = (err && err.name) || ''
+  const causeName = (cause && cause.name) || ''
+  if (name === 'TimeoutError' || causeName === 'TimeoutError' || code === 'UND_ERR_CONNECT_TIMEOUT')
+    return { reason: 'timeout', tls: false }
+  if (/CERT|TLS|SSL/i.test(code) || /certificate/i.test((cause && cause.message) || ''))
+    return { reason: `tls-error (${code || 'certificate'})`, tls: true }
+  if (code) return { reason: code.toLowerCase().replace(/^err_/, ''), tls: false }
+  return { reason: (cause && cause.message) || String(err), tls: false }
+}
+
+/** Human-readable notes column for one audited site. */
+export function buildNotes(site) {
+  const notes = []
+  if (site.error) notes.push(`unreachable: ${site.error}`)
+  if (site.httpStatus && (site.httpStatus < 200 || site.httpStatus >= 400))
+    notes.push(`HTTP ${site.httpStatus}`)
+  if (site.redirectChain && site.redirectChain.length > 1)
+    notes.push(`redirects to ${site.finalUrl}`)
+  if (site.finalUrl && site.finalUrl.startsWith('http://')) notes.push('final URL is not HTTPS')
+  if (site.retried) notes.push('needed retry')
+  if (!site.error && site.ok && site.footer && !isCompliant(site.footer)) {
+    const missing = []
+    if (!site.footer.footerMarker) missing.push('FFC marker')
+    if (!site.footer.ffcLink) missing.push('FFC link')
+    if (!site.footer.hubLink) missing.push('hub link')
+    if (!site.footer.ein) missing.push('EIN')
+    if (!site.footer.supportedBy) missing.push('"Supported by"')
+    notes.push(`missing: ${missing.join(', ')}`)
+  }
+  return notes.join('; ')
+}
+
+// ---------------------------------------------------------------------------
+// Report rendering (pure)
+// ---------------------------------------------------------------------------
+
+const mark = (v) => (v ? 'yes' : 'no')
+const httpsCell = (s) => (s.httpsOk === null || s.httpsOk === undefined ? '—' : mark(s.httpsOk))
+
+/** Summary counts across all audited sites. */
+export function buildSummary(sites) {
+  const reachable = sites.filter((s) => s.ok)
+  const down = sites.filter((s) => !s.ok)
+  const compliant = reachable.filter((s) => isCompliant(s.footer))
+  const checkCount = (key) => reachable.filter((s) => s.footer && s.footer[key]).length
+  return {
+    total: sites.length,
+    reachable: reachable.length,
+    down: down.length,
+    compliant: compliant.length,
+    checks: {
+      footerMarker: checkCount('footerMarker'),
+      ffcLink: checkCount('ffcLink'),
+      hubLink: checkCount('hubLink'),
+      ein: checkCount('ein'),
+      supportedBy: checkCount('supportedBy'),
+    },
+  }
+}
+
+/** Render the two-section markdown report. */
+export function buildMarkdownReport(sites, generatedAt) {
+  const summary = buildSummary(sites)
+  const down = sites.filter((s) => !s.ok)
+  const lines = []
+  lines.push('# FFC Fleet Audit Report')
+  lines.push('')
+  lines.push(`> **Point-in-time snapshot** generated on ${generatedAt}.`)
+  lines.push('> Re-run with `node scripts/fleet-audit.mjs` or the **Fleet Audit** workflow')
+  lines.push('> (`.github/workflows/fleet-audit.yml`, workflow_dispatch). The fleet is every')
+  lines.push('> live charity site in `docs/sites_list.csv` (Site Health = Live, still with')
+  lines.push('> FFC, not staging, not for-profit).')
+  lines.push('')
+  lines.push('## Summary')
+  lines.push('')
+  lines.push(`- **Sites audited:** ${summary.total}`)
+  lines.push(`- **Reachable:** ${summary.reachable} / ${summary.total}`)
+  lines.push(`- **Down / broken:** ${summary.down}`)
+  lines.push(
+    `- **Footer-standard compliant:** ${summary.compliant} / ${summary.reachable} reachable sites`
+  )
+  lines.push(
+    `- Individual checks (of ${summary.reachable} reachable): FFC marker ${summary.checks.footerMarker}, ` +
+      `FFC link ${summary.checks.ffcLink}, hub link ${summary.checks.hubLink}, ` +
+      `EIN ${summary.checks.ein}, "Supported by" ${summary.checks.supportedBy}`
+  )
+  lines.push('')
+  if (down.length > 0) {
+    lines.push('## Down or broken sites (action needed)')
+    lines.push('')
+    lines.push('| Charity | Problem |')
+    lines.push('| ------- | ------- |')
+    for (const s of down) lines.push(`| ${s.domain} | ${buildNotes(s) || 'unreachable'} |`)
+    lines.push('')
+  }
+  lines.push('## Section A — FFC footer-standard compliance')
+  lines.push('')
+  lines.push('| Charity | Status | HTTPS | Footer marker | Supported by | EIN | Hub link | Notes |')
+  lines.push('| ------- | ------ | ----- | ------------- | ------------ | --- | -------- | ----- |')
+  for (const s of sites) {
+    const f = s.footer || {}
+    lines.push(
+      `| ${s.domain} | ${s.error ? 'DOWN' : s.httpStatus} | ${httpsCell(s)} | ` +
+        `${s.ok ? mark(f.footerMarker) : '—'} | ${s.ok ? mark(f.supportedBy) : '—'} | ` +
+        `${s.ok ? mark(f.ein) : '—'} | ${s.ok ? mark(f.hubLink) : '—'} | ${buildNotes(s)} |`
+    )
+  }
+  lines.push('')
+  lines.push('## Section B — Site health')
+  lines.push('')
+  lines.push('| Charity | HTTP status | HTTPS | Final URL | Redirect hops | Notes |')
+  lines.push('| ------- | ----------- | ----- | --------- | ------------- | ----- |')
+  for (const s of sites) {
+    const hops = s.redirectChain ? s.redirectChain.length - 1 : 0
+    lines.push(
+      `| ${s.domain} | ${s.error ? 'DOWN' : s.httpStatus} | ${httpsCell(s)} | ` +
+        `${s.finalUrl || '—'} | ${hops} | ${buildNotes(s)} |`
+    )
+  }
+  lines.push('')
+  return lines.join('\n')
+}
+
+// ---------------------------------------------------------------------------
+// Network probe (only used when run directly)
+// ---------------------------------------------------------------------------
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+async function fetchOnce(url) {
+  return fetch(url, {
+    redirect: 'manual',
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    headers: { 'user-agent': USER_AGENT, accept: 'text/html,*/*' },
+  })
+}
+
+/** Follow redirects manually so the chain is recorded. Throws on network/TLS errors. */
+async function follow(startUrl) {
+  const chain = []
+  let url = startUrl
+  for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+    const res = await fetchOnce(url)
+    chain.push({ url, status: res.status })
+    const location = res.headers.get('location')
+    if (res.status >= 300 && res.status < 400 && location) {
+      url = new URL(location, url).href
+      await sleep(PACING_MS)
+      continue
+    }
+    const body = await res.text()
+    return { chain, finalUrl: url, status: res.status, body }
+  }
+  return { chain, finalUrl: url, status: 0, body: '', tooManyRedirects: true }
+}
+
+/** Probe one site: HTTPS GET with redirect recording, one retry on failure. */
+async function probeSite(entry) {
+  const startUrl = `https://${entry.domain}/`
+  let retried = false
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      const res = await follow(startUrl)
+      const ok = res.status >= 200 && res.status < 400 && !res.tooManyRedirects
+      return {
+        ...entry,
+        ok,
+        httpStatus: res.status,
+        httpsOk: res.finalUrl.startsWith('https://'),
+        finalUrl: res.finalUrl,
+        redirectChain: res.chain,
+        footer: ok ? analyzeFooter(res.body) : null,
+        error: res.tooManyRedirects ? 'too many redirects' : null,
+        retried,
+      }
+    } catch (err) {
+      const { reason, tls } = classifyError(err)
+      if (attempt === 0) {
+        retried = true
+        await sleep(PACING_MS * 2)
+        continue
+      }
+      return {
+        ...entry,
+        ok: false,
+        httpStatus: null,
+        httpsOk: tls ? false : null,
+        finalUrl: null,
+        redirectChain: null,
+        footer: null,
+        error: reason,
+        retried,
+      }
+    }
+  }
+}
+
+async function main() {
+  const args = process.argv.slice(2)
+  const argValue = (flag, fallback) => {
+    const idx = args.indexOf(flag)
+    return idx !== -1 && args[idx + 1] ? args[idx + 1] : fallback
+  }
+  const jsonOut = argValue('--json', join(SCRIPT_DIR, '..', 'docs', 'fleet-audit.json'))
+  const mdOut = argValue('--md', join(SCRIPT_DIR, '..', 'docs', 'fleet-audit-report.md'))
+
+  const records = parseCsv(readFileSync(CSV_PATH, 'utf8'))
+  const fleet = selectFleet(records)
+  console.log(`Auditing ${fleet.length} live charity sites...`)
+
+  const results = []
+  for (const entry of fleet) {
+    const site = await probeSite(entry)
+    results.push(site)
+    const verdict = site.error
+      ? `DOWN (${site.error})`
+      : `${site.httpStatus}${isCompliant(site.footer) ? ' compliant' : ''}`
+    console.log(`  ${site.domain}: ${verdict}`)
+    await sleep(PACING_MS)
+  }
+
+  const generatedAt = new Date().toISOString()
+  const summary = buildSummary(results)
+  writeFileSync(
+    jsonOut,
+    JSON.stringify({ generatedAt, source: 'docs/sites_list.csv', summary, sites: results }, null, 2)
+  )
+  writeFileSync(mdOut, buildMarkdownReport(results, generatedAt.slice(0, 10)) + '\n')
+  console.log(
+    `\nDone: ${summary.compliant}/${summary.reachable} reachable sites footer-compliant, ` +
+      `${summary.down} down of ${summary.total} audited.`
+  )
+  console.log(`JSON: ${jsonOut}\nReport: ${mdOut}`)
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((err) => {
+    console.error(err)
+    process.exit(1)
+  })
+}


### PR DESCRIPTION
Refs FreeForCharity/FFC-Cloudflare-Automation#697 (overnight blocks 10+11)

## Summary

One polite probe pass over every **live charity site FFC serves**, producing a two-section report: (A) FFC footer-standard compliance, (B) site health. The fleet (85 sites) comes from `docs/sites_list.csv` — the same committed snapshot the `/sites-list` dashboard renders — filtered to Site Health = Live, still with FFC, not staging, not for-profit, and not expired/cancelled/fraud/transferred.

- **`scripts/fleet-audit.mjs`** — dependency-free prober: 250ms pacing, 10s timeout, one retry, manual redirect following (chain recorded), HTTPS/TLS validity via the request itself, and five footer-standard checks (FFC marker, freeforcharity.org link, hub link, EIN pattern, "Supported by" phrasing). Writes JSON (machine) + markdown report. Pure helpers exported for tests.
- **`docs/fleet-audit-report.md`** — committed point-in-time snapshot (generated 2026-07-12, re-runnable via script/workflow).
- **`.github/workflows/fleet-audit.yml`** — `workflow_dispatch` only; runs the script, uploads JSON+md artifacts, prints the report to the job summary. Plain `GITHUB_TOKEN`, no environment gate (read-only external GETs).
- **`__tests__/fleet-audit.test.js`** — 26 unit tests over the parsing/verdict/report functions (mocked data, no network).

## Headline numbers (2026-07-12 snapshot)

- **0 / 84** reachable sites meet the full footer standard (expected — the standard just shipped)
- **1 site down:** sporting2impact.org (TLS handshake failure, `ERR_SSL_PACKET_LENGTH_TOO_LONG`)
- Partial adoption: FFC marker on 23 sites, FFC link 17, EIN 15, "Supported by" 7, hub link 2

## Test plan

- [x] `pnpm jest __tests__/fleet-audit.test.js` — 26/26 pass
- [x] `pnpm run lint`, `pnpm run type-check`, `pnpm run format` — clean
- [x] `pnpm run build` + full `pnpm test` — 929/930 pass (single failure is the pre-existing Windows-only exec-bit check on `.husky/commit-msg`, green on ubuntu CI)
- [x] Script executed once for real (read-only GETs); report committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)