### PR TITLE
feat(security): publish RFC 9116 security.txt at both paths

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -154,10 +154,31 @@ jobs:
           fi
           echo "✓ .nojekyll file found in ./out directory"
 
+      - name: Verify security.txt exists at both paths
+        run: |
+          for f in ./out/.well-known/security.txt ./out/security.txt; do
+            if [ ! -f "$f" ]; then
+              echo "Error: $f not found in build output"
+              exit 1
+            fi
+            echo "✓ $f found"
+          done
+          # The two copies must not drift apart (payload below the comments).
+          if ! diff <(grep -v '^#' ./out/.well-known/security.txt) \
+                    <(grep -v '^#' ./out/security.txt) > /dev/null; then
+            echo "Error: security.txt payloads differ between /.well-known/ and root"
+            exit 1
+          fi
+          echo "✓ security.txt payloads match"
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v5
         with:
           path: ./out
+          # Without this, upload-pages-artifact drops dot-entries such as
+          # .well-known/ and .nojekyll, so /.well-known/security.txt would
+          # silently never reach the deployed site. Refs #788.
+          include-hidden-files: true
 
   deploy:
     environment:

--- a/public/.well-known/security.txt
+++ b/public/.well-known/security.txt
@@ -1,0 +1,22 @@
+# RFC 9116 security.txt for ffcadmin.org.
+#
+# This file MUST stay byte-for-byte identical to public/security.txt below
+# the header block.
+#
+# Why two copies: GitHub Pages (this site's host) does not reliably serve
+# files inside dot-prefixed directories like `.well-known/`. The
+# actions/upload-pages-artifact step additionally drops dot-entries unless
+# `include-hidden-files: true` is set — see .github/workflows/deploy.yml.
+# The /security.txt root copy is the fallback so scanners still find a
+# reachable file if the well-known path is ever dropped again. RFC 9116
+# §2.5.2 allows multiple Canonical lines to advertise both URLs.
+#
+# Expires MUST be a future RFC 3339 datetime. Bump it on a regular cadence.
+
+Contact: mailto:clarkemoyer@freeforcharity.org
+Expires: 2027-12-31T00:00:00.000Z
+Preferred-Languages: en
+Canonical: https://ffcadmin.org/.well-known/security.txt
+Canonical: https://ffcadmin.org/security.txt
+Policy: https://ffcadmin.org/vulnerability-disclosure-policy/
+Acknowledgments: https://ffcadmin.org/security-acknowledgements/

--- a/public/security.txt
+++ b/public/security.txt
@@ -1,0 +1,22 @@
+# RFC 9116 security.txt — root-path copy.
+#
+# This file MUST stay byte-for-byte identical to
+# public/.well-known/security.txt below the header block.
+#
+# Why two copies: GitHub Pages (this site's host) does not reliably serve
+# files inside dot-prefixed directories like `.well-known/`. The
+# actions/upload-pages-artifact step additionally drops dot-entries unless
+# `include-hidden-files: true` is set — see .github/workflows/deploy.yml.
+# This root copy is the fallback so scanners still find a reachable file if
+# the well-known path is ever dropped again. RFC 9116 §2.5.2 allows multiple
+# Canonical lines to advertise both URLs.
+#
+# Expires MUST be a future RFC 3339 datetime. Bump it on a regular cadence.
+
+Contact: mailto:clarkemoyer@freeforcharity.org
+Expires: 2027-12-31T00:00:00.000Z
+Preferred-Languages: en
+Canonical: https://ffcadmin.org/.well-known/security.txt
+Canonical: https://ffcadmin.org/security.txt
+Policy: https://ffcadmin.org/vulnerability-disclosure-policy/
+Acknowledgments: https://ffcadmin.org/security-acknowledgements/


### PR DESCRIPTION
## Why

ffcadmin.org ships a `/vulnerability-disclosure-policy/` page and a `/security-acknowledgements/` page, but served **no security.txt in any form**. Verified live before this change:

```
https://ffcadmin.org/.well-known/security.txt  -> 404
https://ffcadmin.org/security.txt              -> 404
```

The site publishes a disclosure policy that security researchers cannot discover via the RFC 9116 standard path.

## What changed

**1. Dual-published security.txt** — matching the pattern already proven in `FFC-IN-FFC_Single_Page_Template` and `FFC-IN-Footer_Only_Template`:

- `public/.well-known/security.txt` — RFC 9116 canonical path
- `public/security.txt` — root fallback (GitHub Pages has historically dropped dot-directories)

RFC 9116 §2.5.2 permits multiple `Canonical` lines, so both URLs are advertised. Payload:

```
Contact: mailto:clarkemoyer@freeforcharity.org
Expires: 2027-12-31T00:00:00.000Z
Preferred-Languages: en
Canonical: https://ffcadmin.org/.well-known/security.txt
Canonical: https://ffcadmin.org/security.txt
Policy: https://ffcadmin.org/vulnerability-disclosure-policy/
Acknowledgments: https://ffcadmin.org/security-acknowledgements/
```

`Contact` is taken from the site's own vulnerability-disclosure-policy page. Policy/Acknowledgments URLs were verified to return **200** live (trailing slashes match this repo's `trailingSlash: true`).

**2. `include-hidden-files: true` on the Pages upload — Refs #788.**

`actions/upload-pages-artifact@v5` **drops dot-entries** unless this flag is set. Without it, `.well-known/` would silently never reach the deployed site and the canonical path would have stayed 404 while the PR looked like it landed.

**3. Pre-upload guard.** The deploy now fails if either copy is missing from the build output, or if the two payloads drift apart.

## Verification

Local `pnpm run build`, then inspecting `out/`:

```
-rw-r--r-- 1053 out/.well-known/security.txt
-rw-r--r-- 1054 out/security.txt
PAYLOADS MATCH
```

| Check | Result |
|---|---|
| `pnpm run build` | pass — both files in `out/` |
| `pnpm run lint` | pass |
| `pnpm run type-check` | pass |
| `prettier@3.8.1 --check` on touched files | pass |
| `pnpm test` | 1153/1154 pass |

The single test failure is **pre-existing and unrelated**: `__tests__/commitlint-config.test.js` asserts a Unix execute bit on the husky `commit-msg` hook, which Windows filesystems do not preserve. It touches none of the three files in this PR.

`check:drift` is not present in this repo (it is template-only), so it was not run.

## Note for reviewers

There is no `security-txt-expiry.yml` workflow in this repo — the templates have one that opens an issue as the `Expires` date approaches. Not added here to keep this PR scoped; worth a follow-up so the date does not silently lapse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
