### PR TITLE
feat: auto-attach site-config partial to new work orders + sync integration tests

### DIFF
--- a/__tests__/fixtures/whmcs-get-clients-products.json
+++ b/__tests__/fixtures/whmcs-get-clients-products.json
@@ -1,0 +1,185 @@
+{
+  "//": "Realistic WHMCS GetClientsProducts response shapes for the sync integration tests. WHMCS's XML-ish JSON returns products.product as an ARRAY for several services, a single OBJECT for exactly one, and omits it for none. Statuses deliberately mix casing (WHMCS does not guarantee it). regdate '0000-00-00' is WHMCS's null date.",
+  "multi": {
+    "result": "success",
+    "totalresults": "9",
+    "startnumber": 0,
+    "numreturned": 9,
+    "products": {
+      "product": [
+        {
+          "id": "201",
+          "clientid": "90",
+          "pid": "33",
+          "name": "FFC Onboarding — 501(c)(3)",
+          "domain": "",
+          "regdate": "2026-07-12",
+          "status": "Active",
+          "customfields": {
+            "customfield": [
+              {
+                "id": "1",
+                "name": "Organization Type",
+                "value": "501(c)(3) Food, Water, or Shelter Organization"
+              },
+              {
+                "id": "2",
+                "name": "Mission Statement",
+                "value": "We provide shelter, food, and job placement to families in crisis."
+              },
+              { "id": "3", "name": "EIN", "value": "12-3456789" },
+              {
+                "id": "4",
+                "name": "GuideStar / Candid profile",
+                "value": "<a href=\"https://www.guidestar.org/profile/12-3456789\">profile</a>"
+              },
+              {
+                "id": "5",
+                "name": "Facebook Page",
+                "value": "https://www.facebook.com/helpinghandsshelter"
+              },
+              {
+                "id": "6",
+                "name": "LinkedIn Page",
+                "value": "https://www.linkedin.com/company/helping-hands-shelter/"
+              }
+            ]
+          }
+        },
+        {
+          "id": "202",
+          "clientid": "91",
+          "pid": "16",
+          "name": "FFC Onboarding — pre-501(c)(3)",
+          "regdate": "2026-07-15",
+          "status": "active",
+          "customfields": {
+            "customfield": [
+              {
+                "id": "2",
+                "name": "Mission Statement",
+                "value": "Neighborhood tool library for low-income makers."
+              }
+            ]
+          }
+        },
+        {
+          "id": "203",
+          "clientid": "92",
+          "pid": "33",
+          "name": "FFC Onboarding — 501(c)(3)",
+          "regdate": "2026-07-01",
+          "status": "Pending",
+          "customfields": { "customfield": [] }
+        },
+        {
+          "id": "204",
+          "clientid": "93",
+          "pid": "33",
+          "name": "FFC Onboarding — 501(c)(3)",
+          "regdate": "2026-05-20",
+          "status": "Cancelled",
+          "customfields": { "customfield": [] }
+        },
+        {
+          "id": "205",
+          "clientid": "94",
+          "pid": "16",
+          "name": "FFC Onboarding — pre-501(c)(3)",
+          "regdate": "2026-04-02",
+          "status": "Completed",
+          "customfields": { "customfield": [] }
+        },
+        {
+          "id": "206",
+          "clientid": "95",
+          "pid": "33",
+          "name": "FFC Onboarding — 501(c)(3)",
+          "regdate": "2026-06-01",
+          "status": "ACTIVE",
+          "customfields": { "customfield": [] }
+        },
+        {
+          "id": "207",
+          "clientid": "96",
+          "pid": "33",
+          "name": "FFC Onboarding — 501(c)(3)",
+          "regdate": "0000-00-00",
+          "status": "Active",
+          "customfields": { "customfield": [] }
+        },
+        {
+          "id": "208",
+          "clientid": "97",
+          "pid": "33",
+          "name": "FFC Onboarding — 501(c)(3)",
+          "regdate": "2026-03-15",
+          "status": "Terminated",
+          "customfields": { "customfield": [] }
+        },
+        {
+          "id": "209",
+          "clientid": "98",
+          "pid": "33",
+          "name": "FFC Onboarding — 501(c)(3)",
+          "regdate": "2026-03-16",
+          "status": "Fraud",
+          "customfields": { "customfield": [] }
+        }
+      ]
+    }
+  },
+  "single": {
+    "result": "success",
+    "totalresults": "1",
+    "startnumber": 0,
+    "numreturned": 1,
+    "products": {
+      "product": {
+        "id": "301",
+        "clientid": "90",
+        "pid": "33",
+        "name": "FFC Onboarding — 501(c)(3)",
+        "regdate": "2026-07-12",
+        "status": "Active",
+        "customfields": { "customfield": [] }
+      }
+    }
+  },
+  "empty": {
+    "result": "success",
+    "totalresults": "0",
+    "startnumber": 0,
+    "numreturned": 0
+  },
+  "singlePending": {
+    "result": "success",
+    "totalresults": "1",
+    "products": {
+      "product": {
+        "id": "203",
+        "clientid": "92",
+        "pid": "33",
+        "name": "FFC Onboarding — 501(c)(3)",
+        "regdate": "2026-07-01",
+        "status": "Pending",
+        "customfields": { "customfield": [] }
+      }
+    }
+  },
+  "singleTurnedActive": {
+    "result": "success",
+    "totalresults": "1",
+    "products": {
+      "product": {
+        "id": "203",
+        "clientid": "92",
+        "pid": "33",
+        "name": "FFC Onboarding — 501(c)(3)",
+        "regdate": "2026-07-01",
+        "status": "Active",
+        "customfields": { "customfield": [] }
+      }
+    }
+  }
+}

--- a/__tests__/intake-issues.test.js
+++ b/__tests__/intake-issues.test.js
@@ -23,8 +23,11 @@ let stubBody,
   loadState,
   labelsFor,
   hasHumanEdits,
+  configAttachment,
+  extractConfigAttachment,
   ID_MARKER,
-  VALIDATION_CHECKLIST
+  VALIDATION_CHECKLIST,
+  SAMPLE_APPLICATION
 
 beforeAll(async () => {
   const mod = await import('../scripts/lib/intake-issues.mjs')
@@ -35,8 +38,11 @@ beforeAll(async () => {
   loadState = mod.loadState
   labelsFor = mod.labelsFor
   hasHumanEdits = mod.hasHumanEdits
+  configAttachment = mod.configAttachment
+  extractConfigAttachment = mod.extractConfigAttachment
   ID_MARKER = mod.ID_MARKER
   VALIDATION_CHECKLIST = mod.VALIDATION_CHECKLIST
+  SAMPLE_APPLICATION = (await import('../scripts/generate-footer-config.mjs')).SAMPLE_APPLICATION
 })
 
 const repo = 'FreeForCharity/FFC-IN-ffcadmin.org'
@@ -70,6 +76,55 @@ describe('stubBody', () => {
     expect(body).not.toMatch(liveUrlRe) // the placeholder itself never parses as a URL
     const filled = body.replace(/^Live site:.*$/m, 'Live site: https://a.github.io/b/')
     expect(filled.match(liveUrlRe)?.[1]).toBe('https://a.github.io/b/')
+  })
+})
+
+describe('configAttachment / extractConfigAttachment', () => {
+  it('a validated record yields the collapsed SiteConfig partial with the manual-fields list', () => {
+    const block = configAttachment(SAMPLE_APPLICATION, repo)
+    expect(block).toMatch(
+      /^<details><summary>Generated site\.config partial \(from validated application data\)<\/summary>/
+    )
+    expect(block).toMatch(/<\/details>$/)
+    expect(block).toContain('```json')
+    expect(block).toContain(`"name": "${SAMPLE_APPLICATION.charityName}"`)
+    expect(block).toContain(`"ein": "${SAMPLE_APPLICATION.ein}"`)
+    expect(block).toContain('"supportedBy"')
+    expect(block).toContain('Manual fields:')
+    expect(block).toContain('`contactEmail`')
+    // Deterministic: no timestamp, so the block never churns on its own.
+    expect(configAttachment(SAMPLE_APPLICATION, repo)).toBe(block)
+  })
+
+  it('a record failing bridge validation yields the fail-open gap list instead', () => {
+    const block = configAttachment({ id: 'ffc-1', charityName: 'Bare Org' }, repo)
+    expect(block).toContain('config not generatable — missing:')
+    expect(block).toContain('missing "ein"')
+    expect(block).toContain('missing "candidUrl"')
+    expect(block).toContain('missing "charityStage"')
+    expect(block).not.toContain('```json')
+  })
+
+  it('round-trips through extractConfigAttachment from a full stub body', () => {
+    const attachment = configAttachment(SAMPLE_APPLICATION, repo)
+    const body = stubBody(SAMPLE_APPLICATION, repo, { attachment })
+    expect(extractConfigAttachment(body)).toBe(attachment)
+    // The attachment sits BEFORE the volunteer-owned Gate-3 block, keeping the
+    // validation checklist the last block in the body.
+    expect(body.indexOf('</details>')).toBeLessThan(body.indexOf('### Validation checklist'))
+    // A body without an attachment extracts to '' (pre-feature stubs).
+    expect(extractConfigAttachment(stubBody(SAMPLE_APPLICATION, repo))).toBe('')
+    expect(extractConfigAttachment(undefined)).toBe('')
+  })
+
+  it('an attached stub still refreshes cleanly: the attachment is not a human edit', () => {
+    const attachment = configAttachment(SAMPLE_APPLICATION, repo)
+    const existing = stubBody(SAMPLE_APPLICATION, repo, { attachment })
+    // The refresh path rebuilds the body with new data + the carried-over block.
+    const fresh = stubBody({ ...SAMPLE_APPLICATION, missionExcerpt: 'New mission' }, repo, {
+      attachment: extractConfigAttachment(existing),
+    })
+    expect(hasHumanEdits(existing, fresh)).toBe(false)
   })
 })
 

--- a/__tests__/whmcs-sync-integration.test.js
+++ b/__tests__/whmcs-sync-integration.test.js
@@ -1,0 +1,330 @@
+/**
+ * Integration tests for the WHMCS sync's production filter path, driven by
+ * realistic GetClientsProducts payload fixtures
+ * (`__tests__/fixtures/whmcs-get-clients-products.json`).
+ *
+ * Round-2 review gap: the status filter inside `collect()` was unexported and
+ * untested against real WHMCS response shapes. The filter path is now pure and
+ * exported (`productsFromResponse` + `isIntakeStatus`/`isPendingStatus` +
+ * `ingestProducts`), so these tests run the exact production code from raw
+ * payload to created/refreshed GitHub issues (mocked `fetch` — no network):
+ *
+ *   fixture response -> productsFromResponse -> ingestProducts
+ *     -> buildApplicationRecords -> syncIntakeIssues
+ *
+ * Covered: Active-vs-Pending filtering incl. case variants; the
+ * WHMCS_INTAKE_SINCE creation cutoff with pre-/post-/missing-date services;
+ * the pendingSeen-turned-Active bypass; single-element vs multi-element vs
+ * empty WHMCS response shapes; and the auto-attached site-config partial
+ * (attached on create — validated JSON or the fail-open gap list — and never
+ * regenerated on refresh).
+ */
+
+import { readFileSync } from 'fs'
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+const fixtures = JSON.parse(
+  readFileSync(join(__dirname, 'fixtures', 'whmcs-get-clients-products.json'), 'utf8')
+)
+
+let productsFromResponse, isIntakeStatus, isPendingStatus, ingestProducts, buildApplicationRecords
+let syncIntakeIssues, loadState, stubBody, configAttachment
+
+beforeAll(async () => {
+  const whmcs = await import('../scripts/whmcs-applications.mjs')
+  productsFromResponse = whmcs.productsFromResponse
+  isIntakeStatus = whmcs.isIntakeStatus
+  isPendingStatus = whmcs.isPendingStatus
+  ingestProducts = whmcs.ingestProducts
+  buildApplicationRecords = whmcs.buildApplicationRecords
+  const issues = await import('../scripts/lib/intake-issues.mjs')
+  syncIntakeIssues = issues.syncIntakeIssues
+  loadState = issues.loadState
+  stubBody = issues.stubBody
+  configAttachment = issues.configAttachment
+})
+
+const repo = 'FreeForCharity/FFC-IN-ffcadmin.org'
+const CUTOFF = '2026-07-11'
+
+/** Public company names GetClientsDetails would resolve (collect() step 2). */
+const COMPANIES = {
+  90: 'Helping Hands Shelter',
+  91: 'Neighborhood Tool Library',
+  92: 'Applied Early Org',
+  95: 'Historical Active Org',
+  96: 'Undated Org',
+}
+
+/**
+ * Run the production pipeline exactly as collect() does, minus the network:
+ * normalize the fixture response, ingest through the status filter, resolve
+ * company names, and build the PII-safe published records.
+ */
+function recordsFromResponse(resp) {
+  const byClient = new Map()
+  const pendingIds = new Set()
+  // collect() queries GetClientsProducts once per onboarding pid ('16,33') and
+  // ingests each response under that pid; the fixture folds both queries into
+  // one payload, so split it back out per pid here.
+  const products = productsFromResponse(resp)
+  for (const pid of ['16', '33']) {
+    ingestProducts(
+      pid,
+      products.filter((p) => p.pid === pid),
+      byClient,
+      pendingIds
+    )
+  }
+  for (const [clientId, rec] of byClient) rec.company = COMPANIES[clientId] || ''
+  return { applications: buildApplicationRecords(byClient), pendingIds }
+}
+
+describe('WHMCS response shapes (products.product)', () => {
+  it('normalizes the multi-element array shape', () => {
+    const products = productsFromResponse(fixtures.multi)
+    expect(Array.isArray(products)).toBe(true)
+    expect(products).toHaveLength(9)
+  })
+
+  it('normalizes the single-element OBJECT shape (one service -> no array)', () => {
+    const products = productsFromResponse(fixtures.single)
+    expect(products).toHaveLength(1)
+    expect(products[0].clientid).toBe('90')
+  })
+
+  it('normalizes the empty shape (products key omitted entirely)', () => {
+    expect(productsFromResponse(fixtures.empty)).toEqual([])
+    expect(productsFromResponse({})).toEqual([])
+    expect(productsFromResponse(undefined)).toEqual([])
+  })
+})
+
+describe('production status filter (Active vs Pending vs everything else)', () => {
+  it('accepts intake statuses case-insensitively and rejects all lifecycle rest', () => {
+    const products = productsFromResponse(fixtures.multi)
+    const eligible = products.filter(isIntakeStatus).map((p) => p.clientid)
+    // 'Active', 'active', 'ACTIVE' all pass; Pending/Cancelled/Completed/
+    // Terminated/Fraud never do.
+    expect(eligible.sort()).toEqual(['90', '91', '95', '96'])
+    const pending = products.filter(isPendingStatus).map((p) => p.clientid)
+    expect(pending).toEqual(['92'])
+  })
+
+  it('never treats a missing or unknown status as eligible', () => {
+    expect(isIntakeStatus({})).toBe(false)
+    expect(isIntakeStatus({ status: '' })).toBe(false)
+    expect(isIntakeStatus({ status: 'Suspended' })).toBe(false)
+    expect(isPendingStatus({})).toBe(false)
+  })
+
+  it('ingestProducts partitions the payload: eligible merged, pending tracked without a record', () => {
+    const byClient = new Map()
+    const pendingIds = new Set()
+    const { eligibleCount, pendingCount } = ingestProducts(
+      '33',
+      productsFromResponse(fixtures.multi),
+      byClient,
+      pendingIds
+    )
+    expect(eligibleCount).toBe(4)
+    expect(pendingCount).toBe(1)
+    expect([...byClient.keys()].sort()).toEqual(['90', '91', '95', '96'])
+    // Pending services get NO working record — only the tracked id.
+    expect(byClient.has('92')).toBe(false)
+    expect([...pendingIds]).toEqual(['ffc-92'])
+  })
+
+  it('derives the PII-safe fields through the real custom-field extractors', () => {
+    const { applications } = recordsFromResponse(fixtures.multi)
+    const shelter = applications.find((a) => a.id === 'ffc-90')
+    expect(shelter).toMatchObject({
+      charityName: 'Helping Hands Shelter',
+      charityStage: '501c3',
+      ein: '12-3456789',
+      candidUrl: 'https://www.guidestar.org/profile/12-3456789',
+      facebookUrl: 'https://www.facebook.com/helpinghandsshelter',
+      linkedinUrl: 'https://www.linkedin.com/company/helping-hands-shelter/',
+      submittedAt: '2026-07-12T00:00:00.000Z',
+    })
+    // WHMCS's null date '0000-00-00' must not become a submittedAt.
+    expect(applications.find((a) => a.id === 'ffc-96')).not.toHaveProperty('submittedAt')
+  })
+})
+
+describe('fixture payload -> issues (mocked GitHub)', () => {
+  let tmp, stateFile, calls, realFetch, existingIssues
+
+  const installFetchMock = () => {
+    global.fetch = jest.fn(async (url, init = {}) => {
+      const u = String(url)
+      const method = init.method || 'GET'
+      calls.push({ url: u, method, body: init.body })
+      const ok = (json) => ({ ok: true, status: 200, json: async () => json })
+      if (method === 'GET' && u.includes('/issues?labels=')) {
+        return ok(u.includes('page=1') ? existingIssues : [])
+      }
+      if (method === 'POST' && u.endsWith('/issues')) return ok({ number: 100 })
+      return ok({})
+    })
+  }
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'whmcs-sync-'))
+    stateFile = join(tmp, 'state.json')
+    calls = []
+    existingIssues = []
+    realFetch = global.fetch
+    installFetchMock()
+  })
+
+  afterEach(() => {
+    global.fetch = realFetch
+    rmSync(tmp, { recursive: true, force: true })
+  })
+
+  const creates = () => calls.filter((c) => c.method === 'POST' && c.url.endsWith('/issues'))
+  const patches = () => calls.filter((c) => c.method === 'PATCH')
+  const createdBodies = () => creates().map((c) => JSON.parse(c.body))
+
+  const sync = (resp, overrides = {}) => {
+    const { applications, pendingIds } = recordsFromResponse(resp)
+    return syncIntakeIssues({
+      applications,
+      repo,
+      token: 'test-token',
+      stateFile,
+      source: 'WHMCS',
+      createNewSince: CUTOFF,
+      pendingIds,
+      ...overrides,
+    })
+  }
+
+  it('creates issues only for post-cutoff approved services; pre-cutoff and undated stay silent', async () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    const result = await sync(fixtures.multi)
+
+    // 90 + 91 postdate the cutover; 95 (2026-06-01) is flood-guarded; 96 has
+    // WHMCS's null date; 92 is Pending (tracked, no issue); the rest are
+    // Cancelled/Completed/Terminated/Fraud and never reach the sync at all.
+    expect(result.created).toBe(2)
+    const titles = createdBodies().map((b) => b.title)
+    expect(titles).toEqual(['[Intake] Helping Hands Shelter', '[Intake] Neighborhood Tool Library'])
+    // The undated-but-approved service is named for human follow-up.
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('Undated Org (ffc-96)'))
+    // The Pending id is persisted for the post-approval bypass.
+    expect(loadState(stateFile).pendingSeenIds).toEqual(['ffc-92'])
+    warn.mockRestore()
+  })
+
+  it('pendingSeen-turned-Active: a pre-cutoff application creates its work order once approved', async () => {
+    // Run 1: the service is Pending in WHMCS — tracked, no issue.
+    await sync(fixtures.singlePending)
+    expect(creates()).toHaveLength(0)
+    expect(loadState(stateFile).pendingSeenIds).toEqual(['ffc-92'])
+
+    // Run 2: the SAME service is now Active. Its application date (2026-07-01)
+    // predates the cutoff, but the pendingSeen record bypasses the flood guard.
+    calls = []
+    const result = await sync(fixtures.singleTurnedActive)
+    expect(result.created).toBe(1)
+    expect(createdBodies()[0].title).toBe('[Intake] Applied Early Org')
+    // The id graduates out of pending tracking once its issue exists.
+    const state = loadState(stateFile)
+    expect(state.seenApplicationIds).toEqual(['ffc-92'])
+    expect(state.pendingSeenIds).toEqual([])
+  })
+
+  describe('auto-attached site-config partial', () => {
+    it('a validated 501(c)(3) record gets the collapsed JSON partial on create', async () => {
+      await sync(fixtures.multi)
+      const shelter = createdBodies().find((b) => b.title.includes('Helping Hands'))
+      expect(shelter.body).toContain(
+        '<details><summary>Generated site.config partial (from validated application data)</summary>'
+      )
+      expect(shelter.body).toContain('```json')
+      // Real values from the fixture payload flow into the SiteConfig shape.
+      expect(shelter.body).toContain('"name": "Helping Hands Shelter"')
+      expect(shelter.body).toContain('"ein": "12-3456789"')
+      expect(shelter.body).toContain('"profileUrl": "https://www.guidestar.org/profile/12-3456789"')
+      expect(shelter.body).toContain('"href": "https://www.facebook.com/helpinghandsshelter"')
+      // Permanent FFC attribution + the fill-by-hand list ride along.
+      expect(shelter.body).toContain('"supportedBy"')
+      expect(shelter.body).toContain('Manual fields:')
+      expect(shelter.body).toContain('`contactEmail`')
+      // The attachment must sit BEFORE the volunteer-owned validation block.
+      expect(shelter.body.indexOf('</details>')).toBeLessThan(
+        shelter.body.indexOf('### Validation checklist (Gate 3)')
+      )
+    })
+
+    it('a record failing bridge validation gets the fail-open gap list instead', async () => {
+      await sync(fixtures.multi)
+      const library = createdBodies().find((b) => b.title.includes('Tool Library'))
+      expect(library.body).toContain('config not generatable — missing:')
+      // pre-501(c)(3), no EIN, no Candid URL — every gap is itemized.
+      expect(library.body).toContain('missing "ein"')
+      expect(library.body).toContain('missing "candidUrl"')
+      expect(library.body).toContain('footer generation requires a validated 501c3 application')
+      expect(library.body).not.toContain('```json')
+    })
+
+    it('refresh never regenerates or invents an attachment (pre-attachment stubs stay bare)', async () => {
+      const { applications } = recordsFromResponse(fixtures.single)
+      const app = applications[0]
+      // An existing bot stub created BEFORE the auto-attach feature, with stale
+      // data so the refresh has something to update.
+      existingIssues = [
+        {
+          number: 7,
+          user: { login: 'github-actions[bot]' },
+          title: '[Intake] Old Name',
+          body: stubBody({ ...app, charityName: 'Old Name' }, repo),
+        },
+      ]
+      const result = await sync(fixtures.single)
+      expect(result.created).toBe(0)
+      expect(result.updated).toBe(1)
+      const patched = JSON.parse(patches()[0].body)
+      expect(patched.body).not.toContain('Generated site.config partial')
+    })
+
+    it('refresh carries an existing attachment over verbatim (no churn, no clobber)', async () => {
+      const { applications } = recordsFromResponse(fixtures.multi)
+      const app = applications.find((a) => a.id === 'ffc-90')
+      const attachment = configAttachment(app, repo)
+      // Identical data -> identical body -> no PATCH at all (no churn).
+      existingIssues = [
+        {
+          number: 8,
+          user: { login: 'github-actions[bot]' },
+          title: '[Intake] Helping Hands Shelter',
+          body: stubBody(app, repo, { attachment }),
+        },
+      ]
+      let result = await sync(fixtures.multi)
+      expect(result.updated).toBe(0)
+      expect(patches()).toHaveLength(0)
+
+      // Changed data -> the refresh updates the fields but keeps the
+      // creation-time attachment byte-for-byte.
+      calls = []
+      existingIssues = [
+        {
+          number: 8,
+          user: { login: 'github-actions[bot]' },
+          title: '[Intake] Old Shelter Name',
+          body: stubBody({ ...app, charityName: 'Old Shelter Name' }, repo, { attachment }),
+        },
+      ]
+      result = await sync(fixtures.multi)
+      expect(result.updated).toBe(1)
+      const patched = JSON.parse(patches()[0].body)
+      expect(patched.body).toContain(attachment)
+      expect(patched.title).toBe('[Intake] Helping Hands Shelter')
+    })
+  })
+})

--- a/docs/footer-bridge.md
+++ b/docs/footer-bridge.md
@@ -67,9 +67,22 @@ The charity Facebook/LinkedIn **page** URLs collected by the hardened onboarding
 flow straight into `social`; only applications that predate those fields need volunteer fill-in
 for social links.
 
+## Auto-attached to new work orders
+
+Since the intake sync's auto-attach landed, every **newly created** `kind:intake` work-order issue
+already carries this bridge's output, generated at creation time from the same application record:
+a collapsed **"Generated site.config partial (from validated application data)"** block holding the
+`siteConfig` JSON plus the manual-fields checklist — or, when the record fails validation, the
+fail-open gap list (`config not generatable — missing: …`) so the volunteer knows exactly what to
+chase in WHMCS. The block is generated **once, on creation, never on refresh**: the daily sync
+carries it over verbatim (including any edits made inside it). Work orders created before the
+feature stay bare — for those, or to regenerate after WHMCS data is fixed, run the CLI steps below.
+
 ## How a volunteer uses it (website-provisioning work order)
 
 1. Open the charity's `kind:intake` work-order issue; note the application id (`ffc-<clientId>`).
+   **If the issue already has the collapsed "Generated site.config partial" block with JSON, skip
+   to step 5 using that block.**
 2. Get the application record: run the **WHMCS Intake** workflow with dry-run enabled and copy the
    record from the log, or save the JSON array to a file.
 3. Generate the partial (from the FFC-IN-ffcadmin.org repo root):

--- a/docs/gated-journey-operator-runbook.md
+++ b/docs/gated-journey-operator-runbook.md
@@ -162,7 +162,12 @@ lands, the checklist is verified by hand exactly as in the pilot (Section 7).
 
 ### Footer-config bridge (the checklist's footer item)
 
-The footer must be **generated from validated application data, not hand-typed**. Use
+The footer must be **generated from validated application data, not hand-typed**. Newly created
+work orders already carry the bridge's output as a collapsed **"Generated site.config partial"**
+block in the issue body (creation-time only; the daily refresh never regenerates it) — either the
+`siteConfig` JSON plus manual-fields checklist, or the fail-open gap list when the application
+fails validation. Use that block directly (jump to step 4). For older work orders, or to
+regenerate after fixing WHMCS data, run
 [`scripts/generate-footer-config.mjs`](../scripts/generate-footer-config.mjs) per
 [footer-bridge.md](./footer-bridge.md):
 

--- a/docs/intake-automation-architecture.md
+++ b/docs/intake-automation-architecture.md
@@ -106,11 +106,15 @@ same issue plumbing so dedup, body, and labels stay identical.
 
 One `kind:intake` issue per approved application (label `status:needs-admin` at creation). The
 stub body carries: a welcome preamble with the `ffc-application-id` dedup marker; structured intake
-fields pre-filled from the application; the **Gate-3 validation checklist** (8 objective items,
-Section 4b) as the last, volunteer-owned block; and the **`Live site:` line** whose placeholder
-deliberately contains no `http(s)` URL. Existing issues are found by marker (survives state-file
-loss) and their data fields refreshed daily — unless `hasHumanEdits()` detects a ticked box, a
-filled `Live site:` URL, or any structural edit, after which the issue is human-owned.
+fields pre-filled from the application; a collapsed **auto-attached site-config partial** generated
+at creation by the footer bridge — the validated `siteConfig` JSON plus its manual-fields
+checklist, or (fail-open) the `config not generatable — missing: …` gap list when the record fails
+the bridge's validation; the **Gate-3 validation checklist** (8 objective items, Section 4b) as
+the last, volunteer-owned block; and the **`Live site:` line** whose placeholder deliberately
+contains no `http(s)` URL. Existing issues are found by marker (survives state-file loss) and
+their data fields refreshed daily — the site-config attachment is never regenerated on refresh,
+only carried over verbatim — unless `hasHumanEdits()` detects a ticked box, a filled `Live site:`
+URL, or any structural edit, after which the issue is human-owned.
 
 ### Roadmap data generator — `scripts/generate-roadmap-data.ts`
 

--- a/scripts/lib/intake-issues.mjs
+++ b/scripts/lib/intake-issues.mjs
@@ -12,6 +12,9 @@
  */
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs'
 import { dirname } from 'path'
+// The site-config bridge (Gate 3): pure transform + validator, no CLI side
+// effects on import (its main() is guarded by an argv check).
+import { buildSiteConfigPartial, validateApplication } from '../generate-footer-config.mjs'
 
 export const ID_MARKER = 'ffc-application-id'
 
@@ -116,14 +119,88 @@ export const VALIDATION_CHECKLIST = [
   'Content reviewed and approved by the charity',
 ]
 
+// The auto-attached site-config block is identified by this exact <summary>
+// text — the extractor below greps for it, so keep builder and regex in sync.
+const CONFIG_ATTACHMENT_SUMMARY = 'Generated site.config partial (from validated application data)'
+const CONFIG_ATTACHMENT_RE = new RegExp(
+  `<details><summary>${CONFIG_ATTACHMENT_SUMMARY.replace(/[.()]/g, '\\$&')}</summary>[\\s\\S]*?</details>`
+)
+
+/**
+ * Build the collapsed site-config attachment for a NEW work-order issue: the
+ * SiteConfig partial generated from the validated application record by the
+ * footer bridge (scripts/generate-footer-config.mjs), plus the manual-fields
+ * checklist. Fail-open per record: when the record fails the bridge's
+ * validation, the block carries the failure list instead — the volunteer sees
+ * exactly which onboarding gaps to chase in WHMCS rather than a silent gap.
+ * Deliberately timestamp-free so the attachment is deterministic for a given
+ * record. Exported for unit testing.
+ */
+export function configAttachment(app, repo) {
+  const open = [`<details><summary>${CONFIG_ATTACHMENT_SUMMARY}</summary>`, '']
+  const close = ['', '</details>']
+  const bridgeDoc = `https://github.com/${repo}/blob/main/docs/footer-bridge.md`
+  let problems = validateApplication(app)
+  if (problems.length === 0) {
+    let partial
+    try {
+      partial = buildSiteConfigPartial(app)
+    } catch (err) {
+      problems = [errMsg(err)] // fail open: attach the reason, never abort the create
+    }
+    if (partial) {
+      return [
+        ...open,
+        "_Transcribe into the charity repo's `src/lib/site.config.ts` (key names and nesting_",
+        `_match one-for-one). See [footer-bridge.md](${bridgeDoc}); never change or drop \`supportedBy\`._`,
+        '',
+        '```json',
+        JSON.stringify(partial.siteConfig, null, 2),
+        '```',
+        '',
+        'Manual fields: the application cannot supply these — fill each by hand:',
+        '',
+        ...partial.manualFields.map((f) => `- \`${f.key}\` — ${f.note}`),
+        ...close,
+      ].join('\n')
+    }
+  }
+  return [
+    ...open,
+    'config not generatable — missing:',
+    '',
+    ...problems.map((p) => `- ${p}`),
+    '',
+    '_These are onboarding gaps: complete them in WHMCS (see_',
+    `_[footer-bridge.md](${bridgeDoc})), then regenerate with_`,
+    '_`node scripts/generate-footer-config.mjs` — never guess values._',
+    ...close,
+  ].join('\n')
+}
+
+/**
+ * Pull the auto-attached site-config block out of an existing issue body ('' if
+ * absent). The daily refresh carries it over VERBATIM — including any edits a
+ * volunteer made inside it — because the attachment is generated once, at issue
+ * creation, and never regenerated. Exported for unit testing.
+ */
+export function extractConfigAttachment(body) {
+  const m = String(body ?? '').match(CONFIG_ATTACHMENT_RE)
+  return m ? m[0] : ''
+}
+
 /**
  * Build the stub issue body. The leading block is a human-facing welcome plus
  * the dedup marker; the issue-form parser drops that preamble (it has no `###`
  * heading) and reads the structured fields below. Pre-filling the fields we know
  * from the application makes the readiness engine + roadmap card show an
  * accurate charity status, mission, and tier instead of empty defaults.
+ *
+ * `attachment` (optional) is a pre-built site-config <details> block (see
+ * configAttachment): the creation path generates it fresh; the refresh path
+ * passes through whatever block the existing issue already carries.
  */
-export function stubBody(app, repo) {
+export function stubBody(app, repo, { attachment = '' } = {}) {
   const name = app.charityName || 'your charity'
   const tier = app.serviceTier ? `\n\n**Service requested:** ${app.serviceTier}` : ''
   const lines = [
@@ -153,6 +230,10 @@ export function stubBody(app, repo) {
   field('Brief mission', app.missionExcerpt)
   field('EIN', app.ein)
   field('Candid / GuideStar profile URL', app.candidUrl)
+  // Collapsed site-config attachment (creation-time only; carried over verbatim
+  // on refresh). Sits BETWEEN the data fields and the validation checklist so
+  // the volunteer-owned validation block stays last (see hasHumanEdits).
+  if (attachment) lines.push(String(attachment).trim(), '')
   // Gate-3 validation checklist (docs Section 4b): the work order carries the
   // checklist where the sponsoring admin ticks it. Keep this block LAST — the
   // human-edit detector treats everything from its heading onward as the
@@ -341,12 +422,16 @@ export async function syncIntakeIssues({
     if (!id) continue
     try {
       const title = `[Intake] ${app.charityName || id}`
-      const body = stubBody(app, repo)
       // Marker lookup FIRST: an existing issue is always refreshed (the cutoff
       // below only guards NEW creation), so pre-cutoff charities keep their
       // refresh behaviour even if the state file is ever lost.
       const existing = await findIssueForId(id)
       if (existing) {
+        // Refresh path: NEVER regenerate the site-config attachment — carry
+        // whatever block the issue already has (or none) over verbatim, so the
+        // creation-time attachment (and any volunteer edits inside it) survives
+        // data refreshes without producing churn of its own.
+        const body = stubBody(app, repo, { attachment: extractConfigAttachment(existing.body) })
         if (isRefreshableStub(existing) && (existing.body !== body || existing.title !== title)) {
           // Never clobber human edits — ticked validation checkboxes, a filled
           // "Live site:" URL, or any structural change survive the refresh.
@@ -377,6 +462,9 @@ export async function syncIntakeIssues({
         }
         continue
       }
+      // Creation path: the ONE place the site-config attachment is generated
+      // (validated partial, or the fail-open gap list for the volunteer).
+      const body = stubBody(app, repo, { attachment: configAttachment(app, repo) })
       await gh(`/repos/${repo}/issues`, {
         method: 'POST',
         body: JSON.stringify({ title, body, labels: labelsFor(app) }),

--- a/scripts/lib/intake-issues.mjs
+++ b/scripts/lib/intake-issues.mjs
@@ -123,7 +123,7 @@ export const VALIDATION_CHECKLIST = [
 // text — the extractor below greps for it, so keep builder and regex in sync.
 const CONFIG_ATTACHMENT_SUMMARY = 'Generated site.config partial (from validated application data)'
 const CONFIG_ATTACHMENT_RE = new RegExp(
-  `<details><summary>${CONFIG_ATTACHMENT_SUMMARY.replace(/[.()]/g, '\\$&')}</summary>[\\s\\S]*?</details>`
+  `<details><summary>${CONFIG_ATTACHMENT_SUMMARY.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}</summary>[\\s\\S]*?</details>`
 )
 
 /**

--- a/scripts/whmcs-applications.mjs
+++ b/scripts/whmcs-applications.mjs
@@ -371,9 +371,97 @@ export function buildApplicationRecords(byClient) {
   )
 }
 
+/**
+ * Normalize a GetClientsProducts response to a product array. WHMCS's XML-ish
+ * JSON returns `products.product` as an ARRAY for several services, a single
+ * OBJECT for exactly one, and omits it entirely for none — all three shapes
+ * must land as a plain array. Exported for unit testing.
+ */
+export function productsFromResponse(resp) {
+  return [].concat(resp?.products?.product || [])
+}
+
+/**
+ * The production status filter: true when a client product's WHMCS service
+ * status is an intake (approved) status — the gate that decides whether a
+ * work-order issue may exist at all. Case-insensitive (WHMCS status casing is
+ * not guaranteed). Exported for unit testing.
+ */
+export const isIntakeStatus = (product) =>
+  INTAKE_STATUSES.has(String(product?.status || '').toLowerCase())
+
+/** True when the service status means "application still under review". Exported for unit testing. */
+export const isPendingStatus = (product) =>
+  PENDING_STATUSES.has(String(product?.status || '').toLowerCase())
+
+/**
+ * Pure per-pid ingest (the production filter path, extracted from collect() so
+ * fixture payloads can drive it without network): partition one product list
+ * into intake-eligible vs pending, record pending owners in `pendingIds`
+ * (tracked, no issue — see PENDING_STATUSES), and merge each eligible
+ * product's PII-safe working fields into `byClient`. A client holding both
+ * products is listed once; the 501c3 product (pid 33) wins for the tier label.
+ * Returns the partition sizes for logging. Exported for unit testing.
+ */
+export function ingestProducts(pid, products, byClient, pendingIds) {
+  const eligible = products.filter(isIntakeStatus)
+  const pending = products.filter(isPendingStatus)
+  for (const p of pending) {
+    const clientId = String(p?.clientid || '').trim()
+    if (clientId) pendingIds.add(`ffc-${clientId}`)
+  }
+  for (const p of eligible) {
+    const clientId = String(p?.clientid || '').trim()
+    if (!clientId) continue
+    const regIso = isoDate(p?.regdate)
+    const mission = missionFromProduct(p)
+    const missionOption = missionTierFromProduct(p)
+    // Non-PII transparency fields (allowlisted by field name; board/contact
+    // fields are never matched). Candid link + EIN help donors evaluate.
+    const candidUrl = sanitizeCandidUrl(fieldValue(p, /guidestar|candid/i))
+    const ein = sanitizeEin(fieldValue(p, /\bEIN\b|tax id/i))
+    // Charity social PAGE URLs — the onboarding products carry custom fields
+    // slugged `facebook-page` / `linkedin-page` (org pages, not personal
+    // profiles). The strict "page" suffix keeps board-member profile fields
+    // (e.g. "President — linkedin url") out by construction.
+    const facebookUrl = sanitizeSocialUrl(
+      fieldValue(p, /facebook[\s_-]*page/i),
+      /(^|\.)facebook\.com$/i
+    )
+    const linkedinUrl = sanitizeSocialUrl(
+      fieldValue(p, /linkedin[\s_-]*page/i),
+      /(^|\.)linkedin\.com$/i
+    )
+    const existing = byClient.get(clientId)
+    if (existing) {
+      if (pid === '33') existing.pid = pid
+      if (!existing.mission && mission) existing.mission = mission
+      if (!existing.missionOption && missionOption) existing.missionOption = missionOption
+      if (!existing.regIso && regIso) existing.regIso = regIso
+      if (!existing.candidUrl && candidUrl) existing.candidUrl = candidUrl
+      if (!existing.ein && ein) existing.ein = ein
+      if (!existing.facebookUrl && facebookUrl) existing.facebookUrl = facebookUrl
+      if (!existing.linkedinUrl && linkedinUrl) existing.linkedinUrl = linkedinUrl
+    } else {
+      byClient.set(clientId, {
+        clientId,
+        pid,
+        mission,
+        missionOption,
+        regIso,
+        candidUrl,
+        ein,
+        facebookUrl,
+        linkedinUrl,
+        company: undefined,
+      })
+    }
+  }
+  return { eligibleCount: eligible.length, pendingCount: pending.length }
+}
+
 async function collect() {
-  // clientId -> working record. A client holding both products is listed once;
-  // the 501c3 product (pid 33) wins for the tier label.
+  // clientId -> working record (see ingestProducts).
   const byClient = new Map()
   // Service ids currently PENDING (application under review): recorded in the
   // sync state so a later approval creates a work order even when the
@@ -387,68 +475,12 @@ async function collect() {
       console.warn(`WHMCS GetClientsProducts pid=${pid} failed: ${errMsg(err)}`)
       continue
     }
-    const products = [].concat(resp?.products?.product || [])
-    const eligible = products.filter((p) =>
-      INTAKE_STATUSES.has(String(p?.status || '').toLowerCase())
-    )
-    const pending = products.filter((p) =>
-      PENDING_STATUSES.has(String(p?.status || '').toLowerCase())
-    )
-    for (const p of pending) {
-      const clientId = String(p?.clientid || '').trim()
-      if (clientId) pendingIds.add(`ffc-${clientId}`)
-    }
+    const products = productsFromResponse(resp)
+    const { eligibleCount, pendingCount } = ingestProducts(pid, products, byClient, pendingIds)
     console.log(
-      `pid ${pid} -> ${products.length} client product(s); ${eligible.length} in intake status ` +
-        `[${[...INTAKE_STATUSES].join(', ')}]; ${pending.length} pending (tracked, no issue)`
+      `pid ${pid} -> ${products.length} client product(s); ${eligibleCount} in intake status ` +
+        `[${[...INTAKE_STATUSES].join(', ')}]; ${pendingCount} pending (tracked, no issue)`
     )
-    for (const p of eligible) {
-      const clientId = String(p?.clientid || '').trim()
-      if (!clientId) continue
-      const regIso = isoDate(p?.regdate)
-      const mission = missionFromProduct(p)
-      const missionOption = missionTierFromProduct(p)
-      // Non-PII transparency fields (allowlisted by field name; board/contact
-      // fields are never matched). Candid link + EIN help donors evaluate.
-      const candidUrl = sanitizeCandidUrl(fieldValue(p, /guidestar|candid/i))
-      const ein = sanitizeEin(fieldValue(p, /\bEIN\b|tax id/i))
-      // Charity social PAGE URLs — the onboarding products carry custom fields
-      // slugged `facebook-page` / `linkedin-page` (org pages, not personal
-      // profiles). The strict "page" suffix keeps board-member profile fields
-      // (e.g. "President — linkedin url") out by construction.
-      const facebookUrl = sanitizeSocialUrl(
-        fieldValue(p, /facebook[\s_-]*page/i),
-        /(^|\.)facebook\.com$/i
-      )
-      const linkedinUrl = sanitizeSocialUrl(
-        fieldValue(p, /linkedin[\s_-]*page/i),
-        /(^|\.)linkedin\.com$/i
-      )
-      const existing = byClient.get(clientId)
-      if (existing) {
-        if (pid === '33') existing.pid = pid
-        if (!existing.mission && mission) existing.mission = mission
-        if (!existing.missionOption && missionOption) existing.missionOption = missionOption
-        if (!existing.regIso && regIso) existing.regIso = regIso
-        if (!existing.candidUrl && candidUrl) existing.candidUrl = candidUrl
-        if (!existing.ein && ein) existing.ein = ein
-        if (!existing.facebookUrl && facebookUrl) existing.facebookUrl = facebookUrl
-        if (!existing.linkedinUrl && linkedinUrl) existing.linkedinUrl = linkedinUrl
-      } else {
-        byClient.set(clientId, {
-          clientId,
-          pid,
-          mission,
-          missionOption,
-          regIso,
-          candidUrl,
-          ein,
-          facebookUrl,
-          linkedinUrl,
-          company: undefined,
-        })
-      }
-    }
   }
   // Resolve the public organization name per client (read-only, no stats).
   for (const [clientId, rec] of byClient) {


### PR DESCRIPTION
Refs FreeForCharity/FFC-Cloudflare-Automation#697 (overnight blocks 3+14)

## Summary

**Block 3 — footer-config auto-attach.** When the WHMCS sync creates a NEW `kind:intake` work-order issue, it now generates the SiteConfig partial from the application record — reusing the footer bridge's exported transform (`buildSiteConfigPartial` / `validateApplication` from `scripts/generate-footer-config.mjs`, imported, not shelled out) — and appends it to the stub body inside a collapsed `<details><summary>Generated site.config partial (from validated application data)</summary>` block: the `siteConfig` JSON plus the manual-fields checklist. Fail-open per issue: a record failing the bridge's validation gets the gap list (`config not generatable — missing: ...`) instead, so the volunteer knows what to chase in WHMCS. Attach happens **only on CREATE, never on refresh** — the daily refresh carries the existing block over verbatim (including volunteer edits inside it), keeping PR #598's refresh-preservation logic intact with zero attachment churn.

**Block 14 — sync integration tests.** The round-2 review found the production status-filter path in `collect()` unexported and untested against realistic WHMCS payload shapes. Minimal, behavior-preserving refactor of `scripts/whmcs-applications.mjs`: `productsFromResponse()` (array / single-object / omitted shapes), `isIntakeStatus` / `isPendingStatus` predicates, and the pure per-pid `ingestProducts()` extracted from `collect()`. New fixture-driven suite (`__tests__/whmcs-sync-integration.test.js` + `__tests__/fixtures/whmcs-get-clients-products.json`) drives the real production code from raw payload to mocked GitHub issues.

## Coverage added

- Active-vs-Pending filtering incl. case variants (`Active`/`active`/`ACTIVE` pass; `Pending`/`Cancelled`/`Completed`/`Terminated`/`Fraud`/missing never do)
- `WHMCS_INTAKE_SINCE` creation cutoff with pre-/post-cutoff dates and WHMCS's `0000-00-00` null date (undated approved records warn by name)
- pendingSeen-turned-Active bypass (pre-cutoff application approved post-cutoff still gets its work order, then graduates out of pending tracking)
- single-element (object) vs multi-element (array) vs empty `products.product` response shapes
- Auto-attach: validated JSON partial on create, fail-open gap list on create, absent when refreshing pre-feature stubs, preserved byte-for-byte when refreshing attached stubs (and no-churn when data is unchanged)
- Unit tests for `configAttachment` / `extractConfigAttachment` round-trip, determinism, placement before the volunteer-owned Gate-3 block, and refresh-compatibility with `hasHumanEdits`

## Test plan

- `npx jest` — 943/944 pass locally; the sole failure is the known Windows-worktree husky executable-bit check (environmental)
- `prettier --check` and `eslint` clean on all touched files
- Docs updated: `docs/footer-bridge.md`, `docs/gated-journey-operator-runbook.md`, `docs/intake-automation-architecture.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)