### PR TITLE
fix(footer): bring ffcadmin.org footer to full FFC footer standard (Level 2)

### DIFF
--- a/__tests__/components/Footer.test.tsx
+++ b/__tests__/components/Footer.test.tsx
@@ -33,13 +33,33 @@ describe('Footer Component', () => {
       expect(screen.getByText(/501\(c\)\(3\) nonprofit/i)).toBeInTheDocument()
     })
 
-    it('should have link to main Free For Charity website', () => {
+    it('should have "Supported by" attribution linking to Free For Charity', () => {
       render(<Footer />)
-      const ffcLink = screen.getByRole('link', { name: /A project of Free For Charity/i })
+      const ffcLink = screen.getByRole('link', { name: /Supported by Free For Charity/i })
       expect(ffcLink).toBeInTheDocument()
       expect(ffcLink).toHaveAttribute('href', 'https://freeforcharity.org')
       expect(ffcLink).toHaveAttribute('target', '_blank')
       expect(ffcLink).toHaveAttribute('rel', 'noopener noreferrer')
+    })
+
+    it('should have Supported Charity Login link to the FFC hub', () => {
+      render(<Footer />)
+      const hubLink = screen.getByRole('link', { name: /Supported Charity Login/i })
+      expect(hubLink).toBeInTheDocument()
+      expect(hubLink).toHaveAttribute('href', 'https://freeforcharity.org/hub/')
+      expect(hubLink).toHaveAttribute('target', '_blank')
+      expect(hubLink).toHaveAttribute('rel', 'noopener noreferrer')
+    })
+
+    it('should display the FFC EIN block', () => {
+      render(<Footer />)
+      expect(screen.getByText(/EIN[:\s]*46-2471893/i)).toBeInTheDocument()
+    })
+
+    it('should link to the GuideStar profile by EIN', () => {
+      render(<Footer />)
+      const guidestarLink = screen.getByRole('link', { name: /View Full GuideStar Profile/i })
+      expect(guidestarLink).toHaveAttribute('href', 'https://www.guidestar.org/profile/46-2471893')
     })
 
     it('should display privacy policy link', () => {

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -9,8 +9,7 @@ declare global {
   }
 }
 
-const GUIDESTAR_PROFILE_URL =
-  'https://www.guidestar.org/profile/shared/bbbe173a-87b9-4af9-a8a2-cae255a95742'
+const GUIDESTAR_PROFILE_URL = 'https://www.guidestar.org/profile/46-2471893'
 
 export default function Footer() {
   return (
@@ -356,6 +355,16 @@ export default function Footer() {
               </li>
               <li>
                 <a
+                  href="https://freeforcharity.org/hub/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-gray-400 hover:text-white transition-colors"
+                >
+                  Supported Charity Login
+                </a>
+              </li>
+              <li>
+                <a
                   href="https://freeforcharity.org/"
                   target="_blank"
                   rel="noopener noreferrer"
@@ -556,7 +565,7 @@ export default function Footer() {
                 className="hover:opacity-80 transition-opacity"
                 style={{ color: 'var(--color-ffc-teal)' }}
               >
-                A project of Free For Charity
+                Supported by Free For Charity
               </a>
             </p>
             <p className="mt-2">


### PR DESCRIPTION
Refs FreeForCharity/FFC-Cloudflare-Automation#697 (fleet footer retrofit — pilot 1: our own site)

## Summary

The fleet audit (`docs/fleet-audit-report.md`) classifies ffcadmin.org as attribution-only: **missing hub link** and **legacy attribution wording** (target: "Supported by"). FFC's own admin portal must pass its own standard — Level 2 (full 501(c)(3)), since ffcadmin IS Free For Charity (EIN 46-2471893). This PR is pilot 1 of the fleet footer retrofit program: standardize on ourselves first.

- **Attribution**: `A project of Free For Charity` → `Supported by Free For Charity` (the target wording `scripts/fleet-audit.mjs` tracks via its `supportedBy` check), still linking to https://freeforcharity.org
- **Hub link**: new **Supported Charity Login** link to https://freeforcharity.org/hub/ in the *For Charities & Donors* footer column (satisfies the audit's `hubLink` regex)
- **GuideStar**: profile link now uses the canonical EIN-based URL https://www.guidestar.org/profile/46-2471893 (was an opaque `profile/shared/…` UUID link); Platinum Seal widget unchanged
- **Already compliant, untouched**: FFC marker, freeforcharity.org link, EIN block (46-2471893), build-time current-year copyright
- Footer design/layout preserved — content adapted in place, not transplanted

Unit tests updated for the new attribution wording, plus new coverage for the hub link, EIN block, and EIN-based GuideStar link.

## Test plan

- [x] `pnpm run format` / `lint` / `type-check` — clean
- [x] `pnpm run build` — static export succeeds
- [x] `pnpm test` — 1019 passed (1 pre-existing Windows-only exec-bit env failure in `commitlint-config.test.js`, unrelated; passes in Linux CI)
- [x] `pnpm run test:e2e` — 28/28 passed
- [x] Ran `scripts/fleet-audit.mjs` `analyzeFooter`/`isCompliant` against the built `out/index.html`: `{footerMarker: true, ffcLink: true, hubLink: true, ein: true, supportedBy: true}` → **isCompliant: true** — the ffcadmin.org row flips to compliant (with target wording) on the next fleet audit run

🤖 Generated with [Claude Code](https://claude.com/claude-code)