### PR TITLE
fix(privacy): deny tracking by default until consent is given

### DIFF
--- a/__tests__/consent-mode.test.js
+++ b/__tests__/consent-mode.test.js
@@ -1,0 +1,109 @@
+/**
+ * Consent Mode v2 regression tests.
+ *
+ * These assert on SOURCE TEXT rather than rendering the layout, because the property
+ * that matters is document-order: the consent defaults must be parsed before GTM
+ * initialises. jsdom cannot observe that — it evaluates whatever it is handed, in the
+ * order it is handed it — so a render-based test would pass just as happily with the
+ * two blocks swapped, which is precisely the bug.
+ *
+ * The defect these lock in: GTM loaded with no consent state at all, which Google
+ * treats as unrestricted. Every tag fired on first paint, before the banner appeared.
+ * The site asked for consent it had already stopped waiting for.
+ */
+
+const fs = require('fs')
+const path = require('path')
+
+const ROOT = path.resolve(__dirname, '..')
+const layoutSrc = fs.readFileSync(path.join(ROOT, 'src/app/layout.tsx'), 'utf8')
+const consentSrc = fs.readFileSync(path.join(ROOT, 'src/components/CookieConsent.tsx'), 'utf8')
+
+describe('Consent Mode v2 defaults', () => {
+  test('a consent default block exists in the layout', () => {
+    expect(layoutSrc).toMatch(/gtag\(\s*'consent'\s*,\s*'default'/)
+  })
+
+  test('the consent default is parsed BEFORE the GTM snippet', () => {
+    const consentAt = layoutSrc.search(/gtag\(\s*'consent'\s*,\s*'default'/)
+    const gtmAt = layoutSrc.indexOf('googletagmanager.com/gtm.js')
+
+    expect(consentAt).toBeGreaterThan(-1)
+    expect(gtmAt).toBeGreaterThan(-1)
+    // Strictly before. Equal or after means GTM initialises unrestricted.
+    expect(consentAt).toBeLessThan(gtmAt)
+  })
+
+  test('every tracking-storage category defaults to denied', () => {
+    // Split at the GTM snippet so a "granted" appearing later in the file cannot
+    // satisfy these assertions by accident.
+    const defaultBlock = layoutSrc.slice(0, layoutSrc.indexOf('googletagmanager.com/gtm.js'))
+
+    for (const key of ['ad_storage', 'ad_user_data', 'ad_personalization', 'analytics_storage']) {
+      expect(defaultBlock).toMatch(new RegExp(`'${key}':\\s*'denied'`))
+    }
+  })
+
+  test('the consent default is a raw inline script, not next/script', () => {
+    // next/script injects at runtime even with beforeInteractive, so it cannot
+    // guarantee it runs before a parser-executed tag. Only a raw <script> can.
+    const block = layoutSrc.slice(0, layoutSrc.indexOf('googletagmanager.com/gtm.js'))
+    expect(block).toMatch(/<script\s+id="consent-mode-default"/)
+    expect(block).not.toMatch(/<Script\s+id="consent-mode-default"/)
+  })
+})
+
+describe('CookieConsent grant path', () => {
+  test('accepting pushes a real Consent Mode update, not only the custom event', () => {
+    expect(consentSrc).toMatch(/gtag\?\.\(\s*'consent'\s*,\s*'update'/)
+  })
+
+  test('the custom consent_update event is retained for container triggers', () => {
+    // Kept deliberately: container-side triggers may depend on it. Removing it
+    // would be a silent behaviour change on the GTM side, invisible from this repo.
+    expect(consentSrc).toMatch(/event:\s*'consent_update'/)
+  })
+
+  test('analytics_storage in the update tracks the analytics preference', () => {
+    expect(consentSrc).toMatch(
+      /analytics_storage:\s*prefs\.analytics\s*\?\s*'granted'\s*:\s*'denied'/
+    )
+  })
+})
+
+describe('Analytics provisioning guard', () => {
+  test('a provisioning check exists', () => {
+    expect(consentSrc).toMatch(/isAnalyticsProvisioned/)
+  })
+
+  test('loadGoogleAnalytics returns early when the ID is not provisioned', () => {
+    const fnAt = consentSrc.indexOf('const loadGoogleAnalytics')
+    expect(fnAt).toBeGreaterThan(-1)
+    const body = consentSrc.slice(fnAt, fnAt + 900)
+    const guardAt = body.indexOf('isAnalyticsProvisioned')
+    const loadAt = body.indexOf('googletagmanager.com/gtag')
+    expect(guardAt).toBeGreaterThan(-1)
+    // The guard must precede the script injection, or it guards nothing.
+    expect(guardAt).toBeLessThan(loadAt)
+  })
+
+  test('the placeholder ID is rejected and real IDs are accepted', () => {
+    // Mirrors the implementation's predicate. Kept in sync by the source assertion
+    // above; this checks the RULE is right, that one checks it is USED.
+    const isProvisioned = (id) => /^G-[A-Z0-9]{6,}$/.test(id) && !/^G-X+$/.test(id)
+
+    expect(isProvisioned('G-XXXXXXXXXX')).toBe(false)
+    expect(isProvisioned('G-XXXX')).toBe(false)
+    expect(isProvisioned('')).toBe(false)
+    expect(isProvisioned('G-')).toBe(false)
+
+    expect(isProvisioned('G-ABC123XYZ')).toBe(true)
+    expect(isProvisioned('G-1A2B3C4D5E')).toBe(true)
+  })
+
+  test('the fallback in source is still the placeholder, so the guard is load-bearing', () => {
+    // If someone hardcodes a real ID as the fallback, the guard stops being the thing
+    // that protects unprovisioned sites — and this test should fail so that is noticed.
+    expect(consentSrc).toMatch(/NEXT_PUBLIC_GA_MEASUREMENT_ID \|\| 'G-X+'/)
+  })
+})

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -60,6 +60,43 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en">
       <head>
+        {/*
+          Consent Mode v2 defaults. This MUST render before the GTM snippet below,
+          and it is a plain inline <script> rather than next/script on purpose:
+          next/script "beforeInteractive" is still injected by the runtime, whereas
+          a raw inline tag is executed by the parser at exactly this position. GTM
+          reads the consent state present when it initialises, so "before" here is a
+          correctness requirement, not a preference.
+
+          Without this block GTM loaded with no consent state at all, which Google
+          treats as unrestricted: every tag in the container fired on first paint,
+          before the banner was even shown. The banner's later consent_update then
+          arrived after the tracking it was supposed to authorise had already
+          happened — the site behaved as though consent were granted while telling
+          the visitor it was being asked for.
+
+          Denied-by-default is also what the banner's own copy promises. wait_for_update
+          gives the stored-preference restore a window to grant before tags evaluate,
+          so a returning visitor who already accepted is not measured as a new denial.
+        */}
+        <script
+          id="consent-mode-default"
+          dangerouslySetInnerHTML={{
+            __html: `
+              window.dataLayer = window.dataLayer || [];
+              function gtag(){dataLayer.push(arguments);}
+              gtag('consent', 'default', {
+                'ad_storage': 'denied',
+                'ad_user_data': 'denied',
+                'ad_personalization': 'denied',
+                'analytics_storage': 'denied',
+                'functionality_storage': 'granted',
+                'security_storage': 'granted',
+                'wait_for_update': 500
+              });
+            `,
+          }}
+        />
         <Script
           id="google-tag-manager"
           strategy="afterInteractive"

--- a/src/components/CookieConsent.tsx
+++ b/src/components/CookieConsent.tsx
@@ -6,6 +6,19 @@ import { useState, useEffect, useRef } from 'react'
 // Environment variables for tracking IDs (replace with actual values)
 const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID || 'G-XXXXXXXXXX'
 
+// The fallback above is a placeholder, not a measurement ID. Loading it sent real
+// visitors' page views to https://www.googletagmanager.com/gtag/js?id=G-XXXXXXXXXX —
+// a request to Google carrying the visitor's IP and referrer, made in the name of
+// analytics that cannot be collected because no such property exists. That is the
+// privacy cost of tracking with none of the benefit, and it happened only AFTER the
+// visitor clicked Accept, so consent was obtained for something that never worked.
+//
+// A real GA4 ID is 'G-' followed by an alphanumeric string; the placeholder is all
+// X's. Match the shape rather than the exact placeholder so a differently-spelled
+// stand-in ('G-XXXX', 'G-TODO') is caught too.
+const isAnalyticsProvisioned = (id: string): boolean =>
+  /^G-[A-Z0-9]{6,}$/.test(id) && !/^G-X+$/.test(id)
+
 type ConsentPreferences = {
   necessary: boolean
   analytics: boolean
@@ -38,6 +51,12 @@ function isConsentPreferences(value: unknown): value is ConsentPreferences {
 declare global {
   interface Window {
     dataLayer: DataLayerEvent[]
+    // Defined by the inline Consent Mode block in layout.tsx
+    // (`function gtag(){dataLayer.push(arguments)}` — a function declaration in an
+    // inline script becomes a property of window). Optional because that block is
+    // parser-executed in the document head: on any page rendered without the app
+    // layout, and in jsdom-based tests, it is simply absent.
+    gtag?: (...args: unknown[]) => void
     openCookiePreferences?: () => void
   }
 }
@@ -156,6 +175,27 @@ export default function CookieConsent() {
     // Push consent update to GTM dataLayer
     if (typeof window !== 'undefined') {
       window.dataLayer = window.dataLayer || []
+
+      // Consent Mode update. This is what actually releases the tags held by the
+      // denied-by-default state set in layout.tsx. The custom consent_update event
+      // below is kept because container-side triggers may already depend on it, but
+      // it is NOT a substitute: a custom event only does something if a tag in the
+      // container listens for it, whereas this is read by Google's tags directly.
+      // Relying on the custom event alone meant consent was enforced only as long as
+      // container config happened to agree with the banner — invisible from the repo,
+      // and silently lost on any container edit.
+      //
+      // Called through window.gtag rather than pushed as an array: gtag pushes the
+      // `arguments` object, and Google's consent handling reads that shape. A literal
+      // array is NOT equivalent, and the difference is silent — consent would appear
+      // to be sent while the tags stayed denied.
+      window.gtag?.('consent', 'update', {
+        ad_storage: prefs.marketing ? 'granted' : 'denied',
+        ad_user_data: prefs.marketing ? 'granted' : 'denied',
+        ad_personalization: prefs.marketing ? 'granted' : 'denied',
+        analytics_storage: prefs.analytics ? 'granted' : 'denied',
+      })
+
       window.dataLayer.push({
         event: 'consent_update',
         analytics_consent: prefs.analytics ? 'granted' : 'denied',
@@ -173,6 +213,17 @@ export default function CookieConsent() {
   }
 
   const loadGoogleAnalytics = () => {
+    if (!isAnalyticsProvisioned(GA_MEASUREMENT_ID)) {
+      // Nothing to load. Deliberately silent in production rather than throwing:
+      // an unprovisioned site should degrade to no analytics, not to a broken page.
+      if (process.env.NODE_ENV !== 'production') {
+        console.warn(
+          `[CookieConsent] NEXT_PUBLIC_GA_MEASUREMENT_ID is not set (got "${GA_MEASUREMENT_ID}"). Skipping Google Analytics.`
+        )
+      }
+      return
+    }
+
     if (
       typeof window !== 'undefined' &&
       !document.querySelector('script[src*="googletagmanager.com/gtag"]')

--- a/src/components/CookieConsent.tsx
+++ b/src/components/CookieConsent.tsx
@@ -33,6 +33,15 @@ interface DataLayerEvent {
   [key: string]: DataLayerValue
 }
 
+// What actually lands in window.dataLayer is NOT only DataLayerEvent. The inline
+// `function gtag(){dataLayer.push(arguments)}` shim — defined in layout.tsx and again
+// in the GA loader below — pushes an `arguments` object, which has no `event` key.
+// Typing the array as DataLayerEvent[] told TypeScript every entry has `event: string`,
+// so `dataLayer[0].event` would type-check and be undefined at runtime. Google's tags
+// depend on that arguments shape, so it cannot be normalised away; the type has to
+// admit it instead.
+type DataLayerEntry = DataLayerEvent | IArguments
+
 function isConsentPreferences(value: unknown): value is ConsentPreferences {
   if (typeof value !== 'object' || value === null) {
     return false
@@ -50,7 +59,7 @@ function isConsentPreferences(value: unknown): value is ConsentPreferences {
 // Extend Window interface to include dataLayer
 declare global {
   interface Window {
-    dataLayer: DataLayerEvent[]
+    dataLayer: DataLayerEntry[]
     // Defined by the inline Consent Mode block in layout.tsx
     // (`function gtag(){dataLayer.push(arguments)}` — a function declaration in an
     // inline script becomes a property of window). Optional because that block is
@@ -218,7 +227,7 @@ export default function CookieConsent() {
       // an unprovisioned site should degrade to no analytics, not to a broken page.
       if (process.env.NODE_ENV !== 'production') {
         console.warn(
-          `[CookieConsent] NEXT_PUBLIC_GA_MEASUREMENT_ID is not set (got "${GA_MEASUREMENT_ID}"). Skipping Google Analytics.`
+          `[CookieConsent] NEXT_PUBLIC_GA_MEASUREMENT_ID is missing or not a real measurement ID (got "${GA_MEASUREMENT_ID}"). Skipping Google Analytics.`
         )
       }
       return


### PR DESCRIPTION
## The defect

ffcadmin.org shows a cookie banner asking permission for analytics — and loads GTM
unconditionally in `<head>` while asking.

GTM initialised with **no consent state at all**. Google treats absent state as
unrestricted, so every tag in `GTM-WMZH965Q` fired on first paint, before the banner
was rendered let alone answered. The banner's `consent_update` then arrived *after*
the tracking it was meant to authorise had already happened.

Confirmed live before this change: `https://ffcadmin.org/` serves the GTM snippet with
no `consent` directive anywhere in the document.

## Changes

**1. Consent Mode v2 defaults, denied, before GTM** — a raw inline `<script>`, not
`next/script`. `next/script` injects at runtime even under `beforeInteractive`, so it
cannot be guaranteed to precede a parser-executed tag. Document order is the correctness
property here. `wait_for_update: 500` lets the stored-preference restore grant before
tags evaluate, so a returning visitor who already accepted is not re-counted as a denial.

**2. A real consent update on accept** — the banner pushed only a custom `consent_update`
event. A custom event does something only if a tag in the container listens for it, so
consent was enforced only as long as container config happened to agree with the banner
— invisible from this repo, and lost on any container edit. Now also calls
`window.gtag('consent','update',…)`, which Google's tags read directly.

> Called through `gtag` rather than pushed as an array deliberately: `gtag` pushes the
> `arguments` object, and a literal array is **not** equivalent. The difference is silent
> — consent would look sent while the tags stayed denied.

The custom event is retained in case container-side triggers already depend on it.

**3. A provisioning guard on the GA loader** — `NEXT_PUBLIC_GA_MEASUREMENT_ID` falls back
to `G-XXXXXXXXXX`, so accepting the banner requested `gtag/js?id=G-XXXXXXXXXX`: a request
to Google carrying the visitor's IP and referrer, for a property that does not exist.
Privacy cost, no analytics, and it happened *only after* the visitor clicked Accept.
Matched by shape so `G-TODO`-style stand-ins are caught too.

## Verification

Checked against the **built output**, not just source — in `out/index.html` the consent
default sits at byte **3464** and the GTM snippet at **51268**.

The 11 regression tests **fail 8/11 against the unfixed code** and pass 11/11 with it.
They assert on source order because jsdom cannot observe parse order: a render-based test
would pass just as happily with the two blocks swapped, which is exactly the bug.

`pnpm type-check`, `lint`, `build` clean. 1164/1165 tests pass — the single failure is the
husky exec-bit check, which cannot pass on a Windows filesystem and fails identically on a
clean tree.

## Scope

ffcadmin only. The same placeholder-ID defect exists on SPT, FOT and amargraves; those are
separate PRs. `amargraves.org` additionally needs to be pointed at its own container
(`GTM-P42GJR2X`, currently sharing the template's `GTM-TQ5H8HPR`) **before** its dormant
consent components are mounted, or it would gate the wrong container.

Refs #859, #864
