### PR TITLE
ci: add ungated daily claim-sweep for ffcadmin issues

### DIFF
--- a/.github/workflows/claim-sweep.yml
+++ b/.github/workflows/claim-sweep.yml
@@ -1,0 +1,136 @@
+name: Claim Sweep
+run-name: 'Claim sweep: ${{ github.event_name }}'
+
+# Releases stale work-claims on THIS repo's issues, mirroring the AGENTS.md
+# work-claiming protocol (available = `is:open -label:claimed`). An issue
+# labeled `claimed` with no open linked PR and no activity for 48h is freed:
+# the label is removed and a 🔓 comment posted.
+#
+# Why this lives here and not in the hub's 737 Claim Sync sweep: cross-repo
+# mutation of ffcadmin requires the CBM_TOKEN PAT, which exists only inside the
+# hub's gated `github-prod` environment and is therefore unusable from an
+# ungated daily job. This workflow runs in-repo with the ambient GITHUB_TOKEN
+# (issues: write), so it needs no PAT and no environment gate. See
+# FFC-Cloudflare-Automation#786.
+#
+# Writes issues/labels only; no external API; ungated. The decision helpers are
+# inlined below (ffcadmin has no workflow-logic test harness); they are a copy
+# of the hub's scripts/claim-sync-lib.js logic kept intentionally small.
+
+on:
+  schedule:
+    - cron: '53 5 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Report only; do not remove labels or comment'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  # Single shared group so a scheduled and a dispatched sweep serialize and can
+  # never double-comment / double-remove on the same issue.
+  group: claim-sweep
+  cancel-in-progress: false
+
+jobs:
+  sweep:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
+    steps:
+      - name: Release expired claims
+        uses: actions/github-script@v9
+        env:
+          DRY_RUN:
+            ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run || 'false'
+            }}
+        with:
+          script: |
+            const CLAIM_LABEL = 'claimed';
+            // A hand-labeled claim with no open linked PR is released after this
+            // much inactivity (mirrors the 48h AGENTS.md expiry).
+            const EXPIRY_MS = 48 * 60 * 60 * 1000;
+            // GitHub closing keywords plus bare ref/refs (which do not auto-close
+            // but still signal a claim). Requires a separator so "closes#3" and
+            // "prefix" never false-match.
+            const LINK_RE = /\b(close[sd]?|fix(?:e[sd])?|resolve[sd]?|refs?)\b[:\s]+#(\d+)/gi;
+
+            // De-duplicated issue numbers referenced anywhere in a PR body.
+            const extractLinkedIssues = (body) => {
+              const out = [];
+              if (!body) return out;
+              LINK_RE.lastIndex = 0;
+              let m;
+              while ((m = LINK_RE.exec(body)) !== null) {
+                const n = Number(m[2]);
+                if (Number.isInteger(n) && n > 0 && !out.includes(n)) out.push(n);
+              }
+              return out;
+            };
+
+            // Released only when there is NO open linked PR AND the issue has been
+            // idle for >= thresholdMs. An open linked PR always keeps the claim.
+            const decideRelease = ({ hasOpenLinkedPR, lastActivityMs, nowMs, thresholdMs }) => {
+              if (hasOpenLinkedPR) return false;
+              if (!Number.isFinite(lastActivityMs) || !Number.isFinite(nowMs)) return false;
+              return nowMs - lastActivityMs >= thresholdMs;
+            };
+
+            const dryRun = String(process.env.DRY_RUN) === 'true';
+            const now = Date.now();
+            const { owner, repo } = context.repo;
+
+            // Bounded pager: cap pages so the daily sweep can't spike the shared
+            // REST budget. `labels=claimed` already keeps the issue set tiny.
+            const listOpen = async (method, params, maxPages = 5) => {
+              const out = [];
+              for (let page = 1; page <= maxPages; page++) {
+                const { data } = await method({ ...params, per_page: 100, page });
+                out.push(...data);
+                if (data.length < 100) break;
+              }
+              return out;
+            };
+
+            const claimed = await listOpen(github.rest.issues.listForRepo, {
+              owner, repo, state: 'open', labels: CLAIM_LABEL,
+            });
+            const issues = claimed.filter((i) => !i.pull_request);
+
+            const released = [];
+            if (issues.length) {
+              const openPrs = await listOpen(github.rest.pulls.list, {
+                owner, repo, state: 'open',
+              });
+              for (const issue of issues) {
+                const hasOpenLinkedPR = openPrs.some(
+                  (p) => extractLinkedIssues(p.body || '').includes(issue.number),
+                );
+                const lastActivityMs = new Date(issue.updated_at).getTime();
+                if (!decideRelease({ hasOpenLinkedPR, lastActivityMs, nowMs: now, thresholdMs: EXPIRY_MS })) {
+                  continue;
+                }
+                released.push(issue.number);
+                if (dryRun) continue;
+                await github.rest.issues.removeLabel({
+                  owner, repo, issue_number: issue.number, name: CLAIM_LABEL,
+                }).catch(() => {});
+                await github.rest.issues.createComment({
+                  owner, repo, issue_number: issue.number,
+                  body: `🔓 Claim expired — no open linked PR and no activity for 48h. Label \`${CLAIM_LABEL}\` removed; available again (\`is:open -label:claimed\`).`,
+                });
+              }
+            }
+
+            core.summary
+              .addHeading(`Claim sweep — ${released.length} expired claim(s)${dryRun ? ' (dry-run)' : ''}`)
+              .addRaw(released.length ? released.map((n) => `- #${n}`).join('\n') : 'No expired claims. All claims active.')
+              .write();
+            console.log(`${dryRun ? 'Would release' : 'Released'} ${released.length} expired claim(s).`);

--- a/.github/workflows/claim-sweep.yml
+++ b/.github/workflows/claim-sweep.yml
@@ -48,9 +48,9 @@ jobs:
       - name: Release expired claims
         uses: actions/github-script@v9
         env:
-          DRY_RUN:
-            ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run || 'false'
-            }}
+          # Folded scalar (`>-`) so this is unambiguously a string, not a mapping.
+          DRY_RUN: >-
+            ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run || 'false' }}
         with:
           script: |
             const CLAIM_LABEL = 'claimed';
@@ -117,15 +117,30 @@ jobs:
                 if (!decideRelease({ hasOpenLinkedPR, lastActivityMs, nowMs: now, thresholdMs: EXPIRY_MS })) {
                   continue;
                 }
-                released.push(issue.number);
-                if (dryRun) continue;
-                await github.rest.issues.removeLabel({
-                  owner, repo, issue_number: issue.number, name: CLAIM_LABEL,
-                }).catch(() => {});
+                if (dryRun) {
+                  released.push(issue.number);
+                  continue;
+                }
+                try {
+                  await github.rest.issues.removeLabel({
+                    owner, repo, issue_number: issue.number, name: CLAIM_LABEL,
+                  });
+                } catch (e) {
+                  // 404 = the label was already removed (raced with another
+                  // actor): skip quietly — do not post a misleading "removed"
+                  // comment. Any other status (permission, rate-limit, 5xx) is a
+                  // real failure that must surface rather than be masked.
+                  if (e.status === 404) {
+                    core.info(`#${issue.number}: '${CLAIM_LABEL}' already removed; skipping.`);
+                    continue;
+                  }
+                  throw e;
+                }
                 await github.rest.issues.createComment({
                   owner, repo, issue_number: issue.number,
                   body: `🔓 Claim expired — no open linked PR and no activity for 48h. Label \`${CLAIM_LABEL}\` removed; available again (\`is:open -label:claimed\`).`,
                 });
+                released.push(issue.number);
               }
             }
 

--- a/.github/workflows/claim-sweep.yml
+++ b/.github/workflows/claim-sweep.yml
@@ -1,8 +1,9 @@
 name: Claim Sweep
 run-name: 'Claim sweep: ${{ github.event_name }}'
 
-# Releases stale work-claims on THIS repo's issues, mirroring the AGENTS.md
-# work-claiming protocol (available = `is:open -label:claimed`). An issue
+# Releases stale work-claims on THIS repo's issues, mirroring the FFC hub's
+# work-claiming protocol (defined in FreeForCharity/FFC-Cloudflare-Automation
+# AGENTS.md, "Work claiming"; available = `is:open -label:claimed`). An issue
 # labeled `claimed` with no open linked PR and no activity for 48h is freed:
 # the label is removed and a 🔓 comment posted.
 #
@@ -55,7 +56,8 @@ jobs:
           script: |
             const CLAIM_LABEL = 'claimed';
             // A hand-labeled claim with no open linked PR is released after this
-            // much inactivity (mirrors the 48h AGENTS.md expiry).
+            // much inactivity (mirrors the 48h expiry in the hub's work-claiming
+            // protocol — FFC-Cloudflare-Automation AGENTS.md).
             const EXPIRY_MS = 48 * 60 * 60 * 1000;
             // GitHub closing keywords plus bare ref/refs (which do not auto-close
             // but still signal a claim). Requires a separator so "closes#3" and

--- a/.github/workflows/claim-sweep.yml
+++ b/.github/workflows/claim-sweep.yml
@@ -88,31 +88,42 @@ jobs:
             const { owner, repo } = context.repo;
 
             // Bounded pager: cap pages so the daily sweep can't spike the shared
-            // REST budget. `labels=claimed` already keeps the issue set tiny.
-            const listOpen = async (method, params, maxPages = 5) => {
-              const out = [];
+            // REST budget (`labels=claimed` already keeps the issue set tiny).
+            // Returns { items, truncated } so a caller can tell a genuine end of
+            // list from a page-cap cutoff and fail safe on the latter.
+            const MAX_PAGES = 5;
+            const listOpen = async (method, params, maxPages = MAX_PAGES) => {
+              const items = [];
               for (let page = 1; page <= maxPages; page++) {
                 const { data } = await method({ ...params, per_page: 100, page });
-                out.push(...data);
-                if (data.length < 100) break;
+                items.push(...data);
+                if (data.length < 100) return { items, truncated: false };
               }
-              return out;
+              return { items, truncated: true };
             };
 
             const claimed = await listOpen(github.rest.issues.listForRepo, {
               owner, repo, state: 'open', labels: CLAIM_LABEL,
             });
-            const issues = claimed.filter((i) => !i.pull_request);
+            const issues = claimed.items.filter((i) => !i.pull_request);
 
             const released = [];
             if (issues.length) {
-              const openPrs = await listOpen(github.rest.pulls.list, {
+              const prs = await listOpen(github.rest.pulls.list, {
                 owner, repo, state: 'open',
               });
-              for (const issue of issues) {
-                const hasOpenLinkedPR = openPrs.some(
-                  (p) => extractLinkedIssues(p.body || '').includes(issue.number),
+              // Fail-safe: if the open-PR list was truncated at the page cap we
+              // can't be sure an issue has no linked PR, so keep every claim this
+              // run rather than risk releasing an active one (>500 open PRs).
+              if (prs.truncated) {
+                core.warning(
+                  `Open-PR list hit the ${MAX_PAGES}-page cap (>500 open PRs); keeping all claims this run to avoid a false release.`,
                 );
+              }
+              for (const issue of issues) {
+                const hasOpenLinkedPR =
+                  prs.truncated ||
+                  prs.items.some((p) => extractLinkedIssues(p.body || '').includes(issue.number));
                 const lastActivityMs = new Date(issue.updated_at).getTime();
                 if (!decideRelease({ hasOpenLinkedPR, lastActivityMs, nowMs: now, thresholdMs: EXPIRY_MS })) {
                   continue;

--- a/.github/workflows/claim-sweep.yml
+++ b/.github/workflows/claim-sweep.yml
@@ -106,6 +106,14 @@ jobs:
               owner, repo, state: 'open', labels: CLAIM_LABEL,
             });
             const issues = claimed.items.filter((i) => !i.pull_request);
+            // Surface a truncated claimed-issue listing: the sweep would silently
+            // skip the overflow (safe — those claims simply stay put), but a
+            // warning keeps the daily run debuggable if it ever happens.
+            if (claimed.truncated) {
+              core.warning(
+                `Claimed-issue list hit the ${MAX_PAGES}-page cap; some expired claims may be unprocessed this run.`,
+              );
+            }
 
             const released = [];
             if (issues.length) {
@@ -155,7 +163,7 @@ jobs:
               }
             }
 
-            core.summary
+            await core.summary
               .addHeading(`Claim sweep — ${released.length} expired claim(s)${dryRun ? ' (dry-run)' : ''}`)
               .addRaw(released.length ? released.map((n) => `- #${n}`).join('\n') : 'No expired claims. All claims active.')
               .write();


### PR DESCRIPTION
## What & why

Adds `.github/workflows/claim-sweep.yml` — an **ungated, in-repo** daily sweep that releases stale work-claims on this repo's issues, mirroring the AGENTS.md work-claiming protocol (available = `is:open -label:claimed`).

The hub's `737-claim-sync.yml` sweep **can no longer cover ffcadmin**: after hub PR #785 switched that job to the ambient `GITHUB_TOKEN`, it can only mutate the hub repo. Cross-repo mutation of ffcadmin requires `CBM_TOKEN`, which exists only inside the hub's gated `github-prod` environment and is therefore unusable from an ungated daily job. This workflow closes that gap by running **in ffcadmin** with the ambient `GITHUB_TOKEN` (`issues: write`) — no PAT, no environment gate.

Refs FreeForCharity/FFC-Cloudflare-Automation#786

## Behavior

- **Triggers:** `schedule` (daily `53 5 * * *`, off-peak) + `workflow_dispatch` with a `dry_run` boolean input (default `false`).
- **Job:** ungated, `permissions: contents: read, issues: write, pull-requests: read`, `actions/github-script@v9` with the **ambient token** (no `github-token` input passed).
- **Release rule:** an open issue labeled `claimed` with **no open linked PR** (Closes/Fixes/Resolves/Refs #N parsed from PR bodies) **and no activity for 48h** → remove the `claimed` label and post a 🔓 comment. An open linked PR or activity < 48h keeps the claim.
- Bounded pagination (max 5 pages); `labels=claimed` keeps the issue set tiny. Single shared `concurrency` group so a scheduled and a dispatched sweep serialize.
- Decision helpers (`extractLinkedIssues`, `decideRelease`, `CLAIM_LABEL`, `EXPIRY_MS`) are **inlined** — ffcadmin has no workflow-logic test harness, so a small self-contained copy of the hub's `scripts/claim-sync-lib.js` logic keeps it dependency-free.

## Validation

- `npx prettier --check` on the workflow: clean.
- YAML parses; embedded script passes `node --check`.
- Ran the extracted script against mocked `github`/`context`/`core` fixtures:
  - stale (50h) unlinked claim → released + commented;
  - fresh (10h) claim → kept;
  - stale claim with a `Closes #N` / `Refs #N` open PR → kept;
  - `dry_run=true` → reports, mutates nothing;
  - no claimed issues → no-op (no PR fetch).
- Confirmed the `claimed` label already exists in this repo.

## Post-merge verification (per issue #786)

- Dispatch with `dry_run=true`, read the job summary (expect a no-op / active-claims report, no token error).
- Scheduled run completes green with zero mutations when no claims are expired.


---
_Generated by [Claude Code](https://claude.ai/code/session_01X5DM219ESNszhU6dwpZp7H)_