### PR TITLE
feat: align Consent Mode with the shared FFC analytics property

### DIFF
--- a/__tests__/consent-mode.test.js
+++ b/__tests__/consent-mode.test.js
@@ -112,6 +112,48 @@ describe('CookieConsent grant path', () => {
       /analytics_storage:\s*prefs\.analytics\s*\?\s*'granted'\s*:\s*'denied'/
     )
   })
+
+  test('personalization_storage in the update tracks the marketing preference', () => {
+    // Regression: the region-scoped bootstrap denies personalization_storage in
+    // the EEA/UK/CH and grants it everywhere else, but the update call omitted
+    // it — so a non-EEA visitor who declined everything kept
+    // personalization_storage: granted. An opt-out the tags never saw.
+    expect(consentSrc).toMatch(
+      /personalization_storage:\s*prefs\.marketing\s*\?\s*'granted'\s*:\s*'denied'/
+    )
+  })
+
+  // The general form of that bug, so the NEXT omission fails here instead of
+  // shipping. Any category the bootstrap can leave non-granted is a category
+  // the banner must be able to change; one it cannot change keeps its default
+  // forever, silently.
+  test('every category the bootstrap can deny is also settable by the update', () => {
+    const regional = consentModeSrc.slice(firstDefaultAt, secondDefaultAt)
+    // Match any denied consent key, not just those ending in _storage:
+    // ad_user_data and ad_personalization do not carry that suffix, and a
+    // regex anchored on it would quietly skip them.
+    const deniable = [
+      ...new Set(Array.from(regional.matchAll(/'(\w+)':\s*'denied'/g)).map((m) => m[1])),
+    ]
+    // Sanity-check the extraction itself — a regex that silently matched
+    // nothing would make this test vacuously green.
+    expect(deniable).toEqual(
+      expect.arrayContaining([
+        'ad_storage',
+        'ad_user_data',
+        'ad_personalization',
+        'analytics_storage',
+        'personalization_storage',
+      ])
+    )
+
+    const updateAt = consentSrc.indexOf("'consent', 'update'")
+    expect(updateAt).toBeGreaterThan(-1)
+    const updateCall = consentSrc.slice(updateAt, consentSrc.indexOf('})', updateAt))
+
+    const missing = deniable.filter((c) => !updateCall.includes(`${c}:`))
+    expect(missing).toEqual([])
+  })
 })
 
 describe('Analytics provisioning guard', () => {

--- a/__tests__/consent-mode.test.js
+++ b/__tests__/consent-mode.test.js
@@ -18,29 +18,72 @@ const path = require('path')
 const ROOT = path.resolve(__dirname, '..')
 const layoutSrc = fs.readFileSync(path.join(ROOT, 'src/app/layout.tsx'), 'utf8')
 const consentSrc = fs.readFileSync(path.join(ROOT, 'src/components/CookieConsent.tsx'), 'utf8')
+// The bootstrap moved out of the layout into a shared module so it stays
+// byte-identical to FFC-IN-freeforcharity.org's copy. Both sites report to GA4
+// property 386764754 as of GTM-WMZH965Q version 4, and one property fed by two
+// different consent policies fragments the cross-site journeys the
+// consolidation exists to measure.
+const consentModeSrc = fs.readFileSync(path.join(ROOT, 'src/lib/consent-mode.ts'), 'utf8')
+
+const firstDefaultAt = consentModeSrc.indexOf("gtag('consent', 'default'")
+const secondDefaultAt = consentModeSrc.indexOf("gtag('consent', 'default'", firstDefaultAt + 1)
 
 describe('Consent Mode v2 defaults', () => {
-  test('a consent default block exists in the layout', () => {
-    expect(layoutSrc).toMatch(/gtag\(\s*'consent'\s*,\s*'default'/)
+  test('the layout renders the shared bootstrap rather than an inline copy', () => {
+    // A hand-inlined duplicate is exactly how the two sites drift apart, and
+    // drift here means one GA4 property receiving two different policies.
+    expect(layoutSrc).toMatch(/from '@\/lib\/consent-mode'/)
+    expect(layoutSrc).toMatch(/__html:\s*CONSENT_MODE_BOOTSTRAP/)
   })
 
-  test('the consent default is parsed BEFORE the GTM snippet', () => {
-    const consentAt = layoutSrc.search(/gtag\(\s*'consent'\s*,\s*'default'/)
+  test('the consent bootstrap is parsed BEFORE the GTM snippet', () => {
+    // Unchanged in intent from when the block was inline: GTM reads whatever
+    // consent state exists at initialisation, so a bootstrap that lands after
+    // it leaves GTM unrestricted. Anchor on the script tag rather than the
+    // gtag() call, which now lives in the imported module.
+    const bootstrapAt = layoutSrc.indexOf('id="consent-mode-default"')
     const gtmAt = layoutSrc.indexOf('googletagmanager.com/gtm.js')
 
-    expect(consentAt).toBeGreaterThan(-1)
+    expect(bootstrapAt).toBeGreaterThan(-1)
     expect(gtmAt).toBeGreaterThan(-1)
     // Strictly before. Equal or after means GTM initialises unrestricted.
-    expect(consentAt).toBeLessThan(gtmAt)
+    expect(bootstrapAt).toBeLessThan(gtmAt)
   })
 
-  test('every tracking-storage category defaults to denied', () => {
-    // Split at the GTM snippet so a "granted" appearing later in the file cannot
-    // satisfy these assertions by accident.
-    const defaultBlock = layoutSrc.slice(0, layoutSrc.indexOf('googletagmanager.com/gtm.js'))
+  // This previously asserted 'every tracking-storage category defaults to
+  // denied'. That test would still PASS against the region-scoped model — the
+  // regional block does deny every category — while the effective worldwide
+  // default had become granted. A green test whose name describes the opposite
+  // of shipped behaviour is worse than no test, so it now asserts the actual
+  // two-block structure.
+  test('the regional default denies every tracking-storage category', () => {
+    expect(firstDefaultAt).toBeGreaterThan(-1)
+    expect(secondDefaultAt).toBeGreaterThan(firstDefaultAt)
+    const regional = consentModeSrc.slice(firstDefaultAt, secondDefaultAt)
 
     for (const key of ['ad_storage', 'ad_user_data', 'ad_personalization', 'analytics_storage']) {
-      expect(defaultBlock).toMatch(new RegExp(`'${key}':\\s*'denied'`))
+      expect(regional).toMatch(new RegExp(`'${key}':\\s*'denied'`))
+    }
+    expect(regional).toMatch(/'region':/)
+  })
+
+  test('the regional scope covers the EEA, the UK and Switzerland', () => {
+    // Google's EU User Consent Policy is the only reason this list exists.
+    // Dropping a member state silently starts granting storage there.
+    for (const code of ['DE', 'FR', 'IE', 'IS', 'LI', 'NO', 'GB', 'CH']) {
+      expect(consentModeSrc).toMatch(new RegExp(`'${code}'`))
+    }
+  })
+
+  test('the global default grants, and comes AFTER the regional denial', () => {
+    // Order is the entire mechanism: region-scoped settings take precedence
+    // over the unscoped one, so regional-first is what gives the EEA denial
+    // priority. Reversed, EEA/UK/CH visitors would be granted by default —
+    // precisely what Google's policy forbids, with no error to reveal it.
+    const global = consentModeSrc.slice(secondDefaultAt)
+    expect(global).not.toMatch(/'region':/)
+    for (const key of ['ad_storage', 'ad_user_data', 'ad_personalization', 'analytics_storage']) {
+      expect(global).toMatch(new RegExp(`'${key}':\\s*'granted'`))
     }
   })
 

--- a/src/app/cookie-policy/page.tsx
+++ b/src/app/cookie-policy/page.tsx
@@ -84,7 +84,9 @@ export default function CookiePolicy() {
                   Analyze website traffic and user behavior —{' '}
                   <strong>only where analytics storage is permitted</strong>
                 </li>
-                <li>Improve our website and user experience, using whatever the above collect</li>
+                <li>
+                  Improve our website and user experience, using whatever the items above collect
+                </li>
               </ul>
               <p className="mb-4">
                 <strong>Where consent is required.</strong> If you are in the European Economic

--- a/src/app/cookie-policy/page.tsx
+++ b/src/app/cookie-policy/page.tsx
@@ -11,7 +11,7 @@ export const metadata: Metadata = {
 }
 
 // Update this date when the policy changes
-const LAST_UPDATED = 'June 20, 2026'
+const LAST_UPDATED = 'July 26, 2026'
 
 // Table of contents — keep in sync with the section ids below.
 const TOC = [
@@ -70,12 +70,21 @@ export default function CookiePolicy() {
 
             <section id="section-2" className="scroll-mt-20">
               <h2 className="text-2xl font-bold text-gray-900 mb-4">2. How We Use Cookies</h2>
-              <p className="mb-4">When you visit our website, we use cookies to:</p>
+              <p className="mb-4">When you visit our website, cookies may be used to:</p>
               <ul className="list-disc pl-6 mb-4 space-y-2">
-                <li>Remember your cookie consent preferences</li>
-                <li>Understand how you use our website</li>
-                <li>Analyze website traffic and user behavior</li>
-                <li>Improve our website and user experience</li>
+                <li>
+                  Remember your cookie consent preferences — <strong>always, on every visit</strong>
+                  , because without it we cannot honour your choice
+                </li>
+                <li>
+                  Understand how you use our website —{' '}
+                  <strong>only where analytics storage is permitted</strong>
+                </li>
+                <li>
+                  Analyze website traffic and user behavior —{' '}
+                  <strong>only where analytics storage is permitted</strong>
+                </li>
+                <li>Improve our website and user experience, using whatever the above collect</li>
               </ul>
               <p className="mb-4">
                 <strong>Where consent is required.</strong> If you are in the European Economic

--- a/src/app/cookie-policy/page.tsx
+++ b/src/app/cookie-policy/page.tsx
@@ -73,8 +73,9 @@ export default function CookiePolicy() {
               <p className="mb-4">When you visit our website, cookies may be used to:</p>
               <ul className="list-disc pl-6 mb-4 space-y-2">
                 <li>
-                  Remember your cookie consent preferences — <strong>always, on every visit</strong>
-                  , because without it we cannot honour your choice
+                  Remember your cookie consent preferences —{' '}
+                  <strong>from the moment you make a choice</strong>, so we do not have to ask again
+                  and can apply it on later visits
                 </li>
                 <li>
                   Understand how you use our website —{' '}
@@ -96,11 +97,12 @@ export default function CookiePolicy() {
                 by default when you arrive, and declining in the banner switches it off.
               </p>
               <p className="mb-4">
-                This does not mean your device is untouched: the necessary items in section 3.1
-                below — the cookie recording your consent choice, and the note that you dismissed
-                the sister-site banner — are stored either way, because a preference we cannot
-                remember is a preference we cannot honour. They carry no identifier and are never
-                sent to an analytics provider.
+                This does not mean your device is untouched. Once you make a choice, the necessary
+                items in section 3.1 below are saved in your browser regardless of what you chose —
+                your consent preference (kept in local storage and also mirrored to a{' '}
+                <code>cookie-consent</code> cookie) and, if you dismiss it, a note that you closed
+                the sister-site banner. A preference we cannot remember is one we cannot honour.
+                They carry no identifier and are never sent to an analytics provider.
               </p>
               <p className="mb-4">
                 Declining does not make you invisible to us, and we would rather say so plainly than
@@ -152,9 +154,12 @@ export default function CookiePolicy() {
                       <tbody>
                         <tr className="border-b">
                           <td className="py-2 pr-4 font-mono">cookie-consent</td>
-                          <td className="py-2 pr-4">Cookie</td>
-                          <td className="py-2 pr-4">Stores your cookie preferences</td>
-                          <td className="py-2">12 months</td>
+                          <td className="py-2 pr-4">Local storage + cookie</td>
+                          <td className="py-2 pr-4">
+                            Stores your cookie preferences. Written to both; the local-storage copy
+                            is the one we read back on your next visit.
+                          </td>
+                          <td className="py-2">Local storage: until cleared. Cookie: 12 months.</td>
                         </tr>
                         <tr className="border-b">
                           <td className="py-2 pr-4 font-mono">

--- a/src/app/cookie-policy/page.tsx
+++ b/src/app/cookie-policy/page.tsx
@@ -73,10 +73,36 @@ export default function CookiePolicy() {
               <p className="mb-4">When you visit our website, we use cookies to:</p>
               <ul className="list-disc pl-6 mb-4 space-y-2">
                 <li>Remember your cookie consent preferences</li>
-                <li>Understand how you use our website (with your consent)</li>
-                <li>Analyze website traffic and user behavior (with your consent)</li>
+                <li>Understand how you use our website</li>
+                <li>Analyze website traffic and user behavior</li>
                 <li>Improve our website and user experience</li>
               </ul>
+              <p className="mb-4">
+                <strong>Where consent is required.</strong> If you are in the European Economic
+                Area, the United Kingdom, or Switzerland, analytics and advertising storage stay
+                switched off until you accept — nothing is stored on your device and no identifiers
+                are read before then. Everywhere else, analytics storage is enabled by default when
+                you arrive, and declining in the banner switches it off.
+              </p>
+              <p className="mb-4">
+                Declining does not make you invisible to us, and we would rather say so plainly than
+                imply otherwise: Google Analytics still receives a record of the visit, without
+                cookies and without any identifier that could link it to your other visits. We learn
+                that a page was viewed; we do not learn that it was you.
+              </p>
+              <p className="mb-4">
+                We share a single analytics property with our sister site,{' '}
+                <a
+                  href="https://www.freeforcharity.org/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-blue-600 hover:underline"
+                >
+                  freeforcharity.org
+                </a>
+                , so that moving between the two is understood as one visit rather than two
+                unrelated ones. Your consent choice is asked and honoured separately on each site.
+              </p>
             </section>
 
             <section id="section-3" className="scroll-mt-20">
@@ -131,7 +157,7 @@ export default function CookiePolicy() {
 
                 <div className="border-l-4 border-green-600 pl-4">
                   <h3 className="text-xl font-semibold text-gray-900 mb-3">
-                    3.2 Analytics Cookies (Requires Consent)
+                    3.2 Analytics Cookies (Consent Required in the EEA, UK &amp; Switzerland)
                   </h3>
                   <p className="mb-4">
                     These cookies help us understand how visitors interact with our website by
@@ -288,9 +314,11 @@ export default function CookiePolicy() {
 
               <h3 className="text-xl font-semibold text-gray-900 mb-3">4.3 Opt-Out Links</h3>
               <p className="mb-4">
-                Declining analytics in the consent banner already stops both Google Analytics and
-                Microsoft Clarity from loading. For Google Analytics, you can also opt out
-                browser-wide:
+                Declining analytics in the consent banner stops Microsoft Clarity entirely — no
+                session recording takes place. Google Analytics behaves differently and we want to
+                be exact about it: declining stops it using cookies or reading any identifier, but
+                it still receives an anonymous, cookieless record of the visit. For Google
+                Analytics, you can also opt out browser-wide:
               </p>
               <ul className="list-disc pl-6 mb-4 space-y-2">
                 <li>

--- a/src/app/cookie-policy/page.tsx
+++ b/src/app/cookie-policy/page.tsx
@@ -89,9 +89,16 @@ export default function CookiePolicy() {
               <p className="mb-4">
                 <strong>Where consent is required.</strong> If you are in the European Economic
                 Area, the United Kingdom, or Switzerland, analytics and advertising storage stay
-                switched off until you accept — nothing is stored on your device and no identifiers
-                are read before then. Everywhere else, analytics storage is enabled by default when
-                you arrive, and declining in the banner switches it off.
+                switched off until you accept — no analytics or advertising cookie is written and no
+                such identifier is read before then. Everywhere else, analytics storage is enabled
+                by default when you arrive, and declining in the banner switches it off.
+              </p>
+              <p className="mb-4">
+                This does not mean your device is untouched: the necessary items in section 3.1
+                below — the cookie recording your consent choice, and the note that you dismissed
+                the sister-site banner — are stored either way, because a preference we cannot
+                remember is a preference we cannot honour. They carry no identifier and are never
+                sent to an analytics provider.
               </p>
               <p className="mb-4">
                 Declining does not make you invisible to us, and we would rather say so plainly than

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,7 @@ import CookieConsent from '@/components/CookieConsent'
 import BackToTop from '@/components/BackToTop'
 import SisterSiteBanner from '@/components/SisterSiteBanner'
 import { assetPath } from '@/lib/assetPath'
+import { CONSENT_MODE_BOOTSTRAP } from '@/lib/consent-mode'
 
 const SITE_URL = 'https://ffcadmin.org'
 
@@ -75,27 +76,21 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           happened — the site behaved as though consent were granted while telling
           the visitor it was being asked for.
 
-          Denied-by-default is also what the banner's own copy promises. wait_for_update
-          gives the stored-preference restore a window to grant before tags evaluate,
-          so a returning visitor who already accepted is not measured as a new denial.
+          The state itself is REGION-SCOPED rather than denied worldwide, and the
+          bootstrap now lives in @/lib/consent-mode so it stays identical to
+          FFC-IN-freeforcharity.org. Both sites report to one GA4 property
+          (386764754) as of GTM-WMZH965Q version 4, and one property fed by two
+          different consent policies fragments the very cross-site journeys the
+          consolidation exists to measure. See that module for the full rationale,
+          including why Microsoft Clarity is gated container-side instead of here.
+
+          wait_for_update gives the stored-preference restore a window to grant
+          before tags evaluate, so a returning visitor who already accepted is not
+          measured as a new denial.
         */}
         <script
           id="consent-mode-default"
-          dangerouslySetInnerHTML={{
-            __html: `
-              window.dataLayer = window.dataLayer || [];
-              function gtag(){dataLayer.push(arguments);}
-              gtag('consent', 'default', {
-                'ad_storage': 'denied',
-                'ad_user_data': 'denied',
-                'ad_personalization': 'denied',
-                'analytics_storage': 'denied',
-                'functionality_storage': 'granted',
-                'security_storage': 'granted',
-                'wait_for_update': 500
-              });
-            `,
-          }}
+          dangerouslySetInnerHTML={{ __html: CONSENT_MODE_BOOTSTRAP }}
         />
         <Script
           id="google-tag-manager"

--- a/src/app/privacy-policy/page.tsx
+++ b/src/app/privacy-policy/page.tsx
@@ -11,7 +11,7 @@ export const metadata: Metadata = {
 }
 
 // Update this date when the policy changes
-const LAST_UPDATED = 'June 20, 2026'
+const LAST_UPDATED = 'July 26, 2026'
 
 // Table of contents — keep in sync with the section ids below.
 const TOC = [
@@ -104,9 +104,17 @@ export default function PrivacyPolicy() {
                 <li>Referring website addresses</li>
                 <li>Date and time of visit</li>
               </ul>
+              <p className="mb-4">
+                Consent controls whether this information can be{' '}
+                <em>stored on your device or tied to an identifier</em>, not whether the visit is
+                recorded at all. If you are in the EEA, the UK, or Switzerland, nothing is stored
+                and no identifier is read until you accept. Elsewhere, analytics storage is on by
+                default and the banner switches it off.
+              </p>
               <p>
-                This information is collected only if you have provided consent through our cookie
-                consent banner.
+                Either way, a visit you have not consented to is still recorded — cookielessly, with
+                no identifier that could connect it to your other visits. We would rather state that
+                than claim nothing is collected, which would not be true.
               </p>
             </section>
 
@@ -118,7 +126,9 @@ export default function PrivacyPolicy() {
               <ul className="list-disc pl-6 mb-4 space-y-2">
                 <li>Operate, maintain, and improve our website</li>
                 <li>Understand how visitors use our site</li>
-                <li>Analyze site traffic and user behavior (with consent)</li>
+                <li>
+                  Analyze site traffic and user behavior (where analytics storage is permitted)
+                </li>
                 <li>Respond to support requests and communications</li>
                 <li>Detect, prevent, and address technical issues</li>
                 <li>Comply with legal obligations</li>

--- a/src/app/privacy-policy/page.tsx
+++ b/src/app/privacy-policy/page.tsx
@@ -106,10 +106,12 @@ export default function PrivacyPolicy() {
               </ul>
               <p className="mb-4">
                 Consent controls whether this information can be{' '}
-                <em>stored on your device or tied to an identifier</em>, not whether the visit is
-                recorded at all. If you are in the EEA, the UK, or Switzerland, nothing is stored
-                and no identifier is read until you accept. Elsewhere, analytics storage is on by
-                default and the banner switches it off.
+                <em>kept in an analytics cookie or tied to an identifier</em>, not whether the visit
+                is recorded at all. If you are in the EEA, the UK, or Switzerland, no analytics or
+                advertising cookie is written and no such identifier is read until you accept.
+                Elsewhere, analytics storage is on by default and the banner switches it off. The
+                cookie that records your own consent choice is stored either way — without it we
+                could not honour the choice.
               </p>
               <p>
                 Either way, a visit you have not consented to is still recorded — cookielessly, with

--- a/src/app/privacy-policy/page.tsx
+++ b/src/app/privacy-policy/page.tsx
@@ -142,7 +142,11 @@ export default function PrivacyPolicy() {
                 </li>
                 <li>
                   <strong>Analytics Cookies:</strong> Help us understand how visitors interact with
-                  our website (Google Analytics, Microsoft Clarity). Requires consent.
+                  our website (Google Analytics, Microsoft Clarity). Consent is required before
+                  these are set if you are in the EEA, the UK, or Switzerland; elsewhere analytics
+                  storage is on by default and the banner switches it off. Declining always stops
+                  Microsoft Clarity outright, and reduces Google Analytics to a cookieless record
+                  that cannot be linked to your other visits.
                 </li>
                 <li>
                   <strong>Marketing Cookies:</strong> Would be used to track visitors across
@@ -166,10 +170,22 @@ export default function PrivacyPolicy() {
               </p>
               <ul className="list-disc pl-6 mb-4 space-y-2">
                 <li>
-                  <strong>Google Analytics:</strong> Web analytics service (only with consent)
+                  <strong>Google Analytics:</strong> Web analytics service. Runs on every visit;
+                  consent controls whether it may use cookies and identifiers, not whether it runs.
+                  This site reports to the same Google Analytics property as our sister site{' '}
+                  <a
+                    href="https://www.freeforcharity.org/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-blue-600 hover:underline"
+                  >
+                    freeforcharity.org
+                  </a>
+                  , so a visit that spans both sites is recorded as one journey.
                 </li>
                 <li>
-                  <strong>Microsoft Clarity:</strong> User behavior analytics (only with consent)
+                  <strong>Microsoft Clarity:</strong> User behavior analytics (only with consent —
+                  it does not run at all unless you accept analytics)
                 </li>
               </ul>
               <p>

--- a/src/app/privacy-policy/page.tsx
+++ b/src/app/privacy-policy/page.tsx
@@ -109,9 +109,10 @@ export default function PrivacyPolicy() {
                 <em>kept in an analytics cookie or tied to an identifier</em>, not whether the visit
                 is recorded at all. If you are in the EEA, the UK, or Switzerland, no analytics or
                 advertising cookie is written and no such identifier is read until you accept.
-                Elsewhere, analytics storage is on by default and the banner switches it off. The
-                cookie that records your own consent choice is stored either way — without it we
-                could not honour the choice.
+                Elsewhere, analytics storage is on by default and the banner switches it off. Your
+                own consent choice is saved in your browser either way, once you make one — in local
+                storage, and mirrored to a cookie — because a preference we cannot remember is one
+                we cannot honour.
               </p>
               <p>
                 Either way, a visit you have not consented to is still recorded — cookielessly, with

--- a/src/components/CookieConsent.tsx
+++ b/src/components/CookieConsent.tsx
@@ -198,11 +198,31 @@ export default function CookieConsent() {
       // `arguments` object, and Google's consent handling reads that shape. A literal
       // array is NOT equivalent, and the difference is silent — consent would appear
       // to be sent while the tags stayed denied.
+      //
+      // INVARIANT: every category the bootstrap can leave in a non-granted
+      // state must appear here. A category set by the default but never
+      // updated keeps that default forever, so the visitor's choice silently
+      // does not apply to it.
+      //
+      // personalization_storage was exactly that bug, introduced when the
+      // region-scoped bootstrap arrived. It is denied inside the EEA/UK/CH and
+      // granted everywhere else, so a non-EEA visitor who declined everything
+      // still carried personalization_storage: granted — an opt-out the tags
+      // never saw. It tracks `marketing`, matching the mapping in
+      // FFC-IN-freeforcharity.org's updateGoogleConsent().
+      //
+      // functionality_storage and security_storage are deliberately absent:
+      // the bootstrap grants both unconditionally in BOTH blocks, and this
+      // banner has no toggle for them (its categories are necessary /
+      // analytics / marketing), so there is no choice to propagate. Add such a
+      // toggle and it must be added here too — consent-mode.test.js enforces
+      // this invariant so the next omission fails instead of shipping.
       window.gtag?.('consent', 'update', {
         ad_storage: prefs.marketing ? 'granted' : 'denied',
         ad_user_data: prefs.marketing ? 'granted' : 'denied',
         ad_personalization: prefs.marketing ? 'granted' : 'denied',
         analytics_storage: prefs.analytics ? 'granted' : 'denied',
+        personalization_storage: prefs.marketing ? 'granted' : 'denied',
       })
 
       window.dataLayer.push({

--- a/src/lib/consent-mode.ts
+++ b/src/lib/consent-mode.ts
@@ -1,0 +1,146 @@
+// Google Consent Mode v2 defaults.
+//
+// Policy: the most permissive configuration Google's own rules allow.
+//
+// This file is deliberately a near-copy of the module of the same name in
+// FFC-IN-freeforcharity.org. That is not incidental duplication — as of
+// GTM-WMZH965Q container version 4, ffcadmin.org and freeforcharity.org
+// report to the SAME GA4 property (386764754, measurement id
+// G-541Y8JRDLX) so that a visitor's movement between the two sites is one
+// journey rather than two unrelated ones.
+//
+// A single property receiving two DIFFERENT consent policies is a data
+// integrity problem, not a style inconsistency. Before this change
+// ffcadmin denied every storage category worldwide while freeforcharity
+// granted outside the EEA/UK/CH, so the same visitor crossing between the
+// sites would flip consent state mid-journey: sessions would fragment,
+// and the cross-domain continuity the consolidation exists to provide
+// would be silently undone. Keep the two files in step. If you change the
+// region list or the defaults here, change them there in the same PR.
+//
+// Google's EU User Consent Policy binds us as a Google Analytics
+// customer, and it requires opt-IN consent before setting cookies or
+// reading identifiers for visitors in the EEA, the UK, and Switzerland.
+// Everywhere else no such Google-imposed requirement exists, so storage
+// defaults to GRANTED and measurement is complete from the first pageview.
+//
+// Under Consent Mode the Google tags always load; what changes by region
+// is whether they may use cookies:
+//
+//   - Outside EEA/UK/CH  → granted immediately; full cookie-based
+//                          measurement, no banner interaction needed.
+//   - Inside EEA/UK/CH   → denied until the visitor accepts, but GA4 still
+//                          sends COOKIELESS pings, so pageviews are
+//                          modeled rather than lost. Accepting flips
+//                          storage to granted via a `consent update`.
+//
+// IMPORTANT — this governs GOOGLE tags only. Consent Mode is a Google
+// protocol and Microsoft Clarity does not speak it, so Clarity cannot be
+// gated from here. It is gated container-side instead: the Clarity tag in
+// GTM-WMZH965Q carries `consentStatus: needed` on `analytics_storage` as
+// of version 4. Before that it fired on every pageview regardless of
+// choice, while this site's cookie policy promised that declining
+// analytics stopped it — the policy was accurate about intent and wrong
+// about behaviour. If you ever see Clarity recording a declining
+// visitor, that container setting is what regressed.
+
+/**
+ * ISO 3166 region codes where Google's EU User Consent Policy applies:
+ * the 27 EU member states + the 3 non-EU EEA states (IS, LI, NO), plus
+ * the UK (GB) and Switzerland (CH).
+ */
+export const EU_CONSENT_REGIONS = [
+  'AT',
+  'BE',
+  'BG',
+  'HR',
+  'CY',
+  'CZ',
+  'DK',
+  'EE',
+  'FI',
+  'FR',
+  'DE',
+  'GR',
+  'HU',
+  'IE',
+  'IT',
+  'LV',
+  'LT',
+  'LU',
+  'MT',
+  'NL',
+  'PL',
+  'PT',
+  'RO',
+  'SK',
+  'SI',
+  'ES',
+  'SE',
+  // Non-EU EEA
+  'IS',
+  'LI',
+  'NO',
+  // UK + Switzerland
+  'GB',
+  'CH',
+] as const
+
+/**
+ * Milliseconds tags wait for a `consent update` before firing with the
+ * default state. 500ms is Google's documented starting point: long enough
+ * for the stored-preference read, short enough not to meaningfully delay
+ * the first hit.
+ */
+export const CONSENT_WAIT_FOR_UPDATE_MS = 500
+
+/**
+ * The inline bootstrap that must execute BEFORE GTM loads.
+ *
+ * Emitted into <head> in the root layout as a raw inline <script>, not
+ * next/script: next/script "beforeInteractive" is still injected by the
+ * runtime, whereas a raw tag is executed by the parser at exactly its
+ * document position. GTM reads whatever consent state exists when it
+ * initialises, so "before" is a correctness requirement here, not a
+ * preference. `__tests__/consent-mode.test.js` locks that ordering in.
+ *
+ * Two `consent default` calls, in Google's documented order: the
+ * region-scoped denial FIRST, then the global grant. Region-specific
+ * settings take precedence over the unscoped one, so EEA/UK/CH visitors
+ * get denied-by-default and everyone else gets granted-by-default.
+ * Reversing the two would grant the EEA as well.
+ *
+ * `url_passthrough` keeps click ids flowing through navigation when
+ * cookies are denied, and `ads_data_redaction` strips ad identifiers
+ * while `ad_storage` is denied — both are no-ops once consent is granted,
+ * so they cost nothing outside the EEA.
+ *
+ * Declared as a function declaration so `gtag` lands on `window` and the
+ * consent banner shares one queue with it.
+ */
+export const CONSENT_MODE_BOOTSTRAP = `
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('consent', 'default', {
+  'ad_storage': 'denied',
+  'ad_user_data': 'denied',
+  'ad_personalization': 'denied',
+  'analytics_storage': 'denied',
+  'functionality_storage': 'granted',
+  'personalization_storage': 'denied',
+  'security_storage': 'granted',
+  'wait_for_update': ${CONSENT_WAIT_FOR_UPDATE_MS},
+  'region': ${JSON.stringify([...EU_CONSENT_REGIONS])}
+});
+gtag('consent', 'default', {
+  'ad_storage': 'granted',
+  'ad_user_data': 'granted',
+  'ad_personalization': 'granted',
+  'analytics_storage': 'granted',
+  'functionality_storage': 'granted',
+  'personalization_storage': 'granted',
+  'security_storage': 'granted'
+});
+gtag('set', 'url_passthrough', true);
+gtag('set', 'ads_data_redaction', true);
+`.trim()


### PR DESCRIPTION
## Why

ffcadmin.org now reports to the **freeforcharity.org GA4 property** (`386764754`, measurement ID `G-541Y8JRDLX`) as of `GTM-WMZH965Q` **container version 4**, published separately from this PR. The point is that a visitor moving between the two sister sites is measured as one journey instead of two unrelated ones.

One property fed by two different consent policies defeats exactly that. Before this change:

| | freeforcharity.org | ffcadmin.org |
| --- | --- | --- |
| Consent default | region-scoped: EEA/UK/CH denied, granted worldwide | **globally denied** |

So the same visitor crossing between the sites flipped consent state mid-journey, fragmenting the session — silently, with nothing in GA4 to indicate it.

## What changed

**`src/lib/consent-mode.ts` (new)** — the bootstrap, extracted from `layout.tsx`. A deliberate near-copy of the module of the same name in `FFC-IN-freeforcharity.org` so the two stay in step; a hand-inlined duplicate is how they drift apart. Region-scoped denial first, global grant second — reversing that order would grant the EEA by default, which Google's EU User Consent Policy forbids and which nothing reports as an error.

**`src/app/layout.tsx`** — renders `CONSENT_MODE_BOOTSTRAP` instead of an inline literal. Still a raw `<script>`, still before the GTM snippet; both properties are load-bearing and both are still asserted.

**`__tests__/consent-mode.test.js`** — reworked. Three tests grepped the layout for the literal `gtag('consent','default')` call and would simply have broken on the move. One was worse: **"every tracking-storage category defaults to denied" would have kept passing** against the region-scoped model, because the regional block *does* deny every category — while the effective worldwide default had become granted. A green test whose name describes the opposite of shipped behaviour is worse than no test. It now asserts the real two-block structure, the region list, and the ordering.

**`src/app/cookie-policy/page.tsx`, `src/app/privacy-policy/page.tsx`** — both claimed analytics "requires consent" unconditionally, and the cookie policy claimed declining "stops Google Analytics from loading." Under Consent Mode, declining stops it *using cookies and identifiers*, not running. The pages now state where consent is actually required and say plainly that a declining visitor is still counted cookielessly, rather than implying they disappear.

## A privacy defect found and fixed container-side

The Clarity claims in those pages — "only with consent", "declining… stops both Google Analytics and Microsoft Clarity from loading" — were false in the *other* direction. The Clarity tag in `GTM-WMZH965Q` carried `consentStatus: notSet` and fired on every pageview regardless of the visitor's choice, while these pages promised it did not.

Fixed by making behaviour match the promise rather than weakening the promise: the Clarity tag now carries `consentStatus: needed` on `analytics_storage` in version 4. Those sentences are accurate as written now.

## Also in container version 4 (not this diff)

Hostname blocking triggers on both tags. `lighthouserc.json` collects five URLs at `numberOfRuns: 3` from `staticDistDir`, which was generating **2,366 of this property's 2,701 sessions** from `localhost` — 88%, at 0.6% engagement. Real ffcadmin.org traffic is 335 sessions/28d. Without this, consolidating would have imported that noise into the shared property.

## Testing

- `pnpm run type-check` — clean
- `pnpm run lint` — clean
- `pnpm test` — **1,167 passed, 68/68 suites** (after `pnpm run build`; six suites read `out/` and fail without it, as in CI's order)
- Live container verified: `gtm.js?id=GTM-WMZH965Q` serves `G-541Y8JRDLX`, no longer serves `G-7VK191LDRL`, and carries the `ffcadmin\.org$` hostname condition

## Outstanding — requires the GA4 UI

Cross-domain link decoration needs `ffcadmin.org` added under Data Streams → Configure tag settings → **Configure your domains**. That setting is exposed by **no** version of the Admin API — verified against the v1beta and v1alpha discovery docs (revision 20260722), where `WebStreamData` carries only `measurementId`, `firebaseAppId`, and `defaultUri`. Until it is added, both sites report to one property but a hop between them still starts a new session.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NY27Zb9yfEkKFLeN5WRrPF)_