### PR TITLE
fix(footer): add Supported Charity Login hub link + 'Supported by' wording

### DIFF
--- a/__tests__/components/Footer.test.tsx
+++ b/__tests__/components/Footer.test.tsx
@@ -35,11 +35,20 @@ describe('Footer Component', () => {
 
     it('should have link to main Free For Charity website', () => {
       render(<Footer />)
-      const ffcLink = screen.getByRole('link', { name: /A project of Free For Charity/i })
+      const ffcLink = screen.getByRole('link', { name: /Supported by Free For Charity/i })
       expect(ffcLink).toBeInTheDocument()
       expect(ffcLink).toHaveAttribute('href', 'https://freeforcharity.org')
       expect(ffcLink).toHaveAttribute('target', '_blank')
       expect(ffcLink).toHaveAttribute('rel', 'noopener noreferrer')
+    })
+
+    it('should have Supported Charity Login link to the FFC hub', () => {
+      render(<Footer />)
+      const hubLink = screen.getByRole('link', { name: /Supported Charity Login/i })
+      expect(hubLink).toBeInTheDocument()
+      expect(hubLink).toHaveAttribute('href', 'https://freeforcharity.org/hub/')
+      expect(hubLink).toHaveAttribute('target', '_blank')
+      expect(hubLink).toHaveAttribute('rel', 'noopener noreferrer')
     })
 
     it('should display privacy policy link', () => {

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -144,6 +144,16 @@ export default function Footer() {
                   Blog
                 </Link>
               </li>
+              <li>
+                <a
+                  href="https://freeforcharity.org/hub/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-gray-400 hover:text-white transition-colors"
+                >
+                  Supported Charity Login
+                </a>
+              </li>
             </ul>
           </div>
 
@@ -556,7 +566,7 @@ export default function Footer() {
                 className="hover:opacity-80 transition-opacity"
                 style={{ color: 'var(--color-ffc-teal)' }}
               >
-                A project of Free For Charity
+                Supported by Free For Charity
               </a>
             </p>
             <p className="mt-2">


### PR DESCRIPTION
Refs FreeForCharity/FFC-Cloudflare-Automation#697 (fleet footer retrofit — attribution quick wins)

## What this closes (fleet audit checks)

This closes the two open checks for **ffcadmin.org**, and thereby for **ffcsites.org**, which has no content repo of its own — it 301s to https://ffcadmin.org/ and the fleet audit follows the redirect and audits this site's footer:

- **hub link** — adds `Supported Charity Login` (https://freeforcharity.org/hub/) to the footer Quick Links column, matching the existing link styling.
- **"Supported by" target wording** — the copyright line's attribution link now reads `Supported by Free For Charity` instead of the legacy `A project of Free For Charity`; href/target/styling unchanged.

ffcadmin.org is first-party FFC, so no third-party charity data is involved; the existing FFC EIN 46-2471893 and GuideStar seal are untouched.

## Changes

- `src/components/Footer.tsx` — the two footer edits above.
- `__tests__/components/Footer.test.tsx` — attribution-link assertion updated to the new wording; new test asserting the hub link (href, `target="_blank"`, `rel="noopener noreferrer"`).

## Test plan

- Local run of the CI steps: `pnpm run format:check`, `pnpm run lint`, `pnpm run type-check`, `pnpm run build`, `pnpm test` — all green except `commitlint-config.test.js`'s husky executable-bit check, a Windows-clone filesystem artifact that passes on Linux CI (unrelated to this change).
- Footer component suite: 10/10 passing including the new hub-link test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)