### PR TITLE
feat(fleet-status): derive site identity from Pages config, not the CNAME file

### DIFF
--- a/__tests__/fleet-smoke-status.test.js
+++ b/__tests__/fleet-smoke-status.test.js
@@ -87,6 +87,24 @@ describe('computeSiteState', () => {
     ).toBe('passing')
   })
 
+  it('serving identity undeterminable (Pages unreadable + no CNAME) -> unknown, not not-cutover', () => {
+    expect(
+      computeSiteState({
+        domain: null,
+        run: null,
+        pagesEnabled: null,
+        identityUnknown: true,
+        now: NOW,
+      }).state
+    ).toBe('unknown')
+  })
+
+  it('no domain with identity known -> not-cutover (default)', () => {
+    expect(
+      computeSiteState({ domain: null, run: null, identityUnknown: false, now: NOW }).state
+    ).toBe('not-cutover')
+  })
+
   it('in-progress run -> running', () => {
     expect(
       computeSiteState({ domain: 'x.org', run: run({ status: 'in_progress' }), now: NOW }).state

--- a/__tests__/fleet-smoke-status.test.js
+++ b/__tests__/fleet-smoke-status.test.js
@@ -48,11 +48,43 @@ describe('EMPTY_SUMMARY', () => {
   it('has a zeroed count for stale-monitor', () => {
     expect(EMPTY_SUMMARY['stale-monitor']).toBe(0)
   })
+  it('has a zeroed count for not-deployed', () => {
+    expect(EMPTY_SUMMARY['not-deployed']).toBe(0)
+  })
 })
 
 describe('computeSiteState', () => {
   it('no domain -> not-cutover', () => {
     expect(computeSiteState({ domain: null, run: run(), now: NOW }).state).toBe('not-cutover')
+  })
+
+  it('Pages disabled -> not-deployed, even with a fresh passing run', () => {
+    const res = computeSiteState({
+      domain: 'x.org',
+      run: run({ updated_at: hoursAgo(1) }),
+      workflowState: 'active',
+      pagesEnabled: false,
+      now: NOW,
+    })
+    expect(res.state).toBe('not-deployed')
+    expect(res.staleReason).toBeNull()
+  })
+
+  it('Pages disabled with no domain -> not-deployed (not not-cutover)', () => {
+    expect(computeSiteState({ domain: null, run: null, pagesEnabled: false, now: NOW }).state).toBe(
+      'not-deployed'
+    )
+  })
+
+  it('Pages config unreadable (pagesEnabled null) does not force not-deployed', () => {
+    expect(
+      computeSiteState({
+        domain: 'x.org',
+        run: run({ updated_at: hoursAgo(1) }),
+        pagesEnabled: null,
+        now: NOW,
+      }).state
+    ).toBe('passing')
   })
 
   it('in-progress run -> running', () => {

--- a/scripts/generate-fleet-smoke-status.mjs
+++ b/scripts/generate-fleet-smoke-status.mjs
@@ -43,6 +43,7 @@ export const EMPTY_SUMMARY = {
   running: 0,
   'stale-monitor': 0,
   'not-cutover': 0,
+  'not-deployed': 0,
   pending: 0,
   unknown: 0,
 }
@@ -60,6 +61,44 @@ async function ghJson(path) {
   if (res.status === 404) return null
   if (!res.ok) throw new Error(`GitHub API ${path} -> ${res.status}`)
   return res.json()
+}
+
+/**
+ * Read a repo's GitHub Pages configuration — the *serving* truth (#742). The
+ * committed public/CNAME file is only the build's claim of a domain; the Pages
+ * `cname` is what the site is actually served on, and the two can disagree.
+ * Returns:
+ *   { enabled: true,  cname, htmlUrl, status } — Pages on (cname null when
+ *                                                served on the default *.github.io URL).
+ *   { enabled: false, ... }                    — Pages disabled (404).
+ *   { enabled: null,  ... }                    — could not determine (network /
+ *                                                permission / other error).
+ * Pages metadata on a public repo is world-readable with the ambient token,
+ * like the actions/workflows and actions/runs endpoints this script already
+ * reads cross-repo.
+ */
+async function pagesInfo(repo) {
+  try {
+    const res = await fetch(`https://api.github.com/repos/${ORG}/${repo}/pages`, {
+      headers: {
+        Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+    })
+    if (res.status === 404) return { enabled: false, cname: null, htmlUrl: null, status: null }
+    if (!res.ok) return { enabled: null, cname: null, htmlUrl: null, status: null }
+    const body = await res.json()
+    const cname = body?.cname ? String(body.cname).trim() : ''
+    return {
+      enabled: true,
+      cname: cname || null,
+      htmlUrl: body?.html_url || null,
+      status: body?.status || null,
+    }
+  } catch {
+    return { enabled: null, cname: null, htmlUrl: null, status: null }
+  }
 }
 
 async function listFleetRepos() {
@@ -93,15 +132,32 @@ export function hoursSince(iso, now = new Date()) {
  * the workflows list was readable but the workflow is absent, or null/undefined
  * when we could not read the workflows list (treated as unknown, not stale).
  *
+ * `pagesEnabled` is the serving truth from the Pages API (#742): `true` when
+ * Pages is on, `false` when it is disabled (404), and `null`/`undefined` when
+ * we could not read the Pages config (treated as unknown, not disabled).
+ *
  * Precedence, most specific first:
- *   not-cutover  — no CNAME, nothing to monitor.
+ *   not-deployed — Pages disabled, nothing is served, so nothing to monitor.
+ *   not-cutover  — no serving domain yet, nothing to monitor.
  *   running      — a run is queued/in progress right now.
  *   stale-monitor — workflow not active (disabled or missing), OR latest run older than 48h.
  *   passing/failing — latest run's conclusion, when recent.
  *   pending      — cut over, workflow known 'active', no run yet.
  *   unknown      — no run and the workflow state is unknown (list unreadable).
  */
-export function computeSiteState({ domain, run, workflowState, now = new Date() } = {}) {
+export function computeSiteState({
+  domain,
+  run,
+  workflowState,
+  pagesEnabled,
+  now = new Date(),
+} = {}) {
+  // GitHub Pages disabled — the site is not served, so nothing to monitor.
+  // Mirror smoke engine v3's neutral skip. Only a definitive `false` triggers
+  // this; `null`/`undefined` (Pages config unreadable) falls through so a
+  // transient Pages-read failure never mislabels a live site as not-deployed.
+  if (pagesEnabled === false) return { state: 'not-deployed', staleReason: null }
+
   if (!domain) return { state: 'not-cutover', staleReason: null }
   if (run && (run.status === 'in_progress' || run.status === 'queued'))
     return { state: 'running', staleReason: null }
@@ -142,7 +198,7 @@ export function computeSiteState({ domain, run, workflowState, now = new Date() 
 }
 
 async function siteStatus(repo, now = new Date()) {
-  const [cname, issues, workflows] = await Promise.all([
+  const [cname, issues, workflows, pages] = await Promise.all([
     ghJson(`/repos/${ORG}/${repo}/contents/public/CNAME`).catch(() => null),
     ghJson(`/repos/${ORG}/${repo}/issues?state=open&labels=smoke-failure&per_page=1`).catch(
       () => null
@@ -150,11 +206,25 @@ async function siteStatus(repo, now = new Date()) {
     // per_page=100 so the smoke workflow is never off-page and mis-flagged
     // 'missing' (default page size is 30). FFC repos have far fewer than 100.
     ghJson(`/repos/${ORG}/${repo}/actions/workflows?per_page=100`).catch(() => null),
+    // Serving identity — one bounded Pages call per repo (#742).
+    pagesInfo(repo),
   ])
 
-  const domain = cname?.content
-    ? Buffer.from(cname.content, 'base64').toString('utf8').trim()
+  // The committed public/CNAME file is only the build's *claim* of a domain;
+  // keep it as a secondary field so drift from the serving truth stays visible
+  // on the page instead of being silently masked (#742 / #740).
+  const cnameFile = cname?.content
+    ? Buffer.from(cname.content, 'base64').toString('utf8').trim() || null
     : null
+
+  // Primary identity is the Pages `cname` (the serving truth). When Pages is
+  // enabled but has no custom domain, `cname` is null — the site serves on its
+  // default *.github.io URL, i.e. not yet cut over. When the Pages config could
+  // not be read at all (enabled === null) fall back to the committed CNAME file
+  // so a transient Pages-read failure degrades to the pre-#742 behaviour rather
+  // than blanking the domain. When Pages is disabled (enabled === false) there
+  // is no serving domain and computeSiteState resolves it to `not-deployed`.
+  const domain = pages.enabled === true ? pages.cname : pages.enabled === null ? cnameFile : null
   const issue = Array.isArray(issues) && issues[0] ? issues[0] : null
 
   // workflowState: null when the workflows list couldn't be read (unknown —
@@ -187,11 +257,18 @@ async function siteStatus(repo, now = new Date()) {
     run = (runs?.workflow_runs || []).find((r) => r.name === SMOKE_WORKFLOW_NAME) || null
   }
 
-  const { state, staleReason } = computeSiteState({ domain, run, workflowState, now })
+  const { state, staleReason } = computeSiteState({
+    domain,
+    run,
+    workflowState,
+    pagesEnabled: pages.enabled,
+    now,
+  })
 
   return {
     repo,
     domain,
+    cnameFile,
     state,
     smoke: run
       ? {
@@ -230,6 +307,7 @@ async function main() {
           return {
             repo: r,
             domain: null,
+            cnameFile: null,
             state: 'unknown',
             smoke: null,
             smokeWorkflowState: null,

--- a/scripts/generate-fleet-smoke-status.mjs
+++ b/scripts/generate-fleet-smoke-status.mjs
@@ -136,8 +136,14 @@ export function hoursSince(iso, now = new Date()) {
  * Pages is on, `false` when it is disabled (404), and `null`/`undefined` when
  * we could not read the Pages config (treated as unknown, not disabled).
  *
+ * `identityUnknown` is true when serving identity could not be determined from
+ * either source — the Pages config was unreadable AND there is no committed
+ * CNAME file to fall back to. In that case a null `domain` means "we don't
+ * know", not "not cut over".
+ *
  * Precedence, most specific first:
  *   not-deployed — Pages disabled, nothing is served, so nothing to monitor.
+ *   unknown      — serving identity undeterminable (Pages unreadable + no CNAME file).
  *   not-cutover  — no serving domain yet, nothing to monitor.
  *   running      — a run is queued/in progress right now.
  *   stale-monitor — workflow not active (disabled or missing), OR latest run older than 48h.
@@ -150,6 +156,7 @@ export function computeSiteState({
   run,
   workflowState,
   pagesEnabled,
+  identityUnknown = false,
   now = new Date(),
 } = {}) {
   // GitHub Pages disabled — the site is not served, so nothing to monitor.
@@ -158,7 +165,16 @@ export function computeSiteState({
   // transient Pages-read failure never mislabels a live site as not-deployed.
   if (pagesEnabled === false) return { state: 'not-deployed', staleReason: null }
 
-  if (!domain) return { state: 'not-cutover', staleReason: null }
+  if (!domain) {
+    // No serving domain. Distinguish "genuinely not cut over" (we *could* read
+    // the serving identity — it just has no custom domain) from "we couldn't
+    // determine it at all" (Pages unreadable AND no committed CNAME to fall
+    // back to). The latter can happen on a build-emitted-CNAME repo during a
+    // transient Pages-read/rate-limit failure; reporting `unknown` there is
+    // more honest than claiming a cut-over site isn't cut over.
+    if (identityUnknown) return { state: 'unknown', staleReason: null }
+    return { state: 'not-cutover', staleReason: null }
+  }
   if (run && (run.status === 'in_progress' || run.status === 'queued'))
     return { state: 'running', staleReason: null }
 
@@ -225,6 +241,11 @@ async function siteStatus(repo, now = new Date()) {
   // than blanking the domain. When Pages is disabled (enabled === false) there
   // is no serving domain and computeSiteState resolves it to `not-deployed`.
   const domain = pages.enabled === true ? pages.cname : pages.enabled === null ? cnameFile : null
+  // Serving identity is undeterminable only when the Pages config was unreadable
+  // (not a definitive 404) AND there is no committed CNAME to fall back to — then
+  // a null domain means "we don't know", so computeSiteState reports 'unknown'
+  // rather than mislabelling a (possibly cut-over) site as 'not-cutover'.
+  const identityUnknown = pages.enabled === null && !cnameFile
   const issue = Array.isArray(issues) && issues[0] ? issues[0] : null
 
   // workflowState: null when the workflows list couldn't be read (unknown —
@@ -262,6 +283,7 @@ async function siteStatus(repo, now = new Date()) {
     run,
     workflowState,
     pagesEnabled: pages.enabled,
+    identityUnknown,
     now,
   })
 

--- a/src/app/fleet-status/page.tsx
+++ b/src/app/fleet-status/page.tsx
@@ -93,7 +93,7 @@ function SiteTile({ site }: { site: FleetSmokeSite }) {
           Monitoring stopped — {site.staleReason}.
         </div>
       )}
-      {site.cnameFile && site.cnameFile !== site.domain && (
+      {site.state !== 'not-deployed' && site.cnameFile && site.cnameFile !== site.domain && (
         <div className="text-xs text-amber-800 mb-2">
           CNAME file <span className="font-mono">{site.cnameFile}</span> differs from the served
           domain{site.domain ? '' : ' (Pages serves the default URL)'}.

--- a/src/app/fleet-status/page.tsx
+++ b/src/app/fleet-status/page.tsx
@@ -61,11 +61,17 @@ const STATE_STYLES: Record<
     card: 'bg-gray-50 border-gray-200',
     order: 5,
   },
+  'not-deployed': {
+    label: 'Not deployed',
+    dot: 'bg-gray-400',
+    card: 'bg-gray-50 border-gray-200',
+    order: 6,
+  },
   unknown: {
     label: 'Unknown',
     dot: 'bg-gray-300',
     card: 'bg-gray-50 border-gray-200',
-    order: 6,
+    order: 7,
   },
 }
 
@@ -85,6 +91,12 @@ function SiteTile({ site }: { site: FleetSmokeSite }) {
       {site.state === 'stale-monitor' && site.staleReason && (
         <div className="text-xs text-purple-800 font-medium mb-2">
           Monitoring stopped — {site.staleReason}.
+        </div>
+      )}
+      {site.cnameFile && site.cnameFile !== site.domain && (
+        <div className="text-xs text-amber-800 mb-2">
+          CNAME file <span className="font-mono">{site.cnameFile}</span> differs from the served
+          domain{site.domain ? '' : ' (Pages serves the default URL)'}.
         </div>
       )}
       <div className="flex flex-wrap gap-x-3 gap-y-1 text-xs">

--- a/src/app/fleet-status/page.tsx
+++ b/src/app/fleet-status/page.tsx
@@ -95,8 +95,8 @@ function SiteTile({ site }: { site: FleetSmokeSite }) {
       )}
       {site.state !== 'not-deployed' && site.cnameFile && site.cnameFile !== site.domain && (
         <div className="text-xs text-amber-800 mb-2">
-          CNAME file <span className="font-mono">{site.cnameFile}</span> differs from the served
-          domain{site.domain ? '' : ' (Pages serves the default URL)'}.
+          CNAME file <span className="font-mono break-all">{site.cnameFile}</span> differs from the
+          served domain{site.domain ? '' : ' (Pages serves the default URL)'}.
         </div>
       )}
       <div className="flex flex-wrap gap-x-3 gap-y-1 text-xs">

--- a/src/lib/dashboardData.ts
+++ b/src/lib/dashboardData.ts
@@ -25,11 +25,23 @@ export interface CiStatusData {
 }
 
 export type FleetSmokeState =
-  'passing' | 'failing' | 'running' | 'stale-monitor' | 'not-cutover' | 'pending' | 'unknown'
+  | 'passing'
+  | 'failing'
+  | 'running'
+  | 'stale-monitor'
+  | 'not-cutover'
+  | 'not-deployed'
+  | 'pending'
+  | 'unknown'
 
 export interface FleetSmokeSite {
   repo: string
+  // Serving identity resolved from the Pages API `cname` (#742) — the domain the
+  // site is actually served on; null when served on the default *.github.io URL.
   domain: string | null
+  // The committed public/CNAME file value (the build's claim of a domain), kept
+  // as a secondary field so drift from `domain` stays visible; null when absent.
+  cnameFile?: string | null
   state: FleetSmokeState
   smoke: {
     status: string

--- a/src/lib/dashboardData.ts
+++ b/src/lib/dashboardData.ts
@@ -36,8 +36,11 @@ export type FleetSmokeState =
 
 export interface FleetSmokeSite {
   repo: string
-  // Serving identity resolved from the Pages API `cname` (#742) — the domain the
-  // site is actually served on; null when served on the default *.github.io URL.
+  // Serving identity resolved from the Pages API `cname` (#742) — the custom
+  // domain the site is actually served on. null when there is no custom domain:
+  // Pages serves the default *.github.io URL (`not-cutover`), Pages is disabled
+  // (`not-deployed`), or the Pages config couldn't be read and the generator
+  // fell back to a missing/absent CNAME file.
   domain: string | null
   // The committed public/CNAME file value (the build's claim of a domain), kept
   // as a secondary field so drift from `domain` stays visible; null when absent.


### PR DESCRIPTION
## Why

The fleet-smoke-status generator (`scripts/generate-fleet-smoke-status.mjs`, feeds ffcadmin.org/fleet-status) derived each site's `domain` from the repo's committed `public/CNAME` file. But that file is only the build's **claim** of a domain — **GitHub Pages config is the serving truth**, and the two disagree in 14 fleet repos (established on FreeForCharity/FFC-Cloudflare-Automation#740). So the page could report a site under a domain it isn't actually served on, and build-emitted-CNAME repos (which no longer commit a `public/CNAME`) wrongly showed as "not cut over".

Implements FreeForCharity/FFC-Cloudflare-Automation#742. (Note: the issue said "hub side" — the generator actually lives here in ffcadmin.)

## What changed

- **`scripts/generate-fleet-smoke-status.mjs`**
  - New `pagesInfo(repo)` helper: one bounded `GET /repos/{org}/{repo}/pages` per repo (the same public Pages-metadata read smoke engine v3 does in `post-deploy-smoke.yml`).
  - Primary `domain` now comes from the Pages `cname` (null → served on the default `*.github.io` URL, i.e. not yet cut over).
  - The committed CNAME file is preserved as a secondary `cnameFile` field so drift from the serving truth stays visible instead of being silently masked.
  - Pages disabled (404) → new **`not-deployed`** state, mirroring the engine's neutral skip.
  - An unreadable Pages config (any non-404 error) falls back to the committed CNAME file, so a transient/permission failure degrades to the pre-change behaviour rather than blanking or mislabelling a live site.
- **`computeSiteState`**: accepts `pagesEnabled`; only a definitive `false` yields `not-deployed` (`null`/`undefined` fall through). Existing callers/tests unaffected.
- **`src/lib/dashboardData.ts`**: `not-deployed` added to `FleetSmokeState`; `cnameFile` added to `FleetSmokeSite`.
- **`src/app/fleet-status/page.tsx`**: `not-deployed` tile style + summary chip; a per-tile drift note when the CNAME file differs from the served domain.
- **Unit tests**: `not-deployed` cases + `pagesEnabled` precedence + `EMPTY_SUMMARY` key.

## Acceptance criteria (from #742)

- [x] Snapshot rows show the Pages-config domain as primary + the differing `cnameFile` when they drift (the 14 #740 drift repos).
- [x] No REST calls in unbounded loops — exactly one Pages call per repo, bounded by the repo list.
- [x] Pages disabled → `not-deployed` (neutral skip).

## Verification

- `pnpm lint`, `pnpm type-check` clean.
- `pnpm build` + `pnpm test` → **1130/1130 passing** (24/24 in the fleet-smoke-status suite, including the new cases).
- Generator no-token graceful path exercised (`No GITHUB_TOKEN; leaving … unchanged`, exit 0).
- Full drift-diff of the committed snapshot will appear in the next daily refresh PR (`data/fleet-smoke-status`); only the drift repos' identities + the new `cnameFile` change.

Refs #742

---
_Generated by [Claude Code](https://claude.ai/code/session_01GS43jtKzpU154zkxZZNLx9)_