### PR TITLE
feat: read public footer contact + socials from WHMCS into the footer bridge

### DIFF
--- a/__tests__/generate-footer-config.test.js
+++ b/__tests__/generate-footer-config.test.js
@@ -37,21 +37,27 @@ describe('buildSiteConfigPartial — happy path', () => {
       charityStage: '501c3',
     })
     // The partial's keys are named and nested exactly as in the template's
-    // typed SiteConfig (src/lib/site.config.ts) — directly transcribable.
+    // typed SiteConfig (src/lib/site.config.ts) — directly transcribable. The
+    // hardened onboarding forms now supply the public footer contact fields and
+    // the extra social pages, so they flow straight through.
     expect(out.siteConfig).toEqual({
       name: 'Helping Hands Shelter',
       description: 'We provide shelter, food, and job placement to families in crisis.',
       social: [
         { label: 'Facebook', href: 'https://www.facebook.com/helpinghandsshelter' },
         { label: 'LinkedIn', href: 'https://www.linkedin.com/company/helping-hands-shelter/' },
+        { label: 'Instagram', href: 'https://www.instagram.com/helpinghandsshelter' },
+        { label: 'X (Twitter)', href: 'https://x.com/helpinghands' },
+        { label: 'YouTube', href: 'https://www.youtube.com/@helpinghandsshelter' },
       ],
+      contactEmail: 'hello@example.org',
+      phone: { display: '+1 520-555-0100', tel: '+15205550100' },
+      addresses: [{ label: 'Location', lines: ['Tucson, AZ'] }],
       ein: '12-3456789',
       guidestar: {
         profileUrl: 'https://www.guidestar.org/profile/12-3456789',
-        // Only the public profile URL is collected — the direct "shared
-        // profile" link stays a manual fill (kept as '' so the guidestar
-        // object retains the template's full shape).
-        directProfileUrl: '',
+        // The direct "shared profile" link is now captured too (public-by-design).
+        directProfileUrl: 'https://www.guidestar.org/profile/shared/12-3456789',
       },
       supportedBy: {
         name: 'Free For Charity',
@@ -61,31 +67,87 @@ describe('buildSiteConfigPartial — happy path', () => {
     })
   })
 
-  it('lists every SiteConfig key the application cannot supply in manualFields', () => {
+  it('flows the public contact fields into contact/phone/address and drops them from manual', () => {
     const out = buildSiteConfigPartial(SAMPLE_APPLICATION)
-    // The sample record supplies description and social, so only the base
-    // manual-fill list applies.
-    expect(out.manualFields).toEqual(MANUAL_FIELDS_BASE)
-    expect(out.manualFields.map((f) => f.key)).toEqual([
-      'contactEmail',
-      'phone',
-      'addresses',
-      'guidestar.directProfileUrl',
-      'integrations',
-      'url',
-      'tagline',
+    expect(out.siteConfig.contactEmail).toBe('hello@example.org')
+    expect(out.siteConfig.phone).toEqual({ display: '+1 520-555-0100', tel: '+15205550100' })
+    expect(out.siteConfig.addresses).toEqual([{ label: 'Location', lines: ['Tucson, AZ'] }])
+    // Supplied -> not on the manual-fill checklist.
+    const manualKeys = out.manualFields.map((f) => f.key)
+    expect(manualKeys).not.toContain('contactEmail')
+    expect(manualKeys).not.toContain('phone')
+    expect(manualKeys).not.toContain('addresses')
+    expect(manualKeys).not.toContain('guidestar.directProfileUrl')
+  })
+
+  it('emits all five social networks when present, in a fixed order', () => {
+    const out = buildSiteConfigPartial(SAMPLE_APPLICATION)
+    expect(out.siteConfig.social.map((s) => s.label)).toEqual([
+      'Facebook',
+      'LinkedIn',
+      'Instagram',
+      'X (Twitter)',
+      'YouTube',
     ])
+  })
+
+  it('omits contact fields (and re-lists them manual) when the record lacks them', () => {
+    const record = { ...SAMPLE_APPLICATION }
+    delete record.contactEmail
+    delete record.contactPhone
+    delete record.contactCityState
+    delete record.candidDirectUrl
+    const out = buildSiteConfigPartial(record)
+    expect(out.siteConfig).not.toHaveProperty('contactEmail')
+    expect(out.siteConfig).not.toHaveProperty('phone')
+    expect(out.siteConfig).not.toHaveProperty('addresses')
+    // guidestar.directProfileUrl stays in the object (as '') to keep the shape.
+    expect(out.siteConfig.guidestar.directProfileUrl).toBe('')
+    const manualKeys = out.manualFields.map((f) => f.key)
+    expect(manualKeys).toEqual(
+      expect.arrayContaining(['contactEmail', 'phone', 'addresses', 'guidestar.directProfileUrl'])
+    )
+  })
+
+  it('drops individual socials that are absent or on the wrong host', () => {
+    const record = {
+      ...SAMPLE_APPLICATION,
+      instagramUrl: undefined, // absent -> omitted
+      xUrl: 'https://evil.example.com/@spoof', // wrong host -> rejected
+      youtubeUrl: 'https://youtu.be/abcd1234', // short host allowed
+    }
+    const out = buildSiteConfigPartial(record)
+    const labels = out.siteConfig.social.map((s) => s.label)
+    expect(labels).toContain('YouTube')
+    expect(labels).not.toContain('Instagram')
+    expect(labels).not.toContain('X (Twitter)')
+    expect(out.siteConfig.social.find((s) => s.label === 'YouTube').href).toBe(
+      'https://youtu.be/abcd1234'
+    )
+  })
+
+  it('rejects a wrong-host Candid direct link (empty directProfileUrl)', () => {
+    const out = buildSiteConfigPartial({
+      ...SAMPLE_APPLICATION,
+      candidDirectUrl: 'https://evil.example.com/profile/shared/12-3456789',
+    })
+    expect(out.siteConfig.guidestar.directProfileUrl).toBe('')
+    expect(out.manualFields.map((f) => f.key)).toContain('guidestar.directProfileUrl')
+  })
+
+  it('lists every never-suppliable SiteConfig key in manualFields', () => {
+    const out = buildSiteConfigPartial(SAMPLE_APPLICATION)
+    // The sample record supplies description, social, AND every public contact
+    // field, so only the always-manual base list applies.
+    expect(out.manualFields).toEqual(MANUAL_FIELDS_BASE)
+    expect(out.manualFields.map((f) => f.key)).toEqual(['integrations', 'url', 'tagline'])
     // Every manual field carries a note telling the volunteer where to get it.
     for (const f of out.manualFields) {
       expect(typeof f.note).toBe('string')
       expect(f.note.length).toBeGreaterThan(0)
     }
-    // Omitted-key contract: manual keys are NOT emitted in the partial (the
-    // one exception, guidestar.directProfileUrl, is '' to keep the object
-    // shape) — so a volunteer never transcribes a placeholder as real data.
-    expect(out.siteConfig).not.toHaveProperty('contactEmail')
-    expect(out.siteConfig).not.toHaveProperty('phone')
-    expect(out.siteConfig).not.toHaveProperty('addresses')
+    // Omitted-key contract: never-suppliable keys are NOT emitted in the partial
+    // — so a volunteer never transcribes a placeholder as real data.
     expect(out.siteConfig).not.toHaveProperty('integrations')
     expect(out.siteConfig).not.toHaveProperty('url')
     expect(out.siteConfig).not.toHaveProperty('tagline')
@@ -114,6 +176,9 @@ describe('buildSiteConfigPartial — happy path', () => {
       ...SAMPLE_APPLICATION,
       facebookUrl: undefined,
       linkedinUrl: 'https://evil.example.com/spoof', // not linkedin.com -> dropped
+      instagramUrl: undefined,
+      xUrl: undefined,
+      youtubeUrl: undefined,
     }
     const out = buildSiteConfigPartial(record)
     expect(out.siteConfig.social).toEqual([])

--- a/__tests__/generate-footer-config.test.js
+++ b/__tests__/generate-footer-config.test.js
@@ -67,6 +67,21 @@ describe('buildSiteConfigPartial — happy path', () => {
     })
   })
 
+  it('normalizes tel to digits with only a single leading +', () => {
+    // Leading + kept, all other punctuation (incl. a stray inner +) dropped.
+    const withPlus = buildSiteConfigPartial({
+      ...SAMPLE_APPLICATION,
+      contactPhone: '+1 (520) 555+0100',
+    })
+    expect(withPlus.siteConfig.phone).toEqual({
+      display: '+1 (520) 555+0100',
+      tel: '+15205550100',
+    })
+    // No leading + -> tel is bare digits (never gains a +).
+    const noPlus = buildSiteConfigPartial({ ...SAMPLE_APPLICATION, contactPhone: '(520) 555-0100' })
+    expect(noPlus.siteConfig.phone).toEqual({ display: '(520) 555-0100', tel: '5205550100' })
+  })
+
   it('flows the public contact fields into contact/phone/address and drops them from manual', () => {
     const out = buildSiteConfigPartial(SAMPLE_APPLICATION)
     expect(out.siteConfig.contactEmail).toBe('hello@example.org')

--- a/__tests__/intake-issues.test.js
+++ b/__tests__/intake-issues.test.js
@@ -100,7 +100,7 @@ describe('configAttachment / extractConfigAttachment', () => {
     expect(block).toContain(`"ein": "${SAMPLE_APPLICATION.ein}"`)
     expect(block).toContain('"supportedBy"')
     expect(block).toContain('Manual fields:')
-    expect(block).toContain('`contactEmail`')
+    expect(block).toContain('`integrations`')
     // Deterministic: no timestamp, so the block never churns on its own.
     expect(configAttachment(SAMPLE_APPLICATION, repo)).toBe(block)
   })

--- a/__tests__/whmcs-applications.test.js
+++ b/__tests__/whmcs-applications.test.js
@@ -9,7 +9,7 @@
 
 let buildApplicationRecords, TIER_BY_PID, MISSION_MAX_LENGTH, sanitizeCandidUrl, sanitizeEin
 let missionCategoryOption, missionTierFromProduct, MISSION_OPTION, INTAKE_STATUSES, INTAKE_SINCE
-let PENDING_STATUSES, sanitizeSocialUrl
+let PENDING_STATUSES, sanitizeSocialUrl, ingestProducts
 
 beforeAll(async () => {
   const mod = await import('../scripts/whmcs-applications.mjs')
@@ -25,6 +25,7 @@ beforeAll(async () => {
   INTAKE_SINCE = mod.INTAKE_SINCE
   PENDING_STATUSES = mod.PENDING_STATUSES
   sanitizeSocialUrl = mod.sanitizeSocialUrl
+  ingestProducts = mod.ingestProducts
 })
 
 const ALLOWED_KEYS = [
@@ -39,6 +40,14 @@ const ALLOWED_KEYS = [
   'ein',
   'facebookUrl',
   'linkedinUrl',
+  // PUBLIC-by-design footer fields surfaced by the hardened onboarding forms.
+  'instagramUrl',
+  'xUrl',
+  'youtubeUrl',
+  'contactPhone',
+  'contactEmail',
+  'contactCityState',
+  'candidDirectUrl',
   'submittedAt',
 ]
 
@@ -302,5 +311,148 @@ describe('buildApplicationRecords', () => {
       ['2', { clientId: '2', pid: '16', company: 'Alpha', regIso: '2026-01-01T00:00:00.000Z' }],
     ])
     expect(buildApplicationRecords(byClient).map((a) => a.charityName)).toEqual(['Alpha', 'Zebra'])
+  })
+
+  it('emits the public footer contact + extra social fields at the top level (only when set)', () => {
+    const byClient = new Map([
+      [
+        '40',
+        {
+          clientId: '40',
+          pid: '33',
+          company: 'Full Footer Org',
+          instagramUrl: 'https://www.instagram.com/fullfooter',
+          xUrl: 'https://x.com/fullfooter',
+          youtubeUrl: 'https://www.youtube.com/@fullfooter',
+          contactPhone: '+1 520-555-0100',
+          contactEmail: 'hello@example.org',
+          contactCityState: 'Tucson, AZ',
+          candidDirectUrl: 'https://www.guidestar.org/profile/shared/12-3456789',
+        },
+      ],
+      ['41', { clientId: '41', pid: '16', company: 'Bare Org' }],
+    ])
+    const apps = buildApplicationRecords(byClient)
+    const full = apps.find((a) => a.id === 'ffc-40')
+    expect(full).toMatchObject({
+      instagramUrl: 'https://www.instagram.com/fullfooter',
+      xUrl: 'https://x.com/fullfooter',
+      youtubeUrl: 'https://www.youtube.com/@fullfooter',
+      contactPhone: '+1 520-555-0100',
+      contactEmail: 'hello@example.org',
+      contactCityState: 'Tucson, AZ',
+      candidDirectUrl: 'https://www.guidestar.org/profile/shared/12-3456789',
+    })
+    // Every emitted key stays on the PII-safe allowlist.
+    expect(Object.keys(full).every((k) => ALLOWED_KEYS.includes(k))).toBe(true)
+    // Empty record omits them all — never emitted as empty placeholders.
+    const bare = apps.find((a) => a.id === 'ffc-41')
+    for (const k of [
+      'instagramUrl',
+      'xUrl',
+      'youtubeUrl',
+      'contactPhone',
+      'contactEmail',
+      'contactCityState',
+      'candidDirectUrl',
+    ]) {
+      expect(bare).not.toHaveProperty(k)
+    }
+  })
+})
+
+describe('ingestProducts — public footer field reads (allowlisted, PII-safe)', () => {
+  const active = (clientid, customfield) => ({
+    clientid,
+    status: 'Active',
+    regdate: '2026-07-12',
+    customfields: { customfield },
+  })
+
+  it('reads the public footer contact + org social fields from a product', () => {
+    const byClient = new Map()
+    const pendingIds = new Set()
+    // Field NAMES are slug-prefixed as WHMCS GetClientsProducts returns them.
+    ingestProducts(
+      '33',
+      [
+        active('50', [
+          { name: 'public-phone|Public phone (footer)', value: '+1 520-555-0100' },
+          { name: 'public-email|Public email (footer)', value: 'hello@example.org' },
+          { name: 'footer-location|City & State', value: 'Tucson, AZ' },
+          { name: 'social-instagram|Instagram', value: 'https://www.instagram.com/org' },
+          { name: 'social-x|X (Twitter)', value: 'https://x.com/org' },
+          { name: 'social-youtube|YouTube', value: 'https://www.youtube.com/@org' },
+          {
+            name: 'guidestar-full|Candid direct/shared link',
+            value: 'https://www.guidestar.org/profile/shared/12-3456789',
+          },
+        ]),
+      ],
+      byClient,
+      pendingIds
+    )
+    expect(byClient.get('50')).toMatchObject({
+      contactPhone: '+1 520-555-0100',
+      contactEmail: 'hello@example.org',
+      contactCityState: 'Tucson, AZ',
+      instagramUrl: 'https://www.instagram.com/org',
+      xUrl: 'https://x.com/org',
+      youtubeUrl: 'https://www.youtube.com/@org',
+      candidDirectUrl: 'https://www.guidestar.org/profile/shared/12-3456789',
+    })
+  })
+
+  it('NEVER reads a board member *-linkedin field as the org LinkedIn (PII regression)', () => {
+    const byClient = new Map()
+    const pendingIds = new Set()
+    ingestProducts(
+      '33',
+      [
+        active('60', [
+          // Board-member PERSONAL profiles — must never be published.
+          {
+            name: 'chair-linkedin|Chair LinkedIn',
+            value: 'https://www.linkedin.com/in/jane-chair/',
+          },
+          {
+            name: 'secretary-linkedin|Secretary LinkedIn',
+            value: 'https://www.linkedin.com/in/sam-secretary/',
+          },
+          { name: 'treasurer-linkedin', value: 'https://www.linkedin.com/in/tim-treasurer/' },
+          { name: 'vicechair-linkedin', value: 'https://www.linkedin.com/in/val-vicechair/' },
+          { name: 'member-linkedin', value: 'https://www.linkedin.com/in/mo-member/' },
+          { name: 'primary-linkedin', value: 'https://www.linkedin.com/in/pat-primary/' },
+          { name: 'technical-linkedin', value: 'https://www.linkedin.com/in/ted-technical/' },
+          // The real ORG page field (slugged `linkedin-page`).
+          {
+            name: 'linkedin-page|Charity LinkedIn Page URL',
+            value: 'https://www.linkedin.com/company/the-org/',
+          },
+        ]),
+      ],
+      byClient,
+      pendingIds
+    )
+    // Only the org PAGE is captured; no board profile leaks in.
+    expect(byClient.get('60').linkedinUrl).toBe('https://www.linkedin.com/company/the-org/')
+  })
+
+  it('captures NO org LinkedIn when only board *-linkedin fields are present', () => {
+    const byClient = new Map()
+    const pendingIds = new Set()
+    ingestProducts(
+      '33',
+      [
+        active('61', [
+          { name: 'chair-linkedin', value: 'https://www.linkedin.com/in/jane-chair/' },
+          { name: 'treasurer-linkedin', value: 'https://www.linkedin.com/in/tim-treasurer/' },
+        ]),
+      ],
+      byClient,
+      pendingIds
+    )
+    // No field matches the `linkedin-page` org slug -> nothing captured.
+    expect(byClient.get('61').linkedinUrl).toBe('')
   })
 })

--- a/__tests__/whmcs-applications.test.js
+++ b/__tests__/whmcs-applications.test.js
@@ -403,6 +403,58 @@ describe('ingestProducts — public footer field reads (allowlisted, PII-safe)',
     })
   })
 
+  it('keeps the Candid PROFILE and DIRECT links on their own fields (no cross-capture)', () => {
+    const byClient = new Map()
+    const pendingIds = new Set()
+    // Both fields present; their display text both mention "Candid". fieldValue
+    // returns the first NAME match, so the profile reader must skip the
+    // `guidestar-full` slug and the direct reader must skip the profile slug.
+    ingestProducts(
+      '33',
+      [
+        active('70', [
+          {
+            name: 'guidestar-full|GuideStar/Candid full (direct/shared) profile',
+            value: 'https://www.guidestar.org/profile/shared/12-3456789',
+          },
+          {
+            name: 'guidestar|GuideStar/Candid public profile URL',
+            value: 'https://www.guidestar.org/profile/12-3456789',
+          },
+        ]),
+      ],
+      byClient,
+      pendingIds
+    )
+    const rec = byClient.get('70')
+    expect(rec.candidUrl).toBe('https://www.guidestar.org/profile/12-3456789')
+    expect(rec.candidDirectUrl).toBe('https://www.guidestar.org/profile/shared/12-3456789')
+    // And the two never collapse onto the same value.
+    expect(rec.candidUrl).not.toBe(rec.candidDirectUrl)
+  })
+
+  it('does NOT read the direct link as the public profile when only guidestar-full exists', () => {
+    const byClient = new Map()
+    const pendingIds = new Set()
+    ingestProducts(
+      '33',
+      [
+        active('71', [
+          {
+            name: 'guidestar-full|GuideStar/Candid direct/shared profile',
+            value: 'https://www.guidestar.org/profile/shared/12-3456789',
+          },
+        ]),
+      ],
+      byClient,
+      pendingIds
+    )
+    const rec = byClient.get('71')
+    // The profile reader excludes the `guidestar-full` slug entirely.
+    expect(rec.candidUrl).toBe('')
+    expect(rec.candidDirectUrl).toBe('https://www.guidestar.org/profile/shared/12-3456789')
+  })
+
   it('NEVER reads a board member *-linkedin field as the org LinkedIn (PII regression)', () => {
     const byClient = new Map()
     const pendingIds = new Set()

--- a/docs/footer-bridge.md
+++ b/docs/footer-bridge.md
@@ -39,33 +39,45 @@ adopts the same shared shape, the one generated artifact serves **both** templat
 
 ### Field mapping (application record → `siteConfig`)
 
-| Application record          | `siteConfig` key       | Notes                                                                                             |
-| --------------------------- | ---------------------- | ------------------------------------------------------------------------------------------------- |
-| `charityName`               | `name`                 | Public organization legal name                                                                    |
-| `missionExcerpt`            | `description`          | Omitted (and flagged manual) when the application predates the mission field                      |
-| `ein`                       | `ein`                  | Validated NN-NNNNNNN                                                                              |
-| `facebookUrl`/`linkedinUrl` | `social[]`             | `{ label, href }` entries; labels match the template's icon set; host-checked, dropped if invalid |
-| `candidUrl`                 | `guidestar.profileUrl` | `guidestar.directProfileUrl` is emitted as `''` and flagged manual                                |
-| _(constant)_                | `supportedBy`          | **Always** FFC: `{ name, url, hubUrl }` — the permanent footer attribution, never from the record |
+| Application record                                             | `siteConfig` key             | Notes                                                                                                        |
+| -------------------------------------------------------------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `charityName`                                                  | `name`                       | Public organization legal name                                                                               |
+| `missionExcerpt`                                               | `description`                | Omitted (and flagged manual) when the application predates the mission field                                 |
+| `ein`                                                          | `ein`                        | Validated NN-NNNNNNN                                                                                         |
+| `facebookUrl`/`linkedinUrl`/`instagramUrl`/`xUrl`/`youtubeUrl` | `social[]`                   | `{ label, href }` entries; labels match the template's icon set; host-checked, dropped if invalid            |
+| `contactEmail`                                                 | `contactEmail`               | PUBLIC footer email from the hardened onboarding form; omitted (and flagged manual) when the record lacks it |
+| `contactPhone`                                                 | `phone`                      | `{ display, tel }` (tel stripped to `+`/digits); omitted (and flagged manual) when absent                    |
+| `contactCityState`                                             | `addresses[]`                | `[{ label: 'Location', lines: [city & state] }]`; omitted (and flagged manual) when absent                   |
+| `candidUrl`                                                    | `guidestar.profileUrl`       | Public Candid/GuideStar profile URL                                                                          |
+| `candidDirectUrl`                                              | `guidestar.directProfileUrl` | Candid "direct/shared" link; host-checked; emitted as `''` (and flagged manual) when absent                  |
+| _(constant)_                                                   | `supportedBy`                | **Always** FFC: `{ name, url, hubUrl }` — the permanent footer attribution, never from the record            |
+
+The public footer contact fields and the extra social pages are **public-by-design** (they render on
+the charity's website footer) and are read from the hardened onboarding products through the WHMCS
+sync's PII-safe allowlist — never the private "reach you at" phone or any board member's personal
+phone/email/LinkedIn.
 
 ### Manual fields
 
-Contact details (email, phone, address) are PII the WHMCS sync deliberately never surfaces, and
-some `SiteConfig` keys are simply not collected at application time. Those keys are **omitted**
-from the partial (never emitted as placeholder values) and itemized in `manualFields` so the
-provisioning volunteer knows exactly what to fill by hand:
+Some `SiteConfig` keys are never collected at application time, and the public footer fields are
+only present when the applicant filled them in. Keys the record cannot supply are **omitted** from
+the partial (never emitted as placeholder values) and itemized in `manualFields` so the provisioning
+volunteer knows exactly what to fill by hand:
 
-- `contactEmail`, `phone`, `addresses` — from the charity's public website
-- `guidestar.directProfileUrl` — the Candid "shared profile" direct link
-- `integrations` — per-charity Zeffy / Idealist / SociableKit / Microsoft Forms endpoints
+- `integrations` — per-charity Zeffy / Idealist / SociableKit / Microsoft Forms endpoints (never collected)
 - `url` — the site's canonical production URL (set at provisioning/cutover)
 - `tagline` — agreed with the charity
+- `contactEmail`, `phone`, `addresses`, `guidestar.directProfileUrl` — **only** when the application
+  record does not carry the public value (from the charity's public website / Candid profile)
 - `description` / `social` — only when the application record does not carry them
 
-The charity Facebook/LinkedIn **page** URLs collected by the hardened onboarding forms (fields
-`facebook-page` / `linkedin-page`) are surfaced by the sync as `facebookUrl` / `linkedinUrl` and
-flow straight into `social`; only applications that predate those fields need volunteer fill-in
-for social links.
+The public footer fields the hardened onboarding forms collect — the charity Facebook/LinkedIn/
+Instagram/X/YouTube **page** URLs (fields `facebook-page` / `linkedin-page` / `social-instagram` /
+`social-x` / `social-youtube`) and the public contact fields (`public-phone` / `public-email` /
+`footer-location`) plus the Candid `guidestar-full` direct link — are surfaced by the sync's PII-safe
+allowlist and flow straight into `social` / `contactEmail` / `phone` / `addresses` /
+`guidestar.directProfileUrl`; only applications that predate those fields (or leave them blank) need
+volunteer fill-in.
 
 ## Auto-attached to new work orders
 
@@ -116,9 +128,9 @@ the CLI steps below.
 
 - **Auto-PR the generated values** into the charity's FFC-EX repo from the work-order workflow, so
   Gate 3's footer requirement is fully mechanical (generate → validate → PR → review → merge).
-- **Surface the remaining public contact fields** from the hardened onboarding forms through the
-  sync's allowlist so the volunteer fill-in step shrinks further (the social page URLs already
-  flow through).
+- **Site-body / long-form content (pid 40)** — surface the charity's long-form public content
+  through the sync's allowlist (out of scope for the public-footer-fields change; a future
+  follow-up). The public footer contact fields and extra social pages already flow through.
 - **Direct consumption — both templates**: once
   [FFC-IN-Footer_Only_Template](https://github.com/FreeForCharity/FFC-IN-Footer_Only_Template)
   adopts the shared `SiteConfig` shape

--- a/scripts/generate-footer-config.mjs
+++ b/scripts/generate-footer-config.mjs
@@ -48,12 +48,28 @@ export const REQUIRED_FIELDS = [
 ]
 
 /**
- * Optional record fields the config uses when present. `facebookUrl` and
- * `linkedinUrl` are the charity PAGE URLs from the hardened onboarding forms
- * (fields `facebook-page` / `linkedin-page`, never board-member profiles),
- * surfaced by the WHMCS sync's PII-safe allowlist. Exported for unit testing.
+ * Optional record fields the config uses when present. The social page URLs
+ * (`facebookUrl` / `linkedinUrl` / `instagramUrl` / `xUrl` / `youtubeUrl`) and
+ * the public footer contact fields (`contactEmail` / `contactPhone` /
+ * `contactCityState`) are the PUBLIC-by-design values the hardened onboarding
+ * forms collect for the charity's website footer — never board-member profiles
+ * or private "reach you at" contact info — surfaced by the WHMCS sync's PII-safe
+ * allowlist. `candidDirectUrl` is Candid's "direct/shared" profile link.
+ * Exported for unit testing.
  */
-export const OPTIONAL_FIELDS = ['missionExcerpt', 'facebookUrl', 'linkedinUrl', 'submittedAt']
+export const OPTIONAL_FIELDS = [
+  'missionExcerpt',
+  'facebookUrl',
+  'linkedinUrl',
+  'instagramUrl',
+  'xUrl',
+  'youtubeUrl',
+  'contactEmail',
+  'contactPhone',
+  'contactCityState',
+  'candidDirectUrl',
+  'submittedAt',
+]
 
 /**
  * Permanent "Supported by" attribution required by the FFC footer standard on
@@ -68,28 +84,15 @@ export const SUPPORTED_BY = Object.freeze({
 })
 
 /**
- * SiteConfig keys the WHMCS application can never supply. Always present in
- * the output's `manualFields` so the provisioning volunteer knows exactly what
- * to fill by hand (from the charity's public website or the work order).
+ * SiteConfig keys the WHMCS application can NEVER supply — always present in the
+ * output's `manualFields` so the provisioning volunteer knows exactly what to
+ * fill by hand. The public footer contact fields and the Candid direct link are
+ * NOT here: the hardened onboarding forms now capture their public-by-design
+ * values, so they are emitted into the partial when present and only fall back
+ * to `manualFields` (see MANUAL_FIELDS_CONDITIONAL) when the record lacks them.
  * Exported for unit testing.
  */
 export const MANUAL_FIELDS_BASE = [
-  {
-    key: 'contactEmail',
-    note: 'PII the WHMCS sync never surfaces — take the public contact email from the charity website',
-  },
-  {
-    key: 'phone',
-    note: 'PII the WHMCS sync never surfaces — fill { display, tel } from the charity website',
-  },
-  {
-    key: 'addresses',
-    note: 'PII the WHMCS sync never surfaces — fill [{ label, lines, mapUrl }] from the charity website',
-  },
-  {
-    key: 'guidestar.directProfileUrl',
-    note: 'Candid "shared profile" direct link — the application only carries the public profile URL',
-  },
   {
     key: 'integrations',
     note: 'per-charity Zeffy / Idealist / SociableKit / Microsoft Forms endpoints — not collected at application time',
@@ -103,6 +106,39 @@ export const MANUAL_FIELDS_BASE = [
     note: 'short slogan for the default <title> — not collected by the application; agree it with the charity',
   },
 ]
+
+/**
+ * SiteConfig keys the application CAN supply from the hardened onboarding forms'
+ * public footer fields, but only when the applicant filled them in. Each is
+ * emitted into the partial when the record carries it, and appended to
+ * `manualFields` (with the note below) only when it does not. Exported for unit
+ * testing. `has(record)` decides "did the record supply this key?".
+ */
+export const MANUAL_FIELDS_CONDITIONAL = [
+  {
+    key: 'contactEmail',
+    has: (r) => Boolean(String(r.contactEmail ?? '').trim()),
+    note: 'no public contact email on the application — take it from the charity website',
+  },
+  {
+    key: 'phone',
+    has: (r) => Boolean(String(r.contactPhone ?? '').trim()),
+    note: 'no public phone on the application — fill { display, tel } from the charity website',
+  },
+  {
+    key: 'addresses',
+    has: (r) => Boolean(String(r.contactCityState ?? '').trim()),
+    note: 'no public city & state on the application — fill [{ label, lines, mapUrl }] from the charity website',
+  },
+  {
+    key: 'guidestar.directProfileUrl',
+    has: (r) => Boolean(sanitizeSocialUrl(r.candidDirectUrl, GUIDESTAR_HOST_RE)),
+    note: 'no Candid "direct/shared" profile link on the application — add it from the charity\'s Candid profile',
+  },
+]
+
+/** Candid/GuideStar host allowlist for the direct ("shared") profile link. */
+const GUIDESTAR_HOST_RE = /(^|\.)(candid\.org|guidestar\.org)$/i
 
 /** Accept only a real https/http URL on the expected social host, else ''. */
 function sanitizeSocialUrl(raw, hostRe) {
@@ -121,8 +157,9 @@ function sanitizeSocialUrl(raw, hostRe) {
 /**
  * Documented sample record for testing/demo (--sample). Mirrors the exact
  * shape `buildApplicationRecords` publishes for an approved 501(c)(3)
- * application, plus the two social page URLs the hardened onboarding forms
- * collect. Exported for unit testing.
+ * application, plus the public social page URLs and public footer contact
+ * fields the hardened onboarding forms collect. All values are clearly fake
+ * (example.org / obviously-fake handles). Exported for unit testing.
  */
 export const SAMPLE_APPLICATION = {
   id: 'ffc-90',
@@ -133,10 +170,17 @@ export const SAMPLE_APPLICATION = {
   missionCategoryOption: 'Basic needs (food, water, shelter)',
   missionExcerpt: 'We provide shelter, food, and job placement to families in crisis.',
   candidUrl: 'https://www.guidestar.org/profile/12-3456789',
+  candidDirectUrl: 'https://www.guidestar.org/profile/shared/12-3456789',
   ein: '12-3456789',
   submittedAt: '2026-07-11T00:00:00.000Z',
   facebookUrl: 'https://www.facebook.com/helpinghandsshelter',
   linkedinUrl: 'https://www.linkedin.com/company/helping-hands-shelter/',
+  instagramUrl: 'https://www.instagram.com/helpinghandsshelter',
+  xUrl: 'https://x.com/helpinghands',
+  youtubeUrl: 'https://www.youtube.com/@helpinghandsshelter',
+  contactEmail: 'hello@example.org',
+  contactPhone: '+1 520-555-0100',
+  contactCityState: 'Tucson, AZ',
 }
 
 /**
@@ -195,16 +239,47 @@ export function buildSiteConfigPartial(record, { now = new Date() } = {}) {
   const legalName = String(record.charityName).trim()
 
   // SiteConfig.social — icon in the template footer resolves by `label`, so
-  // the labels here must match the template's known set exactly.
+  // the labels here must match the template's known set exactly. All hosts are
+  // validated; a wrong-host or non-URL value is dropped.
   const social = []
   const facebook = sanitizeSocialUrl(record.facebookUrl, /(^|\.)facebook\.com$/i)
   if (facebook) social.push({ label: 'Facebook', href: facebook })
   const linkedin = sanitizeSocialUrl(record.linkedinUrl, /(^|\.)linkedin\.com$/i)
   if (linkedin) social.push({ label: 'LinkedIn', href: linkedin })
+  const instagram = sanitizeSocialUrl(record.instagramUrl, /(^|\.)instagram\.com$/i)
+  if (instagram) social.push({ label: 'Instagram', href: instagram })
+  const x = sanitizeSocialUrl(record.xUrl, /(^|\.)(x\.com|twitter\.com)$/i)
+  if (x) social.push({ label: 'X (Twitter)', href: x })
+  const youtube = sanitizeSocialUrl(record.youtubeUrl, /(^|\.)(youtube\.com|youtu\.be)$/i)
+  if (youtube) social.push({ label: 'YouTube', href: youtube })
 
   const mission = String(record.missionExcerpt ?? '').trim()
 
-  const manualFields = [...MANUAL_FIELDS_BASE]
+  // PUBLIC footer contact fields the hardened onboarding forms now capture.
+  const contactEmail = String(record.contactEmail ?? '').trim()
+  const contactPhone = String(record.contactPhone ?? '').trim()
+  const contactCityState = String(record.contactCityState ?? '').trim()
+  // SiteConfig.phone is { display, tel }: display is verbatim, tel strips to the
+  // href-safe subset (leading + and digits) for the footer's tel: link.
+  const phone = contactPhone
+    ? { display: contactPhone, tel: contactPhone.replace(/[^\d+]/g, '') }
+    : null
+  // SiteConfig.addresses is [{ label, lines, mapUrl }]; the application supplies
+  // only a public city & state, so emit a single labelled line.
+  const addresses = contactCityState ? [{ label: 'Location', lines: [contactCityState] }] : []
+  // Candid "direct/shared" profile link — sanitized to a candid.org/guidestar.org
+  // URL; '' keeps the guidestar object's template shape when absent.
+  const guidestarDirectProfileUrl = sanitizeSocialUrl(record.candidDirectUrl, GUIDESTAR_HOST_RE)
+
+  // manualFields: the conditional public keys the record did NOT supply, then
+  // the always-manual base, then description/social when the record lacks them.
+  const manualFields = [
+    ...MANUAL_FIELDS_CONDITIONAL.filter((f) => !f.has(record)).map(({ key, note }) => ({
+      key,
+      note,
+    })),
+    ...MANUAL_FIELDS_BASE,
+  ]
   if (!mission) {
     manualFields.push({
       key: 'description',
@@ -214,7 +289,7 @@ export function buildSiteConfigPartial(record, { now = new Date() } = {}) {
   if (social.length === 0) {
     manualFields.push({
       key: 'social',
-      note: 'no valid Facebook/LinkedIn PAGE URL on the application — fill [{ label, href }] from the charity public presence',
+      note: 'no valid social PAGE URL on the application — fill [{ label, href }] from the charity public presence',
     })
   }
 
@@ -234,16 +309,20 @@ export function buildSiteConfigPartial(record, { now = new Date() } = {}) {
     manualFields,
     // The partial: key names and nesting match the template's SiteConfig
     // (src/lib/site.config.ts) exactly. Keys listed in manualFields are
-    // omitted, EXCEPT guidestar.directProfileUrl which is emitted as '' so
-    // the guidestar object keeps the template's full shape.
+    // omitted (the volunteer never transcribes a placeholder as real data),
+    // EXCEPT guidestar.directProfileUrl which is always emitted (as '' when
+    // absent) so the guidestar object keeps the template's full shape.
     siteConfig: {
       name: legalName,
       ...(mission ? { description: mission } : {}),
       social,
+      ...(contactEmail ? { contactEmail } : {}),
+      ...(phone ? { phone } : {}),
+      ...(addresses.length ? { addresses } : {}),
       ein: record.ein,
       guidestar: {
         profileUrl: record.candidUrl,
-        directProfileUrl: '',
+        directProfileUrl: guidestarDirectProfileUrl,
       },
       // FFC footer standard: always present, always these values.
       supportedBy: { ...SUPPORTED_BY },

--- a/scripts/generate-footer-config.mjs
+++ b/scripts/generate-footer-config.mjs
@@ -259,11 +259,15 @@ export function buildSiteConfigPartial(record, { now = new Date() } = {}) {
   const contactEmail = String(record.contactEmail ?? '').trim()
   const contactPhone = String(record.contactPhone ?? '').trim()
   const contactCityState = String(record.contactCityState ?? '').trim()
-  // SiteConfig.phone is { display, tel }: display is verbatim, tel strips to the
-  // href-safe subset (leading + and digits) for the footer's tel: link.
-  const phone = contactPhone
-    ? { display: contactPhone, tel: contactPhone.replace(/[^\d+]/g, '') }
-    : null
+  // SiteConfig.phone is { display, tel }: display is verbatim, tel is the
+  // href-safe subset for the footer's tel: link — digits, keeping only a single
+  // LEADING '+' (any non-leading '+' is dropped, so "+1 (520) 555+0100" ->
+  // "+15205550100" and a bare "520-555-0100" -> "5205550100").
+  const telHref = (raw) => {
+    const digits = raw.replace(/\D/g, '')
+    return /^\s*\+/.test(raw) ? `+${digits}` : digits
+  }
+  const phone = contactPhone ? { display: contactPhone, tel: telHref(contactPhone) } : null
   // SiteConfig.addresses is [{ label, lines, mapUrl }]; the application supplies
   // only a public city & state, so emit a single labelled line.
   const addresses = contactCityState ? [{ label: 'Location', lines: [contactCityState] }] : []

--- a/scripts/whmcs-applications.mjs
+++ b/scripts/whmcs-applications.mjs
@@ -430,8 +430,14 @@ export function ingestProducts(pid, products, byClient, pendingIds) {
     const mission = missionFromProduct(p)
     const missionOption = missionTierFromProduct(p)
     // Non-PII transparency fields (allowlisted by field name; board/contact
-    // fields are never matched). Candid link + EIN help donors evaluate.
-    const candidUrl = sanitizeCandidUrl(fieldValue(p, /guidestar|candid/i))
+    // fields are never matched). Candid link + EIN help donors evaluate. The
+    // profile reader must NOT swallow the `guidestar-full` (direct/shared)
+    // field — fieldValue returns the first name match, so any name carrying the
+    // `guidestar-full` slug is excluded (its display text also mentions Candid),
+    // keeping the public profile URL and the direct link cleanly separated.
+    const candidUrl = sanitizeCandidUrl(
+      fieldValue(p, /^(?!.*guidestar-full).*(?:guidestar|candid)/i)
+    )
     const ein = sanitizeEin(fieldValue(p, /\bEIN\b|tax id/i))
     // Charity social PAGE URLs — the onboarding products carry custom fields
     // slugged `facebook-page` / `linkedin-page` (org pages, not personal
@@ -450,34 +456,33 @@ export function ingestProducts(pid, products, byClient, pendingIds) {
       /(^|\.)linkedin\.com$/i
     )
     // Additional PUBLIC org social pages captured on the hardened onboarding
-    // products (slugged `social-instagram` / `social-x` / `social-youtube`).
-    // Host-checked; these are public-by-design (they render on the site footer).
+    // products. These fields are ALWAYS slugged on pid 16/33 (`social-instagram`
+    // / `social-x` / `social-youtube`), so each read is anchored to ONLY its
+    // exact slug — no broad `instagram`/`twitter`/`youtube` alternatives that
+    // could catch a differently-purposed field. Host-checked; public-by-design.
     const instagramUrl = sanitizeSocialUrl(
-      fieldValue(p, /social-instagram|(^|[^a-z])instagram/i),
+      fieldValue(p, /social-instagram/i),
       /(^|\.)instagram\.com$/i
     )
-    const xUrl = sanitizeSocialUrl(
-      fieldValue(p, /social-x|x \(twitter\)/i),
-      /(^|\.)(x\.com|twitter\.com)$/i
-    )
+    const xUrl = sanitizeSocialUrl(fieldValue(p, /social-x/i), /(^|\.)(x\.com|twitter\.com)$/i)
     const youtubeUrl = sanitizeSocialUrl(
-      fieldValue(p, /social-youtube|youtube/i),
+      fieldValue(p, /social-youtube/i),
       /(^|\.)(youtube\.com|youtu\.be)$/i
     )
-    // PUBLIC footer contact fields (slugged `public-phone` / `public-email` /
-    // `footer-location`). These are the org's PUBLIC-facing values the charity
-    // chose for its website footer — NOT the private onboarding "reach you at"
-    // phone or any board member's personal phone/email. Captured as trimmed
-    // strings; the footer bridge sanitizes further. NEVER read the private
-    // `*-phone` / `*-email` board fields.
-    const contactPhone = fieldValue(p, /public-phone|public phone/i)
-    const contactEmail = fieldValue(p, /public-email|public email/i)
-    const contactCityState = fieldValue(p, /footer-location|city ?& ?state|city and state/i)
+    // PUBLIC footer contact fields (always slugged `public-phone` / `public-email`
+    // / `footer-location` on pid 16/33). These are the org's PUBLIC-facing values
+    // the charity chose for its website footer — NOT the private onboarding "reach
+    // you at" phone or any board member's personal phone/email. Each read is
+    // anchored to ONLY its exact slug; captured as trimmed strings (the footer
+    // bridge sanitizes further). NEVER read the private `*-phone` / `*-email`
+    // board fields.
+    const contactPhone = fieldValue(p, /public-phone/i)
+    const contactEmail = fieldValue(p, /public-email/i)
+    const contactCityState = fieldValue(p, /footer-location/i)
     // Candid "full"/"direct/shared" profile link (distinct from the public
-    // profile URL). Reuses the Candid sanitizer (candid.org/guidestar.org only).
-    const candidDirectUrl = sanitizeCandidUrl(
-      fieldValue(p, /guidestar-full|guidestar.*(full|direct|shared)|candid.*(direct|shared)/i)
-    )
+    // profile URL above, which excludes this slug). Always slugged
+    // `guidestar-full`; reuses the Candid sanitizer (candid.org/guidestar.org).
+    const candidDirectUrl = sanitizeCandidUrl(fieldValue(p, /guidestar-full/i))
     // NOTE: pid 40 (site-body / long-form charity content) is intentionally NOT
     // scanned here — that is a future follow-up, out of scope for this change.
     const existing = byClient.get(clientId)

--- a/scripts/whmcs-applications.mjs
+++ b/scripts/whmcs-applications.mjs
@@ -361,6 +361,19 @@ export function buildApplicationRecords(byClient) {
       // org-public by construction, host-checked, never personal profiles.
       ...(rec.facebookUrl ? { facebookUrl: rec.facebookUrl } : {}),
       ...(rec.linkedinUrl ? { linkedinUrl: rec.linkedinUrl } : {}),
+      // Additional PUBLIC org social pages + PUBLIC footer contact fields
+      // (public-by-design: they render on the charity's website footer). These
+      // do NOT leak into the public roadmap issue — `stubBody` renders only a
+      // fixed field allowlist (charityName, serviceTier, charityStatusOption,
+      // missionCategoryOption, missionExcerpt, ein, candidUrl) and `writeState`
+      // stores ids only, so extra top-level record keys stay off the roadmap.
+      ...(rec.instagramUrl ? { instagramUrl: rec.instagramUrl } : {}),
+      ...(rec.xUrl ? { xUrl: rec.xUrl } : {}),
+      ...(rec.youtubeUrl ? { youtubeUrl: rec.youtubeUrl } : {}),
+      ...(rec.contactPhone ? { contactPhone: rec.contactPhone } : {}),
+      ...(rec.contactEmail ? { contactEmail: rec.contactEmail } : {}),
+      ...(rec.contactCityState ? { contactCityState: rec.contactCityState } : {}),
+      ...(rec.candidDirectUrl ? { candidDirectUrl: rec.candidDirectUrl } : {}),
       ...(rec.regIso ? { submittedAt: rec.regIso } : {}),
     })
   }
@@ -428,10 +441,45 @@ export function ingestProducts(pid, products, byClient, pendingIds) {
       fieldValue(p, /facebook[\s_-]*page/i),
       /(^|\.)facebook\.com$/i
     )
+    // ORG LinkedIn PAGE only. The "page" suffix is load-bearing PII safety: it
+    // excludes every board-member profile field (`chair-linkedin`,
+    // `secretary-linkedin`, `treasurer-linkedin`, `primary-linkedin`, …), and
+    // sanitizeSocialUrl additionally rejects `/in/…` personal-profile paths.
     const linkedinUrl = sanitizeSocialUrl(
       fieldValue(p, /linkedin[\s_-]*page/i),
       /(^|\.)linkedin\.com$/i
     )
+    // Additional PUBLIC org social pages captured on the hardened onboarding
+    // products (slugged `social-instagram` / `social-x` / `social-youtube`).
+    // Host-checked; these are public-by-design (they render on the site footer).
+    const instagramUrl = sanitizeSocialUrl(
+      fieldValue(p, /social-instagram|(^|[^a-z])instagram/i),
+      /(^|\.)instagram\.com$/i
+    )
+    const xUrl = sanitizeSocialUrl(
+      fieldValue(p, /social-x|x \(twitter\)/i),
+      /(^|\.)(x\.com|twitter\.com)$/i
+    )
+    const youtubeUrl = sanitizeSocialUrl(
+      fieldValue(p, /social-youtube|youtube/i),
+      /(^|\.)(youtube\.com|youtu\.be)$/i
+    )
+    // PUBLIC footer contact fields (slugged `public-phone` / `public-email` /
+    // `footer-location`). These are the org's PUBLIC-facing values the charity
+    // chose for its website footer — NOT the private onboarding "reach you at"
+    // phone or any board member's personal phone/email. Captured as trimmed
+    // strings; the footer bridge sanitizes further. NEVER read the private
+    // `*-phone` / `*-email` board fields.
+    const contactPhone = fieldValue(p, /public-phone|public phone/i)
+    const contactEmail = fieldValue(p, /public-email|public email/i)
+    const contactCityState = fieldValue(p, /footer-location|city ?& ?state|city and state/i)
+    // Candid "full"/"direct/shared" profile link (distinct from the public
+    // profile URL). Reuses the Candid sanitizer (candid.org/guidestar.org only).
+    const candidDirectUrl = sanitizeCandidUrl(
+      fieldValue(p, /guidestar-full|guidestar.*(full|direct|shared)|candid.*(direct|shared)/i)
+    )
+    // NOTE: pid 40 (site-body / long-form charity content) is intentionally NOT
+    // scanned here — that is a future follow-up, out of scope for this change.
     const existing = byClient.get(clientId)
     if (existing) {
       if (pid === '33') existing.pid = pid
@@ -442,6 +490,14 @@ export function ingestProducts(pid, products, byClient, pendingIds) {
       if (!existing.ein && ein) existing.ein = ein
       if (!existing.facebookUrl && facebookUrl) existing.facebookUrl = facebookUrl
       if (!existing.linkedinUrl && linkedinUrl) existing.linkedinUrl = linkedinUrl
+      if (!existing.instagramUrl && instagramUrl) existing.instagramUrl = instagramUrl
+      if (!existing.xUrl && xUrl) existing.xUrl = xUrl
+      if (!existing.youtubeUrl && youtubeUrl) existing.youtubeUrl = youtubeUrl
+      if (!existing.contactPhone && contactPhone) existing.contactPhone = contactPhone
+      if (!existing.contactEmail && contactEmail) existing.contactEmail = contactEmail
+      if (!existing.contactCityState && contactCityState)
+        existing.contactCityState = contactCityState
+      if (!existing.candidDirectUrl && candidDirectUrl) existing.candidDirectUrl = candidDirectUrl
     } else {
       byClient.set(clientId, {
         clientId,
@@ -453,6 +509,13 @@ export function ingestProducts(pid, products, byClient, pendingIds) {
         ein,
         facebookUrl,
         linkedinUrl,
+        instagramUrl,
+        xUrl,
+        youtubeUrl,
+        contactPhone,
+        contactEmail,
+        contactCityState,
+        candidDirectUrl,
         company: undefined,
       })
     }


### PR DESCRIPTION
## What & why

WHMCS now captures the full **public** footer data on the onboarding products (pid 16 pre-501c3, pid 33 full-501c3). This wires the WHMCS sync (`scripts/whmcs-applications.mjs`) to **read** those public footer fields and the footer bridge (`scripts/generate-footer-config.mjs`) to **consume** them, so a charity's footer generates completely instead of leaving contact + most socials as manual fill-in.

Refs #697 (part of the Gate-3 footer-bridge line of work).

## PII-safety note (important)

The sync produces "PII-safe application records" that feed BOTH the **public** GitHub roadmap issue (via `stubBody`/`syncIntakeIssues`) AND the footer bridge. The new fields added to the record are **PUBLIC-by-design** — the phone/email/city-state the charity chose for its website footer, and the org's own social page URLs — not the private onboarding "reach you at" phone or any board member's personal phone/email/LinkedIn.

Extra top-level record fields do **not** leak into the roadmap issue: `stubBody` renders only a fixed allowlist:

```js
field('Charity name', app.charityName)
field('Charity status', app.charityStatusOption)
field('Mission category', app.missionCategoryOption)
field('Brief mission', app.missionExcerpt)
field('EIN', app.ein)
field('Candid / GuideStar profile URL', app.candidUrl)
```

and `writeState` persists ids only (`seenApplicationIds`). The private board `*-linkedin` / `*-phone` / `*-email` fields are never matched. A new regression test proves a board `chair-linkedin` field is **not** read as the org LinkedIn.

## Field mapping

| WHMCS field (read via name-match) | record field | `siteConfig` key |
| --- | --- | --- |
| `public-phone` | `contactPhone` | `phone { display, tel }` |
| `public-email` | `contactEmail` | `contactEmail` |
| `footer-location` (city & state) | `contactCityState` | `addresses[{ label, lines }]` |
| `facebook-page` | `facebookUrl` | `social[]` Facebook |
| `linkedin-page` (org only) | `linkedinUrl` | `social[]` LinkedIn |
| `social-instagram` | `instagramUrl` | `social[]` Instagram |
| `social-x` | `xUrl` | `social[]` X (Twitter) |
| `social-youtube` | `youtubeUrl` | `social[]` YouTube |
| `guidestar-full` (Candid direct/shared) | `candidDirectUrl` | `guidestar.directProfileUrl` |

Social + Candid values are host-checked; contact strings are trimmed in the sync and sanitized in the bridge. When a public field is absent it is omitted from the partial and listed in `manualFields` instead.

## Deviation from the original spec (called out)

The spec described a `buildFooterConfig` with `contact` / `socialLinks` / `endorsements` keys. Current `origin/main` has since refactored the bridge to `buildSiteConfigPartial` emitting the shared **`SiteConfig`** shape (template convergence, FFC-Cloudflare-Automation#693): a `social[]` array, `guidestar { profileUrl, directProfileUrl }`, and contact fields that were in `manualFields`. I implemented the spec's **intent** against that current shape (contact → `contactEmail`/`phone`/`addresses`; socials → `social[]`; Candid direct → `guidestar.directProfileUrl`), and moved the now-suppliable keys from always-manual to conditional-manual. Facebook/LinkedIn reads already existed on main and were left unchanged (they already satisfy the PII contract). `docs/footer-bridge.md` was updated to match.

## Test plan

- `pnpm run format` / `format:check` — pass
- `pnpm run lint` — 0 errors (1 pre-existing warning in generated `coverage/`)
- `pnpm run type-check` — pass
- `pnpm run build` — pass
- `pnpm test` — **1058 pass**; the only failure is the pre-existing `commitlint-config › should be executable` Windows executable-bit check (fails on a clean checkout without this change; `search-index` requires build output and passes after `pnpm run build`).
- New tests: bridge — contact/phone/address populated, five socials present/ordered, omitted when absent, wrong-host social + Candid link rejected; sync — public fields read from a product, and board `*-linkedin` NOT read as org LinkedIn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)