### PR TITLE
chore(data): daily data sync (GA + workflow catalog)

### DIFF
--- a/public/data/google-analytics/ffcadmin.org.json
+++ b/public/data/google-analytics/ffcadmin.org.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "updatedAt": "2026-07-13T08:27:05Z",
+  "updatedAt": "2026-07-16T08:01:54Z",
   "site": "ffcadmin.org",
   "propertyId": "513417483",
   "dryRun": false,
@@ -10,34 +10,34 @@
     "endDate": "today"
   },
   "metrics": {
-    "activeUsers": "2004",
-    "newUsers": "2002",
-    "sessions": "2032",
-    "screenPageViews": "2201",
-    "engagementRate": "0.031496062992125984",
-    "eventCount": "6443",
+    "activeUsers": "2009",
+    "newUsers": "2005",
+    "sessions": "2039",
+    "screenPageViews": "2210",
+    "engagementRate": "0.038744482589504657",
+    "eventCount": "6498",
     "keyEvents": "0"
   },
   "topPages": [
     {
+      "path": "/documentation/index.html",
+      "views": "351"
+    },
+    {
       "path": "/index.html",
-      "views": "361"
+      "views": "351"
     },
     {
       "path": "/legacy-wordpress-administration/index.html",
-      "views": "361"
+      "views": "351"
     },
     {
       "path": "/legacy-wordpress-administration/wordpress-web-hosting/index.html",
-      "views": "361"
+      "views": "351"
     },
     {
       "path": "/tech-stack/index.html",
-      "views": "357"
-    },
-    {
-      "path": "/documentation/index.html",
-      "views": "356"
+      "views": "351"
     },
     {
       "path": "/",
@@ -45,7 +45,7 @@
     },
     {
       "path": "/charity-prerequisites/",
-      "views": "32"
+      "views": "35"
     },
     {
       "path": "/site-owner/",
@@ -56,26 +56,26 @@
       "views": "15"
     },
     {
-      "path": "/guides/github-account/",
-      "views": "13"
+      "path": "/roadmap/",
+      "views": "14"
     }
   ],
   "channels": [
     {
       "channel": "Direct",
-      "sessions": "1988"
+      "sessions": "1996"
     },
     {
       "channel": "Organic Search",
-      "sessions": "32"
-    },
-    {
-      "channel": "Unassigned",
-      "sessions": "8"
+      "sessions": "30"
     },
     {
       "channel": "Referral",
-      "sessions": "6"
+      "sessions": "7"
+    },
+    {
+      "channel": "Unassigned",
+      "sessions": "5"
     },
     {
       "channel": "AI Assistant",
@@ -84,12 +84,12 @@
   ],
   "productionHostname": "ffcadmin.org",
   "metricsProduction": {
-    "activeUsers": "208",
-    "newUsers": "206",
-    "sessions": "242",
-    "screenPageViews": "405",
-    "engagementRate": "0.26446280991735538",
-    "eventCount": "1055",
+    "activeUsers": "254",
+    "newUsers": "250",
+    "sessions": "287",
+    "screenPageViews": "455",
+    "engagementRate": "0.27526132404181186",
+    "eventCount": "1233",
     "keyEvents": "0"
   }
 }

--- a/public/data/google-analytics/ffcadmin.org.json
+++ b/public/data/google-analytics/ffcadmin.org.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "updatedAt": "2026-07-16T08:01:54Z",
+  "updatedAt": "2026-07-19T13:09:00Z",
   "site": "ffcadmin.org",
   "propertyId": "513417483",
   "dryRun": false,
@@ -10,34 +10,34 @@
     "endDate": "today"
   },
   "metrics": {
-    "activeUsers": "2009",
-    "newUsers": "2005",
-    "sessions": "2039",
-    "screenPageViews": "2210",
-    "engagementRate": "0.038744482589504657",
-    "eventCount": "6498",
+    "activeUsers": "1945",
+    "newUsers": "1940",
+    "sessions": "1977",
+    "screenPageViews": "2159",
+    "engagementRate": "0.039959534648457258",
+    "eventCount": "6320",
     "keyEvents": "0"
   },
   "topPages": [
     {
-      "path": "/documentation/index.html",
-      "views": "351"
-    },
-    {
-      "path": "/index.html",
-      "views": "351"
-    },
-    {
       "path": "/legacy-wordpress-administration/index.html",
-      "views": "351"
+      "views": "338"
     },
     {
       "path": "/legacy-wordpress-administration/wordpress-web-hosting/index.html",
-      "views": "351"
+      "views": "338"
     },
     {
       "path": "/tech-stack/index.html",
-      "views": "351"
+      "views": "337"
+    },
+    {
+      "path": "/index.html",
+      "views": "336"
+    },
+    {
+      "path": "/documentation/index.html",
+      "views": "333"
     },
     {
       "path": "/",
@@ -45,29 +45,29 @@
     },
     {
       "path": "/charity-prerequisites/",
-      "views": "35"
+      "views": "40"
     },
     {
       "path": "/site-owner/",
-      "views": "32"
-    },
-    {
-      "path": "/get-involved/",
-      "views": "15"
+      "views": "29"
     },
     {
       "path": "/roadmap/",
+      "views": "16"
+    },
+    {
+      "path": "/developer-environment-setup/",
       "views": "14"
     }
   ],
   "channels": [
     {
       "channel": "Direct",
-      "sessions": "1996"
+      "sessions": "1934"
     },
     {
       "channel": "Organic Search",
-      "sessions": "30"
+      "sessions": "31"
     },
     {
       "channel": "Referral",
@@ -75,7 +75,7 @@
     },
     {
       "channel": "Unassigned",
-      "sessions": "5"
+      "sessions": "7"
     },
     {
       "channel": "AI Assistant",
@@ -84,12 +84,12 @@
   ],
   "productionHostname": "ffcadmin.org",
   "metricsProduction": {
-    "activeUsers": "254",
-    "newUsers": "250",
-    "sessions": "287",
-    "screenPageViews": "455",
-    "engagementRate": "0.27526132404181186",
-    "eventCount": "1233",
+    "activeUsers": "263",
+    "newUsers": "258",
+    "sessions": "295",
+    "screenPageViews": "477",
+    "engagementRate": "0.26779661016949152",
+    "eventCount": "1274",
     "keyEvents": "0"
   }
 }

--- a/public/data/google-analytics/ffcadmin.org.timeseries.json
+++ b/public/data/google-analytics/ffcadmin.org.timeseries.json
@@ -6,9 +6,9 @@
     "screenPageViews": "405"
   },
   {
-    "date": "2026-07-16",
-    "activeUsers": "254",
-    "sessions": "287",
-    "screenPageViews": "455"
+    "date": "2026-07-19",
+    "activeUsers": "263",
+    "sessions": "295",
+    "screenPageViews": "477"
   }
 ]

--- a/public/data/google-analytics/ffcadmin.org.timeseries.json
+++ b/public/data/google-analytics/ffcadmin.org.timeseries.json
@@ -4,5 +4,11 @@
     "activeUsers": "208",
     "sessions": "242",
     "screenPageViews": "405"
+  },
+  {
+    "date": "2026-07-16",
+    "activeUsers": "254",
+    "sessions": "287",
+    "screenPageViews": "455"
   }
 ]

--- a/public/data/google-analytics/freeforcharity.org.json
+++ b/public/data/google-analytics/freeforcharity.org.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "updatedAt": "2026-07-13T08:27:02Z",
+  "updatedAt": "2026-07-16T08:01:49Z",
   "site": "freeforcharity.org",
   "propertyId": "386764754",
   "dryRun": false,
@@ -10,34 +10,38 @@
     "endDate": "today"
   },
   "metrics": {
-    "activeUsers": "789",
-    "newUsers": "816",
-    "sessions": "871",
-    "screenPageViews": "1003",
-    "engagementRate": "0.19632606199770378",
-    "eventCount": "3368",
+    "activeUsers": "832",
+    "newUsers": "858",
+    "sessions": "932",
+    "screenPageViews": "1082",
+    "engagementRate": "0.21995708154506438",
+    "eventCount": "3606",
     "keyEvents": "0"
   },
   "topPages": [
     {
       "path": "/",
-      "views": "747"
+      "views": "755"
     },
     {
       "path": "/domains/",
-      "views": "153"
+      "views": "197"
     },
     {
       "path": "/501c3/",
-      "views": "36"
+      "views": "42"
     },
     {
       "path": "/free-charity-web-hosting/",
-      "views": "22"
+      "views": "33"
     },
     {
       "path": "/guidestar-guide/",
-      "views": "11"
+      "views": "13"
+    },
+    {
+      "path": "/about-us/",
+      "views": "6"
     },
     {
       "path": "/ffc-volunteer-proving-ground-core-competencies/",
@@ -45,33 +49,33 @@
     },
     {
       "path": "/pre501c3/",
-      "views": "5"
+      "views": "6"
     },
     {
-      "path": "/help-for-charities/",
+      "path": "/contact-us/",
       "views": "4"
     },
     {
       "path": "/free-for-charitys-tools-for-success/",
-      "views": "3"
-    },
-    {
-      "path": "/free-training-programs/",
-      "views": "3"
+      "views": "4"
     }
   ],
   "channels": [
     {
       "channel": "Direct",
-      "sessions": "685"
+      "sessions": "697"
     },
     {
       "channel": "Organic Search",
-      "sessions": "173"
+      "sessions": "219"
     },
     {
       "channel": "AI Assistant",
-      "sessions": "12"
+      "sessions": "16"
+    },
+    {
+      "channel": "Organic Social",
+      "sessions": "2"
     },
     {
       "channel": "Referral",
@@ -84,12 +88,12 @@
   ],
   "productionHostname": "freeforcharity.org",
   "metricsProduction": {
-    "activeUsers": "179",
-    "newUsers": "177",
-    "sessions": "261",
-    "screenPageViews": "317",
-    "engagementRate": "0.47892720306513409",
-    "eventCount": "949",
+    "activeUsers": "222",
+    "newUsers": "220",
+    "sessions": "325",
+    "screenPageViews": "398",
+    "engagementRate": "0.49538461538461537",
+    "eventCount": "1197",
     "keyEvents": "0"
   }
 }

--- a/public/data/google-analytics/freeforcharity.org.json
+++ b/public/data/google-analytics/freeforcharity.org.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "updatedAt": "2026-07-16T08:01:49Z",
+  "updatedAt": "2026-07-19T13:08:55Z",
   "site": "freeforcharity.org",
   "propertyId": "386764754",
   "dryRun": false,
@@ -10,34 +10,34 @@
     "endDate": "today"
   },
   "metrics": {
-    "activeUsers": "832",
+    "activeUsers": "837",
     "newUsers": "858",
-    "sessions": "932",
-    "screenPageViews": "1082",
-    "engagementRate": "0.21995708154506438",
-    "eventCount": "3606",
+    "sessions": "953",
+    "screenPageViews": "1100",
+    "engagementRate": "0.23189926547743966",
+    "eventCount": "3641",
     "keyEvents": "0"
   },
   "topPages": [
     {
       "path": "/",
-      "views": "755"
+      "views": "719"
     },
     {
       "path": "/domains/",
-      "views": "197"
+      "views": "222"
     },
     {
       "path": "/501c3/",
-      "views": "42"
+      "views": "50"
     },
     {
       "path": "/free-charity-web-hosting/",
-      "views": "33"
+      "views": "43"
     },
     {
       "path": "/guidestar-guide/",
-      "views": "13"
+      "views": "19"
     },
     {
       "path": "/about-us/",
@@ -53,25 +53,25 @@
     },
     {
       "path": "/contact-us/",
-      "views": "4"
+      "views": "5"
     },
     {
-      "path": "/free-for-charitys-tools-for-success/",
-      "views": "4"
+      "path": "/help-for-charities/",
+      "views": "5"
     }
   ],
   "channels": [
     {
       "channel": "Direct",
-      "sessions": "697"
+      "sessions": "681"
     },
     {
       "channel": "Organic Search",
-      "sessions": "219"
+      "sessions": "253"
     },
     {
       "channel": "AI Assistant",
-      "sessions": "16"
+      "sessions": "19"
     },
     {
       "channel": "Organic Social",
@@ -88,12 +88,12 @@
   ],
   "productionHostname": "freeforcharity.org",
   "metricsProduction": {
-    "activeUsers": "222",
-    "newUsers": "220",
-    "sessions": "325",
-    "screenPageViews": "398",
-    "engagementRate": "0.49538461538461537",
-    "eventCount": "1197",
+    "activeUsers": "258",
+    "newUsers": "256",
+    "sessions": "379",
+    "screenPageViews": "460",
+    "engagementRate": "0.48548812664907653",
+    "eventCount": "1380",
     "keyEvents": "0"
   }
 }

--- a/public/data/google-analytics/freeforcharity.org.timeseries.json
+++ b/public/data/google-analytics/freeforcharity.org.timeseries.json
@@ -4,5 +4,11 @@
     "activeUsers": "179",
     "sessions": "261",
     "screenPageViews": "317"
+  },
+  {
+    "date": "2026-07-16",
+    "activeUsers": "222",
+    "sessions": "325",
+    "screenPageViews": "398"
   }
 ]

--- a/public/data/google-analytics/freeforcharity.org.timeseries.json
+++ b/public/data/google-analytics/freeforcharity.org.timeseries.json
@@ -6,9 +6,9 @@
     "screenPageViews": "317"
   },
   {
-    "date": "2026-07-16",
-    "activeUsers": "222",
-    "sessions": "325",
-    "screenPageViews": "398"
+    "date": "2026-07-19",
+    "activeUsers": "258",
+    "sessions": "379",
+    "screenPageViews": "460"
   }
 ]

--- a/public/data/workflow-catalog.json
+++ b/public/data/workflow-catalog.json
@@ -10,7 +10,7 @@
       "5": "Google",
       "6": "WPMUDEV",
       "7": "GitHub (Website + Repo)",
-      "8": "Reserved",
+      "8": "Candid (GuideStar)",
       "9": "Reserved"
     },
     "tagRule": "the [TAG] lists ALL APIs the workflow CALLS (not services configured-for, not plumbing like KV auth or issue comments)"
@@ -979,6 +979,26 @@
       "categoryCode": "WHMCS"
     },
     {
+      "number": 227,
+      "title": "cPanel - Deploy WHMCS Hooks (FTPS/lftp)",
+      "apis": [
+        "cPanel"
+      ],
+      "file": "227-whmcs-hooks-deploy.yml",
+      "triggers": [
+        "workflow_dispatch"
+      ],
+      "environments": [
+        "whmcs-prod"
+      ],
+      "description": "Deploys the version-controlled WHMCS hooks in whmcs/hooks/*.php to the production cPanel host, replacing the manual-FTPS runbook. It uses the SAME proven transport as the freeforcharity.org website deploy (deploy-cpanel.yml): GH OIDC -> Azure -> Key Vault (kv-ffc-admin-prod-cbm) -> MAIN cPanel FTP creds -> lftp over FTPS (AUTH TLS). The MAIN account is homed at the account root, so it can write into ~/public_html/hub/includes/hooks/. Creds are piped to lftp via stdin (never argv).  Target:   public_html/hub/includes/hooks/<file>.php  (relative to the cPanel home) KV creds: wr-all-cbm-cpanel-ffc-interserver-ftp-{host,port,user,password}  mode=verify (default) is READ-ONLY: it connects (proving auth+connectivity), downloads the deployed hooks, and reports whether each matches the repo (or is not deployed yet). mode=deploy uploads each hook first, then downloads + compares and fails on any mismatch.",
+      "safetyLevel": "Writes (verify default)",
+      "approvalEnv": "\u2705 whmcs-prod",
+      "guard": "mode=verify (read-only) vs deploy; hooks input is basename-validated",
+      "category": "WHMCS",
+      "categoryCode": "WHMCS"
+    },
+    {
       "number": 301,
       "title": "M365 - Domain Preflight (Read-only)",
       "apis": [
@@ -1344,7 +1364,7 @@
       "description": "Regenerates an FFC-EX site as a faithful static clone of the live WordPress site and opens a PR on the target FFC-EX repo. Pipeline (all proven locally): clone-site-static.mjs (httrack) -> integrate-clone-into-nextjs.mjs -> next build (output: 'export') so the Next.js app serves the exact clone. See docs/ffc-ex-static-clone-runbook.md.  Auth: uses CBM_TOKEN (cross-repo PAT, same secret create-repo.yml uses) to check out the FFC-EX repo and push a branch + open a PR there. Non-destructive: it never pushes to the FFC-EX default branch, only opens a PR for review.",
       "safetyLevel": "Writes (gated)",
       "approvalEnv": "\u2705 github-prod",
-      "guard": "opens a draft PR (never pushes); serialized",
+      "guard": "ungated preflight (repo must exist; refuses live sites and sibling-domain repos unless `force=true`); opens a draft PR (never pushes); serialized",
       "category": "GitHub (Website + Repo)",
       "categoryCode": "GH"
     },
@@ -1703,6 +1723,66 @@
       "guard": "weekly org inventory (feeds smoke-protected waves); PR-only + auto-merge",
       "category": "GitHub (Website + Repo)",
       "categoryCode": "GH"
+    },
+    {
+      "number": 736,
+      "title": "Repo - Archive / Application Denied (Admin)",
+      "apis": [
+        "Repo"
+      ],
+      "file": "736-repo-archive.yml",
+      "triggers": [
+        "workflow_dispatch"
+      ],
+      "environments": [
+        "github-prod"
+      ],
+      "description": "Destructive-adjacent, so heavily guarded. This workflow ONLY archives a repository (`archived: true`) \u2014 it NEVER deletes one. Archiving is fully reversible (a maintainer can unarchive from Settings), which is the deliberate safety choice: the worst case is a repo that is temporarily read-only, not data loss.  Five guards, all must pass for a live archive: 1. dispatch-only (never issue/label triggered \u2014 no accidental auto-archive) 2. dry_run defaults to true (preview only; you must pass dry_run=false) 3. typed confirmation: confirm_repo must exactly equal repo 4. org lock + hard denylist (refuses anything outside FreeForCharity, and always refuses the automation repo, the website template, and the org-wide .github repo) 5. github-prod environment approval gate (a human reviewer must approve the deployment)",
+      "safetyLevel": "Writes (dry-run default)",
+      "approvalEnv": "\u2705 github-prod",
+      "guard": "ungated preflight (live archive requires a matching successful dry-run within 48h; fails fast on missing/already-archived; warns on recent push/Pages/open-issue references); archive-only (reversible, never deletes); `dry_run` default true; typed `confirm_repo`; org-locked + denylist",
+      "category": "GitHub (Website + Repo)",
+      "categoryCode": "GH"
+    },
+    {
+      "number": 801,
+      "title": "Candid - Charity Check (EIN)",
+      "apis": [
+        "CANDID"
+      ],
+      "file": "801-candid-charity-check.yml",
+      "triggers": [
+        "workflow_dispatch"
+      ],
+      "environments": [
+        "candid-prod-read"
+      ],
+      "description": "Read-only: validates a nonprofit's IRS 501(c)(3) / Pub78 / BMF / OFAC standing via the Candid Charity Check v1 API. Used to verify an applicant's EIN during charity onboarding and to re-verify existing partners. Key comes from Azure Key Vault at run time via OIDC (candid-keys-from-kv); see docs/candid-api-and-mcp.md for the one-time setup.",
+      "safetyLevel": "Reads",
+      "approvalEnv": "candid-prod-read",
+      "guard": "read-only IRS-status lookup; public org data only",
+      "category": "Candid (GuideStar)",
+      "categoryCode": "CANDID"
+    },
+    {
+      "number": 802,
+      "title": "Candid - Essentials Search",
+      "apis": [
+        "CANDID"
+      ],
+      "file": "802-candid-essentials-search.yml",
+      "triggers": [
+        "workflow_dispatch"
+      ],
+      "environments": [
+        "candid-prod-read"
+      ],
+      "description": "Read-only: searches Candid's nonprofit database (Essentials v4) by EIN, organization name, or keywords and reports name / EIN / location / transparency-seal level / profile URL. Used during charity onboarding to locate an applicant's Candid (GuideStar) profile and seal level. Key comes from Azure Key Vault at run time via OIDC (candid-keys-from-kv); see docs/candid-api-and-mcp.md.",
+      "safetyLevel": "Reads",
+      "approvalEnv": "candid-prod-read",
+      "guard": "read-only profile search; public org data only",
+      "category": "Candid (GuideStar)",
+      "categoryCode": "CANDID"
     }
   ]
 }

--- a/src/data/workflow-catalog.json
+++ b/src/data/workflow-catalog.json
@@ -10,7 +10,7 @@
       "5": "Google",
       "6": "WPMUDEV",
       "7": "GitHub (Website + Repo)",
-      "8": "Reserved",
+      "8": "Candid (GuideStar)",
       "9": "Reserved"
     },
     "tagRule": "the [TAG] lists ALL APIs the workflow CALLS (not services configured-for, not plumbing like KV auth or issue comments)"
@@ -979,6 +979,26 @@
       "categoryCode": "WHMCS"
     },
     {
+      "number": 227,
+      "title": "cPanel - Deploy WHMCS Hooks (FTPS/lftp)",
+      "apis": [
+        "cPanel"
+      ],
+      "file": "227-whmcs-hooks-deploy.yml",
+      "triggers": [
+        "workflow_dispatch"
+      ],
+      "environments": [
+        "whmcs-prod"
+      ],
+      "description": "Deploys the version-controlled WHMCS hooks in whmcs/hooks/*.php to the production cPanel host, replacing the manual-FTPS runbook. It uses the SAME proven transport as the freeforcharity.org website deploy (deploy-cpanel.yml): GH OIDC -> Azure -> Key Vault (kv-ffc-admin-prod-cbm) -> MAIN cPanel FTP creds -> lftp over FTPS (AUTH TLS). The MAIN account is homed at the account root, so it can write into ~/public_html/hub/includes/hooks/. Creds are piped to lftp via stdin (never argv).  Target:   public_html/hub/includes/hooks/<file>.php  (relative to the cPanel home) KV creds: wr-all-cbm-cpanel-ffc-interserver-ftp-{host,port,user,password}  mode=verify (default) is READ-ONLY: it connects (proving auth+connectivity), downloads the deployed hooks, and reports whether each matches the repo (or is not deployed yet). mode=deploy uploads each hook first, then downloads + compares and fails on any mismatch.",
+      "safetyLevel": "Writes (verify default)",
+      "approvalEnv": "\u2705 whmcs-prod",
+      "guard": "mode=verify (read-only) vs deploy; hooks input is basename-validated",
+      "category": "WHMCS",
+      "categoryCode": "WHMCS"
+    },
+    {
       "number": 301,
       "title": "M365 - Domain Preflight (Read-only)",
       "apis": [
@@ -1344,7 +1364,7 @@
       "description": "Regenerates an FFC-EX site as a faithful static clone of the live WordPress site and opens a PR on the target FFC-EX repo. Pipeline (all proven locally): clone-site-static.mjs (httrack) -> integrate-clone-into-nextjs.mjs -> next build (output: 'export') so the Next.js app serves the exact clone. See docs/ffc-ex-static-clone-runbook.md.  Auth: uses CBM_TOKEN (cross-repo PAT, same secret create-repo.yml uses) to check out the FFC-EX repo and push a branch + open a PR there. Non-destructive: it never pushes to the FFC-EX default branch, only opens a PR for review.",
       "safetyLevel": "Writes (gated)",
       "approvalEnv": "\u2705 github-prod",
-      "guard": "opens a draft PR (never pushes); serialized",
+      "guard": "ungated preflight (repo must exist; refuses live sites and sibling-domain repos unless `force=true`); opens a draft PR (never pushes); serialized",
       "category": "GitHub (Website + Repo)",
       "categoryCode": "GH"
     },
@@ -1703,6 +1723,66 @@
       "guard": "weekly org inventory (feeds smoke-protected waves); PR-only + auto-merge",
       "category": "GitHub (Website + Repo)",
       "categoryCode": "GH"
+    },
+    {
+      "number": 736,
+      "title": "Repo - Archive / Application Denied (Admin)",
+      "apis": [
+        "Repo"
+      ],
+      "file": "736-repo-archive.yml",
+      "triggers": [
+        "workflow_dispatch"
+      ],
+      "environments": [
+        "github-prod"
+      ],
+      "description": "Destructive-adjacent, so heavily guarded. This workflow ONLY archives a repository (`archived: true`) \u2014 it NEVER deletes one. Archiving is fully reversible (a maintainer can unarchive from Settings), which is the deliberate safety choice: the worst case is a repo that is temporarily read-only, not data loss.  Five guards, all must pass for a live archive: 1. dispatch-only (never issue/label triggered \u2014 no accidental auto-archive) 2. dry_run defaults to true (preview only; you must pass dry_run=false) 3. typed confirmation: confirm_repo must exactly equal repo 4. org lock + hard denylist (refuses anything outside FreeForCharity, and always refuses the automation repo, the website template, and the org-wide .github repo) 5. github-prod environment approval gate (a human reviewer must approve the deployment)",
+      "safetyLevel": "Writes (dry-run default)",
+      "approvalEnv": "\u2705 github-prod",
+      "guard": "ungated preflight (live archive requires a matching successful dry-run within 48h; fails fast on missing/already-archived; warns on recent push/Pages/open-issue references); archive-only (reversible, never deletes); `dry_run` default true; typed `confirm_repo`; org-locked + denylist",
+      "category": "GitHub (Website + Repo)",
+      "categoryCode": "GH"
+    },
+    {
+      "number": 801,
+      "title": "Candid - Charity Check (EIN)",
+      "apis": [
+        "CANDID"
+      ],
+      "file": "801-candid-charity-check.yml",
+      "triggers": [
+        "workflow_dispatch"
+      ],
+      "environments": [
+        "candid-prod-read"
+      ],
+      "description": "Read-only: validates a nonprofit's IRS 501(c)(3) / Pub78 / BMF / OFAC standing via the Candid Charity Check v1 API. Used to verify an applicant's EIN during charity onboarding and to re-verify existing partners. Key comes from Azure Key Vault at run time via OIDC (candid-keys-from-kv); see docs/candid-api-and-mcp.md for the one-time setup.",
+      "safetyLevel": "Reads",
+      "approvalEnv": "candid-prod-read",
+      "guard": "read-only IRS-status lookup; public org data only",
+      "category": "Candid (GuideStar)",
+      "categoryCode": "CANDID"
+    },
+    {
+      "number": 802,
+      "title": "Candid - Essentials Search",
+      "apis": [
+        "CANDID"
+      ],
+      "file": "802-candid-essentials-search.yml",
+      "triggers": [
+        "workflow_dispatch"
+      ],
+      "environments": [
+        "candid-prod-read"
+      ],
+      "description": "Read-only: searches Candid's nonprofit database (Essentials v4) by EIN, organization name, or keywords and reports name / EIN / location / transparency-seal level / profile URL. Used during charity onboarding to locate an applicant's Candid (GuideStar) profile and seal level. Key comes from Azure Key Vault at run time via OIDC (candid-keys-from-kv); see docs/candid-api-and-mcp.md.",
+      "safetyLevel": "Reads",
+      "approvalEnv": "candid-prod-read",
+      "guard": "read-only profile search; public org data only",
+      "category": "Candid (GuideStar)",
+      "categoryCode": "CANDID"
     }
   ]
 }


### PR DESCRIPTION
Automated daily sync from FFC-Cloudflare-Automation (502), delivered by run [29688293219](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/actions/runs/29688293219) — the first successful end-to-end deliver since the #733 FETCH_HEAD fix. PII-safe aggregates only.

Opened manually by the conductor: the workflow's `gh pr view` existence guard matched the *merged* #621 from this branch and skipped PR creation — bug filed in the hub.