### PR TITLE
feat(ci): add scheduled Security Audit + patch postcss advisory

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,0 +1,54 @@
+name: Security Audit
+
+# Runs `pnpm audit` against production dependencies on a daily cadence and on
+# pull requests that touch package files. Fails on `high` or `critical` so the
+# site is never deployed with known-exploitable libraries.
+#
+# Dependabot still handles the upgrades; this workflow makes sure we notice if
+# a published advisory lands between Dependabot runs.
+#
+# Ported from FFC-IN-FFC_Single_Page_Template's security-audit.yml (adapted to
+# pnpm). The cron minute is deliberately distinct from the other FFC repos'
+# audits so the fleet's scheduled runs do not stack.
+
+on:
+  schedule:
+    - cron: '47 6 * * *' # daily, 06:47 UTC
+  pull_request:
+    branches: ['main']
+    paths:
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  audit:
+    name: pnpm audit (production)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 9.0.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'pnpm'
+
+      - name: Install (no scripts)
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Audit high-severity production deps
+        run: pnpm run audit:high

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,8 +1,11 @@
 name: Security Audit
 
 # Runs `pnpm audit` against production dependencies on a daily cadence and on
-# pull requests that touch package files. Fails on `high` or `critical` so the
-# site is never deployed with known-exploitable libraries.
+# pull requests that touch package files. Fails on `high` or `critical`, so a
+# dependency change that introduces a known-exploitable library is caught in
+# review, and an advisory published after merge is caught by the next daily
+# run. This is a detection check, NOT a deploy gate — it does not run on every
+# push, so a red audit does not by itself block a deploy.
 #
 # Dependabot still handles the upgrades; this workflow makes sure we notice if
 # a published advisory lands between Dependabot runs.

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "data:roadmap": "tsx scripts/generate-roadmap-data.ts",
     "analyze": "ANALYZE=true pnpm build",
     "test:e2e": "playwright test",
+    "audit:high": "pnpm audit --prod --audit-level high",
     "prepare": "husky"
   },
   "dependencies": {
@@ -54,7 +55,7 @@
     "js-yaml": "^5.2.1",
     "linkinator": "^7.6.1",
     "lint-staged": "^17.0.8",
-    "postcss": "^8.5.16",
+    "postcss": "^8.5.23",
     "prettier": "^3.9.4",
     "serve": "^14.2.6",
     "tailwindcss": "^4.3.1",
@@ -67,7 +68,7 @@
   "packageManager": "pnpm@9.0.0",
   "pnpm": {
     "overrides": {
-      "postcss@<8.5.10": ">=8.5.10",
+      "postcss@<8.5.18": ">=8.5.18",
       "eslint-plugin-react-hooks": "7.0.1",
       "undici@>=7.0.0 <7.28.0": ">=7.28.0 <8.0.0",
       "sharp": "^0.35.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  postcss@<8.5.10: '>=8.5.10'
+  postcss@<8.5.18: '>=8.5.18'
   eslint-plugin-react-hooks: 7.0.1
   undici@>=7.0.0 <7.28.0: '>=7.28.0 <8.0.0'
   sharp: ^0.35.3
@@ -74,7 +74,7 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       autoprefixer:
         specifier: ^10.5.2
-        version: 10.5.2(postcss@8.5.16)
+        version: 10.5.2(postcss@8.5.23)
       eslint:
         specifier: ^9.39.2
         version: 9.39.4(jiti@2.7.0)
@@ -109,8 +109,8 @@ importers:
         specifier: ^17.0.8
         version: 17.0.8
       postcss:
-        specifier: ^8.5.16
-        version: 8.5.16
+        specifier: ^8.5.23
+        version: 8.5.23
       prettier:
         specifier: ^3.9.4
         version: 3.9.4
@@ -1533,7 +1533,7 @@ packages:
     engines: {node: ^10 || ^12 || >=14}
     hasBin: true
     peerDependencies:
-      postcss: '>=8.5.10'
+      postcss: '>=8.5.18'
 
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
@@ -3120,8 +3120,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.12:
-    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -3342,8 +3342,8 @@ packages:
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
-  postcss@8.5.16:
-    resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
+  postcss@8.5.23:
+    resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -5034,7 +5034,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.3.2
       '@tailwindcss/oxide': 4.3.2
-      postcss: 8.5.16
+      postcss: 8.5.23
       tailwindcss: 4.3.2
 
   '@testing-library/dom@10.4.1':
@@ -5462,13 +5462,13 @@ snapshots:
 
   async-function@1.0.0: {}
 
-  autoprefixer@10.5.2(postcss@8.5.16):
+  autoprefixer@10.5.2(postcss@8.5.23):
     dependencies:
       browserslist: 4.28.4
       caniuse-lite: 1.0.30001799
       fraction.js: 5.3.4
       picocolors: 1.1.1
-      postcss: 8.5.16
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
   available-typed-arrays@1.0.7:
@@ -7375,7 +7375,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.12: {}
+  nanoid@3.3.16: {}
 
   napi-postinstall@0.3.4: {}
 
@@ -7389,7 +7389,7 @@ snapshots:
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.40
       caniuse-lite: 1.0.30001799
-      postcss: 8.5.16
+      postcss: 8.5.23
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.7)
@@ -7584,9 +7584,9 @@ snapshots:
 
   postcss-value-parser@4.2.0: {}
 
-  postcss@8.5.16:
+  postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.12
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 


### PR DESCRIPTION
Implements scope item **2** of FreeForCharity/FFC-Cloudflare-Automation#830 — ffcadmin.org had **no scheduled dependency Security Audit**; only the two fleet templates did.

Refs FreeForCharity/FFC-Cloudflare-Automation#830, FreeForCharity/FFC-Cloudflare-Automation#822

## The blind spot proved itself immediately

#830 argues the missing audit is hiding real vulnerabilities. Adding it here confirmed that on the first run: `pnpm audit --prod --audit-level high` against current `main` reports **1 high** —

> **GHSA-r28c-9q8g-f849** — PostCSS path traversal via previous-source-map auto-loading (`sourceMappingURL`) → arbitrary `.map` file disclosure. Affects `postcss <=8.5.17`, patched in **8.5.18**.

Nothing in this repo's CI would ever have reported it. So this PR ships the **fix together with the check**, which is also what makes the #830 acceptance criterion ("a `workflow_dispatch` run of Security Audit succeeds") satisfiable.

## What changed

**`.github/workflows/security-audit.yml`** (new) — ported from [SPT's `security-audit.yml`](https://github.com/FreeForCharity/FFC-IN-FFC_Single_Page_Template/blob/main/.github/workflows/security-audit.yml), adapted to pnpm:

- daily `schedule` at **`47 6 * * *`** — deliberately distinct from SPT/FOT's `17 6` *and* from this repo's existing `45 6` (`update-fleet-smoke-status.yml`), per the issue's stagger requirement
- `pull_request` on `main` filtered to `package.json` / **`pnpm-lock.yaml`** (pnpm, not npm)
- `workflow_dispatch`, `permissions: contents: read`, `concurrency` group
- install via `pnpm install --frozen-lockfile --ignore-scripts`

**`package.json`**

- new **`audit:high`** script → `pnpm audit --prod --audit-level high`, the workflow's single entry point so the check is reproducible locally
- `postcss` `^8.5.16` → **`^8.5.23`**
- `pnpm.overrides` floor raised: `postcss@<8.5.10: >=8.5.10` → **`postcss@<8.5.18: >=8.5.18`**, so Next's transitive copy is patched too, not just the direct dev dep

**`pnpm-lock.yaml`** — regenerated. Drift limited to the postcss tree (8.5.16 → 8.5.23) and postcss's own `nanoid` dep (3.3.12 → 3.3.16). No unrelated churn.

## Verification (self-checked — exit code, not the version number)

| Check | Result |
| --- | --- |
| `pnpm run audit:high` | **1 high → 0, exit 0** ✅ |
| `pnpm run format:check` | ✅ |
| `pnpm run lint` | ✅ |
| `pnpm run type-check` | ✅ |
| `pnpm run build` | ✅ static export |
| `pnpm test` | ✅ 1154/1154, 67 suites |
| `actionlint` on the new workflow | ✅ clean |

`test:e2e` not run in this sandbox (Playwright) — CI covers it, consistent with the merged #822 portions.

## Fleet heads-up (not fixed here)

This advisory is **not** ffcadmin-specific. Checked all four in-scope repos:

| Repo | postcss resolves | Production audit |
| --- | --- | --- |
| FFC-IN-ffcadmin.org | 8.5.16 → **8.5.23** | fixed by this PR ✅ |
| FFC-IN-FFC_Single_Page_Template | 8.5.22 | already clean ✅ |
| **FFC-IN-Footer_Only_Template** | **8.5.16** | **2 high — red** ⚠️ |
| **FFC-EX-canary** | **8.5.15** | **2 high — red** ⚠️ |

FOT and canary both already *have* the scheduled audit, so their next 06:17 UTC run will go red on its own. Flagged on #830 for routing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XnKrhVdMf6z4n3SkLhTp5A)_