### PR TITLE
chore: bump Node.js toolchain from 20 (EOL) to 24 across workflows

### DIFF
--- a/.github/workflows/build-roadmap-data.yml
+++ b/.github/workflows/build-roadmap-data.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -127,7 +127,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.github/workflows/fleet-audit.yml
+++ b/.github/workflows/fleet-audit.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Run fleet audit
         run: node scripts/fleet-audit.mjs

--- a/.github/workflows/gate3-validate.yml
+++ b/.github/workflows/gate3-validate.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
 
       # The script is dependency-free (plain node fetch), so no pnpm install.
       - name: Run Gate-3 checks

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.github/workflows/linkinator-external.yml
+++ b/.github/workflows/linkinator-external.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.github/workflows/sync-applications.yml
+++ b/.github/workflows/sync-applications.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Sync applications
         run: node scripts/sync-applications.mjs

--- a/.github/workflows/update-ci-status.yml
+++ b/.github/workflows/update-ci-status.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Generate CI status JSON
         run: node scripts/generate-ci-status.mjs

--- a/.github/workflows/update-domain-expiry.yml
+++ b/.github/workflows/update-domain-expiry.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Generate domain expiry JSON (RDAP)
         run: node scripts/generate-domain-expiry.mjs

--- a/.github/workflows/update-fleet-smoke-status.yml
+++ b/.github/workflows/update-fleet-smoke-status.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Generate fleet smoke status JSON
         run: node scripts/generate-fleet-smoke-status.mjs

--- a/.github/workflows/update-volunteer-hours.yml
+++ b/.github/workflows/update-volunteer-hours.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Generate volunteer hours JSON
         run: node scripts/generate-volunteer-hours.mjs

--- a/.github/workflows/whmcs-intake.yml
+++ b/.github/workflows/whmcs-intake.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Load WHMCS credentials from Key Vault
         uses: ./.github/actions/azure-kv-secrets


### PR DESCRIPTION
Ports the template's Node 24 upgrade (FFC-IN-FFC_Single_Page_Template#406) to ffcadmin: 13 workflows move actions/setup-node from EOL Node 20 to 24 (incl. today's update-fleet-smoke-status.yml which copied the old pattern). freeforcharity.org was already on 24. CI on this PR is itself the verification (build/test/lighthouse all run on 24).