### PR TITLE
fix(agentic-os): state what "in flight" counts, and show the denominator

### DIFF
--- a/__tests__/agentic-os-in-flight-panel.test.js
+++ b/__tests__/agentic-os-in-flight-panel.test.js
@@ -76,7 +76,22 @@ describe('in-flight panel legibility (#909)', () => {
       open_prs_total: 8,
     })
     render(<AgenticOs />)
-    expect(screen.getByText('1 of 8 PRs in flight')).toBeInTheDocument()
+    expect(screen.getByText('1 of 8 PR in flight')).toBeInTheDocument()
+  })
+
+  it('separates "none are open" from "none are linked" (open_prs_total: 0)', () => {
+    // 0 is a real reading, not a missing field. A truthiness check would send
+    // it to the pre-#909 wording and lose the distinction this panel is for.
+    loadAgenticOsStatus.mockReturnValue({
+      ...BASE,
+      in_flight_prs: [],
+      in_flight_prs_rule: RULE,
+      open_prs_total: 0,
+    })
+    render(<AgenticOs />)
+    expect(screen.getByText('0 of 0 PRs in flight')).toBeInTheDocument()
+    expect(screen.getByText('No pull requests are open on the hub.')).toBeInTheDocument()
+    expect(screen.queryByText(/No open Agentic OS pull requests right now/)).not.toBeInTheDocument()
   })
 
   it('names the referenced issue on a PR that carries no label at all', () => {
@@ -113,7 +128,7 @@ describe('in-flight panel legibility (#909)', () => {
     // undefined".
     loadAgenticOsStatus.mockReturnValue({ ...BASE, in_flight_prs: [pr({})] })
     render(<AgenticOs />)
-    expect(screen.getByText('1 PRs in flight')).toBeInTheDocument()
+    expect(screen.getByText('1 PR in flight')).toBeInTheDocument()
     expect(screen.queryByText(/What counts:/)).not.toBeInTheDocument()
     expect(screen.queryByText(/undefined/)).not.toBeInTheDocument()
   })

--- a/__tests__/agentic-os-in-flight-panel.test.js
+++ b/__tests__/agentic-os-in-flight-panel.test.js
@@ -76,7 +76,7 @@ describe('in-flight panel legibility (#909)', () => {
       open_prs_total: 8,
     })
     render(<AgenticOs />)
-    expect(screen.getByText('1 of 8 PR in flight')).toBeInTheDocument()
+    expect(screen.getByText('1 of 8 PRs in flight')).toBeInTheDocument()
   })
 
   it('separates "none are open" from "none are linked" (open_prs_total: 0)', () => {

--- a/__tests__/agentic-os-in-flight-panel.test.js
+++ b/__tests__/agentic-os-in-flight-panel.test.js
@@ -1,0 +1,120 @@
+/**
+ * "Pull requests in flight" panel — the #909 regression surface.
+ *
+ * The panel read 0 while eight agent pull requests were open, because the hub
+ * generator filtered on an `agentic-os` label that nothing ever puts on a pull
+ * request. What made that survive was not the wrong number, it was that the
+ * page gave a reader no way to tell "nothing is in flight" from "the filter is
+ * dead": a bare `0`, no stated rule, no denominator.
+ *
+ * So these tests pin the *legibility* of the panel, not just its contents —
+ * the fraction, the stated inclusion rule, and the per-card reason a pull
+ * request appears. They mock the loader because the committed snapshot is a
+ * fixed artifact and these are claims about rendering, not about live counts.
+ */
+import { render, screen } from '@testing-library/react'
+
+// Mocked by relative path: next/jest's `@/` mapper is not applied to the
+// hoisted jest.mock() specifier, though it is to the imports below. Both
+// resolve to the same module, so the page's `@/lib/dashboardData` import
+// receives this mock.
+jest.mock('../src/lib/dashboardData', () => {
+  const actual = jest.requireActual('../src/lib/dashboardData')
+  return { ...actual, loadAgenticOsStatus: jest.fn() }
+})
+
+import { loadAgenticOsStatus } from '@/lib/dashboardData'
+import AgenticOs from '@/app/agentic-os/page'
+
+const BASE = {
+  generated_at: new Date().toISOString(),
+  repo: 'FreeForCharity/FFC-Cloudflare-Automation',
+  backlog_issues: [],
+  in_flight_prs: [],
+  conductor_log: [],
+  pending_gates: [],
+}
+
+const RULE =
+  'Open pull requests on this repo that are agent work on this backlog: a PR is listed ' +
+  'when it carries the agentic-os label, or when its body references an agentic-os issue.'
+
+function pr(overrides) {
+  return {
+    number: 902,
+    title: 'An unlabelled agent PR',
+    state: 'open',
+    draft: true,
+    assignee: null,
+    updated_at: new Date().toISOString(),
+    url: 'https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/902',
+    labels: [],
+    ...overrides,
+  }
+}
+
+describe('in-flight panel legibility (#909)', () => {
+  afterEach(() => jest.resetAllMocks())
+
+  it('states the inclusion rule in words when the feed provides it', () => {
+    loadAgenticOsStatus.mockReturnValue({
+      ...BASE,
+      in_flight_prs: [pr({ linked_agentic_issues: [730] })],
+      in_flight_prs_rule: RULE,
+      open_prs_total: 8,
+    })
+    render(<AgenticOs />)
+    expect(screen.getByText(/What counts:/)).toBeInTheDocument()
+    expect(screen.getByText(new RegExp('carries the agentic-os label'))).toBeInTheDocument()
+  })
+
+  it('shows the count as a fraction of all open PRs, so 0 reads as a filter problem', () => {
+    loadAgenticOsStatus.mockReturnValue({
+      ...BASE,
+      in_flight_prs: [pr({ linked_agentic_issues: [730] })],
+      in_flight_prs_rule: RULE,
+      open_prs_total: 8,
+    })
+    render(<AgenticOs />)
+    expect(screen.getByText('1 of 8 PRs in flight')).toBeInTheDocument()
+  })
+
+  it('names the referenced issue on a PR that carries no label at all', () => {
+    // This is the #909 case: the PR is unlabelled, and the backlog issue it
+    // references is the only reason it belongs on the page. If the panel
+    // cannot say so, a reader cannot check the rule against the rows.
+    loadAgenticOsStatus.mockReturnValue({
+      ...BASE,
+      in_flight_prs: [pr({ labels: [], linked_agentic_issues: [730, 841] })],
+      in_flight_prs_rule: RULE,
+      open_prs_total: 8,
+    })
+    render(<AgenticOs />)
+    expect(screen.getByText(/refs #730, #841/)).toBeInTheDocument()
+  })
+
+  it('distinguishes an empty panel from a dead one when nothing matches', () => {
+    loadAgenticOsStatus.mockReturnValue({
+      ...BASE,
+      in_flight_prs: [],
+      in_flight_prs_rule: RULE,
+      open_prs_total: 8,
+    })
+    render(<AgenticOs />)
+    expect(screen.getByText('0 of 8 PRs in flight')).toBeInTheDocument()
+    expect(
+      screen.getByText(/None of the 8 open pull requests are linked to this backlog/)
+    ).toBeInTheDocument()
+  })
+
+  it('degrades to the old wording on a feed generated before the fix', () => {
+    // Delivery is decoupled: the page ships before the next feed does, and a
+    // pre-#909 snapshot must still render rather than throw or show "of
+    // undefined".
+    loadAgenticOsStatus.mockReturnValue({ ...BASE, in_flight_prs: [pr({})] })
+    render(<AgenticOs />)
+    expect(screen.getByText('1 PRs in flight')).toBeInTheDocument()
+    expect(screen.queryByText(/What counts:/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/undefined/)).not.toBeInTheDocument()
+  })
+})

--- a/src/app/agentic-os/page.tsx
+++ b/src/app/agentic-os/page.tsx
@@ -91,6 +91,11 @@ function PrCard({ pr }: { pr: AgenticPr }) {
       <div className="text-sm text-gray-900">{pr.title}</div>
       <div className="mt-2 text-xs text-gray-500">
         {pr.assignee ?? 'unassigned'} · updated {relativeAge(pr.updated_at)}
+        {/* Why this PR is on the list. Most agent PRs carry no label at all —
+            the backlog issue they reference is what places them here. */}
+        {pr.linked_agentic_issues && pr.linked_agentic_issues.length > 0 && (
+          <> · refs {pr.linked_agentic_issues.map((n) => `#${n}`).join(', ')}</>
+        )}
       </div>
     </div>
   )
@@ -213,7 +218,12 @@ export default function AgenticOsStatus() {
           {data.backlog_issues.length} backlog issues
         </span>
         <span className="inline-flex items-center gap-1.5 rounded-full border border-gray-200 bg-white px-3 py-1 text-sm font-semibold text-gray-800">
-          {data.in_flight_prs.length} PRs in flight
+          {/* Shown as a fraction of all open PRs when the feed provides the
+              denominator. "0 of 8" reads as a filter problem; a bare "0" does
+              not — see #909. */}
+          {typeof data.open_prs_total === 'number'
+            ? `${data.in_flight_prs.length} of ${data.open_prs_total} PRs in flight`
+            : `${data.in_flight_prs.length} PRs in flight`}
         </span>
         <span className="inline-flex items-center gap-1.5 rounded-full border border-gray-200 bg-white px-3 py-1 text-sm font-semibold text-gray-800">
           {data.pending_gates.length} gates waiting
@@ -237,8 +247,20 @@ export default function AgenticOsStatus() {
 
       <section className="mb-10">
         <h2 className="mb-3 text-xl font-bold text-gray-900">Pull requests in flight</h2>
+        {/* State the inclusion rule on the page. A count with no stated
+            definition cannot be checked by a reader, and an empty panel cannot
+            be told apart from a broken one (#909). */}
+        {data.in_flight_prs_rule && (
+          <p className="mb-4 text-sm text-gray-600">
+            <span className="font-semibold">What counts:</span> {data.in_flight_prs_rule}
+          </p>
+        )}
         {data.in_flight_prs.length === 0 ? (
-          <p className="text-sm text-gray-500">No open Agentic OS pull requests right now.</p>
+          <p className="text-sm text-gray-500">
+            {data.open_prs_total
+              ? `None of the ${data.open_prs_total} open pull requests are linked to this backlog.`
+              : 'No open Agentic OS pull requests right now.'}
+          </p>
         ) : (
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
             {data.in_flight_prs.map((pr) => (

--- a/src/app/agentic-os/page.tsx
+++ b/src/app/agentic-os/page.tsx
@@ -228,8 +228,10 @@ export default function AgenticOsStatus() {
           {/* Shown as a fraction of all open PRs when the feed provides the
               denominator. "0 of 8" reads as a filter problem; a bare "0" does
               not — see #909. */}
+          {/* In the fraction form the noun agrees with the total, not the
+              numerator: "1 of 8 PRs", "1 of 1 PR". */}
           {typeof data.open_prs_total === 'number'
-            ? `${data.in_flight_prs.length} of ${data.open_prs_total} ${prLabel(data.in_flight_prs.length)} in flight`
+            ? `${data.in_flight_prs.length} of ${data.open_prs_total} ${prLabel(data.open_prs_total)} in flight`
             : `${data.in_flight_prs.length} ${prLabel(data.in_flight_prs.length)} in flight`}
         </span>
         <span className="inline-flex items-center gap-1.5 rounded-full border border-gray-200 bg-white px-3 py-1 text-sm font-semibold text-gray-800">

--- a/src/app/agentic-os/page.tsx
+++ b/src/app/agentic-os/page.tsx
@@ -25,6 +25,13 @@ const STATUS_JSON_HREF = assetPath('/data/agentic-os-status.json')
 const CONDUCTOR_LOG_HREF = 'https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719'
 const STATUS_ISSUE_HREF = 'https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/723'
 
+/** "PR" / "PRs" for the in-flight chip. Scoped to the chip this change touches
+ * — the sibling backlog/gates chips have the same singular wording issue and
+ * are left for a change that is actually about them. */
+function prLabel(count: number) {
+  return count === 1 ? 'PR' : 'PRs'
+}
+
 function labelBadges(labels: string[] | null | undefined) {
   // The `agentic-os` label is on everything here; surface only the extra labels.
   // Guard for a malformed feed: a null/non-array `labels` must not throw at
@@ -222,8 +229,8 @@ export default function AgenticOsStatus() {
               denominator. "0 of 8" reads as a filter problem; a bare "0" does
               not — see #909. */}
           {typeof data.open_prs_total === 'number'
-            ? `${data.in_flight_prs.length} of ${data.open_prs_total} PRs in flight`
-            : `${data.in_flight_prs.length} PRs in flight`}
+            ? `${data.in_flight_prs.length} of ${data.open_prs_total} ${prLabel(data.in_flight_prs.length)} in flight`
+            : `${data.in_flight_prs.length} ${prLabel(data.in_flight_prs.length)} in flight`}
         </span>
         <span className="inline-flex items-center gap-1.5 rounded-full border border-gray-200 bg-white px-3 py-1 text-sm font-semibold text-gray-800">
           {data.pending_gates.length} gates waiting
@@ -257,9 +264,15 @@ export default function AgenticOsStatus() {
         )}
         {data.in_flight_prs.length === 0 ? (
           <p className="text-sm text-gray-500">
-            {data.open_prs_total
-              ? `None of the ${data.open_prs_total} open pull requests are linked to this backlog.`
-              : 'No open Agentic OS pull requests right now.'}
+            {/* `open_prs_total: 0` is a real reading — no PR is open at all —
+                and a distinct statement from "some are open, none of them are
+                linked". A truthiness check would collapse the two, which is
+                the same conflation this panel exists to undo. */}
+            {typeof data.open_prs_total !== 'number'
+              ? 'No open Agentic OS pull requests right now.'
+              : data.open_prs_total === 0
+                ? 'No pull requests are open on the hub.'
+                : `None of the ${data.open_prs_total} open pull requests are linked to this backlog.`}
           </p>
         ) : (
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">

--- a/src/lib/dashboardData.ts
+++ b/src/lib/dashboardData.ts
@@ -104,6 +104,9 @@ export interface AgenticIssue {
 
 export interface AgenticPr extends AgenticIssue {
   draft: boolean
+  /** Agentic-os issues this PR references — why it counts as in flight.
+   * Optional: a feed generated before the #909 fix will not carry it. */
+  linked_agentic_issues?: number[]
 }
 
 export interface AgenticLogEntry {
@@ -129,6 +132,14 @@ export interface AgenticOsStatusData {
   in_flight_prs: AgenticPr[]
   conductor_log: AgenticLogEntry[]
   pending_gates: AgenticGate[]
+  /** The rule the generator used to decide what counts as "in flight", stated
+   * in the feed so the page renders the definition instead of keeping a second
+   * copy of it that can drift. Optional — feeds predating #909 lack it. */
+  in_flight_prs_rule?: string
+  /** Every open PR on the hub, unfiltered. The denominator matters: a panel
+   * showing a bare 0 is indistinguishable from a panel whose filter is dead,
+   * which is exactly how #909 went unnoticed while 8 PRs were open. */
+  open_prs_total?: number
 }
 
 function readJson<T>(file: string): T | null {


### PR DESCRIPTION
The page half of [FreeForCharity/FFC-Cloudflare-Automation#909](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/909). The generator fix is [hub PR #913](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/913).

## Why this half exists

The hub's filter required an `agentic-os` label **on the pull request**, and nothing labels pull requests — so the panel read `0` while eight agent PRs were open. That is the hub's bug. What let it sit there unnoticed is this page: it rendered a bare count, with no stated rule and no denominator, so **an empty panel and a dead panel looked identical**. Fixing only the filter would leave the next silent failure just as invisible.

## Changes

| Change | Why |
| --- | --- |
| Chip reads **"4 of 8 PRs in flight"** | A fraction is a claim a reader can check. `0 of 8` reads as a filter problem; a bare `0` does not. |
| Section states the inclusion rule in words | Read from the feed's own `in_flight_prs_rule`, not a second copy in the page that can drift from the generator. |
| Each card names its backlog issue — `refs #730` | Most agent PRs carry no label at all; the referenced issue is the entire reason the PR is listed. |
| Empty state says *which* empty it is | "None of the 8 open pull requests are linked to this backlog" vs. nothing open. |

The acceptance criterion this satisfies verbatim: *"The rendered page states the inclusion rule in words."*

## Backward compatibility

All three new feed fields (`in_flight_prs_rule`, `open_prs_total`, per-row `linked_agentic_issues`) are **optional** in `AgenticOsStatusData` / `AgenticPr` and guarded at each call site. Delivery is decoupled — this page ships before the next feed does, and the currently-committed snapshot predates the fix — so a pre-#909 snapshot must render the old wording rather than throw or print "of undefined". That is one of the tests.

There is a further reason it may render the old shape for a while: the feed is regenerated by hub workflow 502's `deliver` job, which needs `read-all-cbm-github-pat` — currently returning **401** (FFC-Cloudflare-Automation#877). The page degrades cleanly until that is reminted.

## Verification

- `pnpm test` → **1170 passed, 69 suites**
- `pnpm run lint` → clean · `pnpm run type-check` → clean · `pnpm run build` → static export, 163 pages
- New: `__tests__/agentic-os-in-flight-panel.test.js`, 5 cases. **Verified they bite:** reverting `page.tsx` to `main` fails 4 of the 5; the fifth is the backward-compatibility case, which must pass either way by design.

**`pnpm run test:e2e` could not run in this sandbox** and I am not claiming it passed. Playwright resolves a pinned browser build (`chromium_headless_shell-1228`) that this image does not carry — it has `chromium-1194` — so every spec fails identically at `browserType.launch: Executable doesn't exist`, before any page loads. The image's own instructions say not to run `playwright install`. Nothing here touches a path covered by `e2e/smoke.spec.ts`; CI is authoritative.

Refs FreeForCharity/FFC-Cloudflare-Automation#909

---
_Generated by [Claude Code](https://claude.ai/code/session_01EHrLY6N8JTT3ArZck283cP)_