### PR TITLE
feat(ci): reconcile data-refresh PRs that fall behind main

### DIFF
--- a/.github/workflows/reconcile-data-prs.yml
+++ b/.github/workflows/reconcile-data-prs.yml
@@ -1,0 +1,72 @@
+name: Reconcile Data PRs
+run-name: 'Reconcile data PRs: ${{ github.event_name }}'
+
+# Unsticks the long-lived data-refresh PRs (FFC-Cloudflare-Automation#908).
+#
+# Ruleset "Merge Queue + Branch Up-to-Date" requires a PR branch be current with
+# `main`. While one data PR waits, the others merge and it falls behind; its
+# auto-merge stays armed but never enqueues, and nothing issues an "Update
+# branch". On 2026-07-29 three public dashboards served stale data for ~6h that
+# way, with every check green.
+#
+# The race is lost after the creating workflow has exited, so this watches from
+# outside it: every 30 minutes across the window the data workflows run in
+# (their crons are 05:00-09:00 UTC), update any behind `data/*` PR and arm
+# auto-merge where the creating workflow never did.
+#
+# Writes only to PR branches already opened by the data workflows (update-branch
+# + auto-merge). No deployment environment, no external API, no credential
+# beyond the ambient GITHUB_TOKEN, so this is ungated by design.
+#
+# A PR still un-reconciled after STUCK_AFTER_HOURS fails this run on purpose: a
+# red scheduled run is what the existing failure-alert layer already watches
+# (FFC-Cloudflare-Automation#843 / #832), so no second alerting path is built
+# here. The six-hour outage was invisible, and that is the part that cost time.
+
+on:
+  schedule:
+    # Every 30 min, 05:00-15:00 UTC — covers every data cron plus the margin the
+    # 2026-07-29 stall needed (06:53 -> 13:07). Deliberately not all day: the
+    # REST budget is shared org-wide (hub AGENTS.md).
+    - cron: '*/30 5-15 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Report only; do not update branches or arm auto-merge'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  # Single shared group so a scheduled and a dispatched run serialize and can
+  # never race each other on the same PR branch.
+  group: reconcile-data-prs
+  cancel-in-progress: false
+
+jobs:
+  reconcile:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # update-branch pushes a merge commit to the PR branch
+      pull-requests: write # arm auto-merge
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      # No dependency install: the script uses only Node built-ins and fetch.
+      - name: Reconcile open data PRs
+        run: node scripts/reconcile-data-prs.mjs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          # Folded scalar (`>-`) so this is unambiguously a string, not a mapping.
+          DRY_RUN: >-
+            ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run || 'false' }}

--- a/__tests__/reconcile-data-prs.test.js
+++ b/__tests__/reconcile-data-prs.test.js
@@ -461,6 +461,49 @@ describe('main() wiring (mocked API, no network)', () => {
     await expect(main()).resolves.toBeUndefined()
   })
 
+  it('treats a 422 as benign when the branch turns out to be current', async () => {
+    // Another actor can update the branch between our compare and our PUT. The
+    // response is a 422 either way, so the message is not the discriminator —
+    // re-reading the comparison is. A false `blocked` here would fail the run
+    // with nothing wrong, and an alert that cries wolf gets ignored.
+    let compares = 0
+    global.fetch = jest.fn(async (url) => {
+      const u = String(url).replace('https://api.github.com', '')
+      if (u.includes('/pulls?state=open')) {
+        return reply(200, [apiPr({ number: 750 })])
+      }
+      if (u.includes('/compare/')) {
+        compares += 1
+        return reply(200, { behind_by: compares === 1 ? 3 : 0 })
+      }
+      if (u.endsWith('/update-branch')) return reply(422, { message: 'Unprocessable Entity' })
+      throw new Error(`unexpected request: ${u}`)
+    })
+    await expect(main()).resolves.toBeUndefined()
+    expect(compares).toBe(2)
+  })
+
+  it('still blocks on a 422 when the branch is genuinely behind', async () => {
+    fakeApi({
+      pulls: [apiPr({ number: 751 })],
+      behind: { 'data/ci-status': 3 },
+      updateBranch: { status: 422, message: 'merge conflict between base and head' },
+    })
+    await expect(main()).rejects.toThrow(/merge conflict/)
+  })
+
+  it('spends no compare call on a draft', async () => {
+    // Drafts are skipped whatever the comparison says, and the REST budget is
+    // shared org-wide.
+    const calls = fakeApi({
+      pulls: [apiPr({ number: 744, draft: true, auto_merge: null, created_at: hoursAgo(30) })],
+      behind: { 'data/ci-status': 7 },
+    })
+    await main()
+    expect(calls.some((c) => c.includes('/compare/'))).toBe(false)
+    expect(calls.some((c) => c.startsWith('PUT') || c === 'POST /graphql')).toBe(false)
+  })
+
   it('fails the run on a conflict a human has to resolve', async () => {
     fakeApi({
       pulls: [apiPr({ number: 741 })],
@@ -491,6 +534,63 @@ describe('main() wiring (mocked API, no network)', () => {
   it('surfaces an API failure instead of exiting clean', async () => {
     global.fetch = jest.fn(async () => reply(500, { message: 'server error' }))
     await expect(main()).rejects.toThrow(/500/)
+  })
+})
+
+describe('entrypoint guard (spawned, not mocked)', () => {
+  const { execFileSync } = require('child_process')
+  const os = require('os')
+
+  /** Runs the script as the workflow does and returns { code, output }. */
+  const run = (cwd, script) => {
+    const env = { ...process.env }
+    delete env.GITHUB_TOKEN // so a running main() identifies itself by failing
+    delete env.GH_TOKEN
+    try {
+      const stdout = execFileSync('node', [script], { cwd, env, encoding: 'utf8' })
+      return { code: 0, output: stdout }
+    } catch (e) {
+      return { code: e.status, output: `${e.stdout || ''}${e.stderr || ''}` }
+    }
+  }
+
+  // The failure mode: if the guard does not match, main() never runs and the
+  // workflow exits 0 having done nothing — a green run that reconciled nothing,
+  // which is precisely the invisibility this whole script exists to remove. So
+  // assert main() RAN, via the one message only main() can produce.
+  const ITS_ALIVE = /GITHUB_TOKEN is required/
+
+  it('runs main() when invoked the way the workflow invokes it', () => {
+    const { code, output } = run(process.cwd(), 'scripts/reconcile-data-prs.mjs')
+    expect(output).toMatch(ITS_ALIVE)
+    expect(code).toBe(1)
+  })
+
+  it('runs main() from a path containing a space', () => {
+    // `file://${process.argv[1]}` fails here while pathToFileURL() does not:
+    // import.meta.url percent-encodes the space, the concatenation does not.
+    // Verified: the naive form yields false and the script exits 0 silently.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'has space-'))
+    try {
+      const scripts = path.join(dir, 'scripts')
+      fs.mkdirSync(scripts)
+      fs.copyFileSync(
+        path.join(process.cwd(), 'scripts', 'reconcile-data-prs.mjs'),
+        path.join(scripts, 'reconcile-data-prs.mjs')
+      )
+      const { code, output } = run(dir, 'scripts/reconcile-data-prs.mjs')
+      expect(output).toMatch(ITS_ALIVE)
+      expect(code).toBe(1)
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('does not run main() on import', async () => {
+    // The other half of the contract: importing for tests must not fire the run.
+    // If it did, this suite would already have hit the network.
+    const mod = await import('../scripts/reconcile-data-prs.mjs')
+    expect(typeof mod.main).toBe('function')
   })
 })
 

--- a/__tests__/reconcile-data-prs.test.js
+++ b/__tests__/reconcile-data-prs.test.js
@@ -1,0 +1,542 @@
+/**
+ * Unit tests for the data-PR reconciler (`scripts/reconcile-data-prs.mjs`) and
+ * its workflow — FFC-Cloudflare-Automation#908.
+ *
+ * Two things are locked in here:
+ *
+ *  1. The decision logic, exercised directly (no network): what gets updated,
+ *     what gets auto-merge armed, what is left alone, and when the run must go
+ *     red instead of reporting a silent success.
+ *  2. Coverage against drift: every workflow that opens a PR on a long-lived
+ *     refresh branch must use a branch the reconciler actually sweeps. A future
+ *     data workflow on a differently-named branch would otherwise be quietly
+ *     uncovered — the same class of invisibility this issue is about.
+ */
+
+const fs = require('fs')
+const path = require('path')
+const yaml = require('js-yaml')
+
+const HOUR = 3600000
+
+let isDataBranch,
+  planFor,
+  decideRunOutcome,
+  buildSummary,
+  main,
+  DATA_BRANCH_PREFIX,
+  DEFAULT_STUCK_AFTER_MS
+
+beforeAll(async () => {
+  // Read at module scope by the script, so they must be set before the import.
+  process.env.GITHUB_TOKEN = 'test-token'
+  process.env.GITHUB_REPOSITORY = 'FreeForCharity/FFC-IN-ffcadmin.org'
+  delete process.env.GITHUB_STEP_SUMMARY
+  const mod = await import('../scripts/reconcile-data-prs.mjs')
+  isDataBranch = mod.isDataBranch
+  planFor = mod.planFor
+  decideRunOutcome = mod.decideRunOutcome
+  buildSummary = mod.buildSummary
+  main = mod.main
+  DATA_BRANCH_PREFIX = mod.DATA_BRANCH_PREFIX
+  DEFAULT_STUCK_AFTER_MS = mod.DEFAULT_STUCK_AFTER_MS
+})
+
+/** The long-lived data branches named in the issue's acceptance criteria. */
+const ACCEPTANCE_BRANCHES = [
+  'data/applications-sync-state',
+  'data/campaigns-registry',
+  'data/ci-status',
+  'data/domain-expiry',
+  'data/fleet-smoke-status',
+  'data/roadmap',
+  'data/sites-list-sync',
+  'data/volunteer-hours',
+]
+
+const NOW = Date.UTC(2026, 6, 30, 12, 0, 0)
+const pr = (over = {}) => ({
+  number: 1,
+  headRef: 'data/ci-status',
+  draft: false,
+  autoMergeEnabled: true,
+  behindBy: 0,
+  createdAtMs: NOW - 10 * 60 * 1000,
+  ...over,
+})
+
+describe('branch selection', () => {
+  it('covers every long-lived data branch the issue names', () => {
+    for (const branch of ACCEPTANCE_BRANCHES) {
+      expect(isDataBranch(branch)).toBe(true)
+    }
+  })
+
+  it('ignores branches that are not data-refresh branches', () => {
+    expect(isDataBranch('main')).toBe(false)
+    expect(isDataBranch('dependabot/npm_and_yarn/js-yaml-5.2.2')).toBe(false)
+    expect(isDataBranch('claude/some-feature')).toBe(false)
+    // Not a prefix match by accident: the separator has to be there.
+    expect(isDataBranch('database-migration')).toBe(false)
+  })
+
+  it('tolerates a missing or non-string ref', () => {
+    expect(isDataBranch(undefined)).toBe(false)
+    expect(isDataBranch(null)).toBe(false)
+    expect(isDataBranch(42)).toBe(false)
+  })
+})
+
+describe('planFor', () => {
+  it('asks for nothing when the PR is current and already armed', () => {
+    const plan = planFor(pr(), { nowMs: NOW })
+    expect(plan.needsUpdate).toBe(false)
+    expect(plan.needsAutoMerge).toBe(false)
+    expect(plan.old).toBe(false)
+  })
+
+  it('asks for an update when the branch is behind', () => {
+    const plan = planFor(pr({ behindBy: 4 }), { nowMs: NOW })
+    expect(plan.needsUpdate).toBe(true)
+    expect(plan.behindBy).toBe(4)
+  })
+
+  it('arms auto-merge when the creating workflow never did', () => {
+    // The live case: update-sites-data.yml has no auto-merge step at all, so
+    // PR #732 sat open for three days at behind=28 and could not merge itself
+    // even from behind=0.
+    const plan = planFor(
+      pr({ headRef: 'data/sites-list-sync', autoMergeEnabled: false, behindBy: 28 }),
+      { nowMs: NOW }
+    )
+    expect(plan.needsAutoMerge).toBe(true)
+    expect(plan.needsUpdate).toBe(true)
+  })
+
+  it('leaves a draft data PR entirely alone', () => {
+    // Auto-merge cannot be armed on a draft, and a draft data PR is a human
+    // holding it deliberately.
+    const plan = planFor(pr({ draft: true, behindBy: 9, autoMergeEnabled: false }), { nowMs: NOW })
+    expect(plan.needsUpdate).toBe(false)
+    expect(plan.needsAutoMerge).toBe(false)
+    expect(plan.old).toBe(false)
+  })
+
+  it('does not call a young PR old', () => {
+    const plan = planFor(pr({ behindBy: 2, createdAtMs: NOW - 20 * 60 * 1000 }), { nowMs: NOW })
+    expect(plan.needsUpdate).toBe(true)
+    expect(plan.old).toBe(false)
+  })
+
+  it('marks a PR past the threshold as old, on age alone', () => {
+    // Deliberately age-only: whether it is stuck is decided from the state after
+    // this cycle's remedies, so a PR the reconciler just rescued is not flagged
+    // for the plan it arrived with.
+    expect(planFor(pr({ behindBy: 2, createdAtMs: NOW - 6 * HOUR }), { nowMs: NOW }).old).toBe(true)
+    expect(planFor(pr({ createdAtMs: NOW - 24 * HOUR }), { nowMs: NOW }).old).toBe(true)
+  })
+
+  it('honours an overridden stuck threshold', () => {
+    const args = { nowMs: NOW, stuckAfterMs: 30 * 60 * 1000 }
+    expect(planFor(pr({ behindBy: 1, createdAtMs: NOW - HOUR }), args).old).toBe(true)
+  })
+
+  it('defaults the threshold to three hours', () => {
+    expect(DEFAULT_STUCK_AFTER_MS).toBe(3 * HOUR)
+  })
+})
+
+describe('decideRunOutcome', () => {
+  const result = (over = {}) => ({
+    number: 5,
+    headRef: 'data/ci-status',
+    behindBy: 0,
+    autoMergeEnabled: true,
+    ageMs: HOUR,
+    old: false,
+    progressing: false,
+    outcome: 'ok',
+    reason: '',
+    actions: [],
+    ...over,
+  })
+
+  it('passes when there is nothing open', () => {
+    expect(decideRunOutcome([]).failed).toBe(false)
+  })
+
+  it('passes when every PR is current', () => {
+    expect(decideRunOutcome([result(), result({ number: 6 })]).failed).toBe(false)
+  })
+
+  it('passes on a young PR reconciled this cycle', () => {
+    // Recovering without a human, within the cycle, is a success — not an alert.
+    const verdict = decideRunOutcome([
+      result({ outcome: 'reconciled', actions: ['update-branch'], old: false }),
+    ])
+    expect(verdict.failed).toBe(false)
+  })
+
+  it('still reports a long-stuck PR it managed to rescue', () => {
+    // Reconciliation makes the dashboards current again; it does not make the
+    // six-hour stall un-happen, and the producer workflow needs fixing.
+    const verdict = decideRunOutcome([
+      result({ outcome: 'reconciled', old: true, ageMs: 6 * HOUR, actions: ['update-branch'] }),
+    ])
+    expect(verdict.failed).toBe(true)
+    expect(verdict.reasons[0]).toMatch(/open 6h, now current and armed but not merged/)
+  })
+
+  it('does not report a PR the merge queue already owns', () => {
+    const verdict = decideRunOutcome([
+      result({ outcome: 'reconciled', old: true, ageMs: 5 * HOUR, progressing: true }),
+    ])
+    expect(verdict.failed).toBe(false)
+  })
+
+  it('fails on a blocked PR even when it is young', () => {
+    const verdict = decideRunOutcome([
+      result({ outcome: 'blocked', reason: 'update-branch 409: merge conflict' }),
+    ])
+    expect(verdict.failed).toBe(true)
+    expect(verdict.reasons.join(' ')).toContain('merge conflict')
+  })
+
+  it('fails on a stuck PR that reconciliation did not fix', () => {
+    const verdict = decideRunOutcome([
+      result({ outcome: 'reconciled', old: true, ageMs: 6 * HOUR, behindBy: 4 }),
+    ])
+    expect(verdict.failed).toBe(true)
+    expect(verdict.reasons[0]).toMatch(/still un-reconciled after 6h/)
+  })
+
+  it('does not double-report a PR that is both blocked and stuck', () => {
+    const verdict = decideRunOutcome([
+      result({ outcome: 'blocked', reason: 'boom', old: true, ageMs: 5 * HOUR }),
+    ])
+    expect(verdict.reasons).toHaveLength(1)
+  })
+
+  it('reports but does not enforce the verdict in dry-run', () => {
+    // Nothing was attempted, so "still needs work" is the expected state; a red
+    // run for a preview would be a lie about the repo's health.
+    const results = [result({ outcome: 'blocked', reason: 'boom' })]
+    expect(decideRunOutcome(results, { dryRun: true }).failed).toBe(false)
+    expect(decideRunOutcome(results, { dryRun: true }).reasons).toHaveLength(1)
+  })
+
+  it('ignores a skipped draft', () => {
+    const verdict = decideRunOutcome([
+      result({ outcome: 'skipped', reason: 'draft', old: true, ageMs: 30 * HOUR }),
+    ])
+    expect(verdict.failed).toBe(false)
+  })
+})
+
+describe('buildSummary', () => {
+  const rec = {
+    number: 732,
+    headRef: 'data/sites-list-sync',
+    behindBy: 28,
+    autoMergeEnabled: false,
+    ageMs: 72 * HOUR,
+    old: true,
+    progressing: false,
+    outcome: 'reconciled',
+    reason: '',
+    actions: ['update-branch', 'enable auto-merge'],
+  }
+
+  it('says so plainly when there is nothing to do', () => {
+    expect(buildSummary([])).toContain('Nothing to reconcile')
+  })
+
+  it('renders one row per PR with the action taken', () => {
+    const out = buildSummary([rec])
+    expect(out).toContain('#732')
+    expect(out).toContain('data/sites-list-sync')
+    expect(out).toContain('update-branch')
+    expect(out).toContain('enable auto-merge')
+  })
+
+  it('surfaces the needs-attention reasons under their own heading', () => {
+    const verdict = { failed: true, reasons: ['#732 (data/sites-list-sync): conflict'] }
+    const out = buildSummary([rec], { verdict })
+    expect(out).toContain('Needs attention')
+    expect(out).toContain('#732 (data/sites-list-sync): conflict')
+  })
+
+  it('marks a dry-run as unenforced so a green run is not misread', () => {
+    const verdict = { failed: false, reasons: ['#732: would update'] }
+    expect(buildSummary([rec], { dryRun: true, verdict })).toContain('not enforced')
+  })
+})
+
+describe('reconcile-data-prs.yml workflow contract', () => {
+  const workflowsDir = path.join(process.cwd(), '.github', 'workflows')
+  const workflowPath = path.join(workflowsDir, 'reconcile-data-prs.yml')
+  let workflow
+
+  beforeAll(() => {
+    workflow = yaml.load(fs.readFileSync(workflowPath, 'utf-8'))
+  })
+
+  it('exists and runs on a schedule as well as on demand', () => {
+    expect(fs.existsSync(workflowPath)).toBe(true)
+    // js-yaml parses a bare `on:` key as the boolean true.
+    const on = workflow.on ?? workflow[true]
+    expect(on).toHaveProperty('schedule')
+    expect(on).toHaveProperty('workflow_dispatch')
+    expect(on.schedule[0].cron).toBe('*/30 5-15 * * *')
+  })
+
+  it('covers the window the data workflows actually run in', () => {
+    // Every data cron must fall inside the reconciler's hour range, or a
+    // producer could open a PR the reconciler never looks at that day.
+    const [, hourRange] = (workflow.on ?? workflow[true]).schedule[0].cron.split(' ')
+    const [from, to] = hourRange.split('-').map(Number)
+    const producerHours = fs
+      .readdirSync(workflowsDir)
+      .filter((f) => f.endsWith('.yml') && f !== 'reconcile-data-prs.yml')
+      .flatMap((f) => {
+        const doc = yaml.load(fs.readFileSync(path.join(workflowsDir, f), 'utf-8'))
+        const on = doc?.on ?? doc?.[true]
+        const schedule = on?.schedule
+        if (!Array.isArray(schedule)) return []
+        const opensDataPr = JSON.stringify(doc).includes(DATA_BRANCH_PREFIX)
+        if (!opensDataPr) return []
+        return schedule.map((s) => Number(String(s.cron).split(' ')[1]))
+      })
+    expect(producerHours.length).toBeGreaterThan(0)
+    for (const hour of producerHours) {
+      expect(hour).toBeGreaterThanOrEqual(from)
+      expect(hour).toBeLessThanOrEqual(to)
+    }
+  })
+
+  it('has the write scopes both remedies need, and no more', () => {
+    const job = workflow.jobs.reconcile
+    expect(job.permissions.contents).toBe('write') // update-branch
+    expect(job.permissions['pull-requests']).toBe('write') // auto-merge
+    expect(job.permissions.issues).toBeUndefined()
+  })
+
+  it('is ungated — no deployment environment', () => {
+    expect(workflow.jobs.reconcile.environment).toBeUndefined()
+  })
+
+  it('serializes runs so two cycles cannot race the same branch', () => {
+    expect(workflow.concurrency.group).toBe('reconcile-data-prs')
+    expect(workflow.concurrency['cancel-in-progress']).toBe(false)
+  })
+
+  it('runs the reconciler script with a token', () => {
+    const step = workflow.jobs.reconcile.steps.find((s) => s.run?.includes('reconcile-data-prs'))
+    expect(step).toBeDefined()
+    expect(step.run).toContain('node scripts/reconcile-data-prs.mjs')
+    expect(step.env.GITHUB_TOKEN).toContain('secrets.GITHUB_TOKEN')
+    expect(step.env.DRY_RUN).toBeDefined()
+  })
+})
+
+describe('main() wiring (mocked API, no network)', () => {
+  const realFetch = global.fetch
+  const hoursAgo = (h) => new Date(Date.now() - h * HOUR).toISOString()
+
+  const reply = (status, body) => ({
+    ok: status < 300,
+    status,
+    text: async () => JSON.stringify(body),
+    json: async () => body,
+  })
+
+  const apiPr = (over = {}) => ({
+    number: 100,
+    node_id: 'PR_kwnode1',
+    draft: false,
+    auto_merge: { merge_method: 'merge' },
+    created_at: hoursAgo(0.2),
+    head: { ref: 'data/ci-status' },
+    base: { ref: 'main' },
+    ...over,
+  })
+
+  /** Routes the four calls the script makes, and records them in order. */
+  const fakeApi = ({ pulls, behind = {}, updateBranch = {}, graphqlError = null }) => {
+    const calls = []
+    global.fetch = jest.fn(async (url, init = {}) => {
+      const u = String(url).replace('https://api.github.com', '')
+      calls.push(`${init.method || 'GET'} ${u}`)
+      if (u.includes('/pulls?state=open')) return reply(200, pulls)
+      if (u.includes('/compare/')) {
+        const head = decodeURIComponent(u.split('...')[1])
+        return reply(200, { behind_by: behind[head] ?? 0 })
+      }
+      if (u.endsWith('/update-branch')) {
+        const status = updateBranch.status ?? 202
+        return reply(status, { message: updateBranch.message ?? 'Updating pull request branch.' })
+      }
+      if (u === '/graphql') {
+        return reply(200, graphqlError ? { errors: [{ message: graphqlError }] } : { data: {} })
+      }
+      throw new Error(`unexpected request: ${u}`)
+    })
+    return calls
+  }
+
+  afterEach(() => {
+    global.fetch = realFetch
+    delete process.env.DRY_RUN
+    jest.restoreAllMocks()
+  })
+
+  it('ignores PRs that are not on data branches', async () => {
+    const calls = fakeApi({
+      pulls: [apiPr({ number: 730, head: { ref: 'dependabot/npm_and_yarn/js-yaml-5.2.2' } })],
+    })
+    await main()
+    expect(calls).toEqual([
+      'GET /repos/FreeForCharity/FFC-IN-ffcadmin.org/pulls?state=open&per_page=100',
+    ])
+  })
+
+  it('updates a branch that has fallen behind', async () => {
+    const calls = fakeApi({
+      pulls: [apiPr({ number: 739, head: { ref: 'data/ci-status' } })],
+      behind: { 'data/ci-status': 4 },
+    })
+    await main()
+    expect(calls).toContain('PUT /repos/FreeForCharity/FFC-IN-ffcadmin.org/pulls/739/update-branch')
+    // Already armed by its creating workflow — do not touch auto-merge.
+    expect(calls.some((c) => c.includes('/graphql'))).toBe(false)
+  })
+
+  it('arms auto-merge when the creating workflow never did', async () => {
+    const calls = fakeApi({
+      pulls: [apiPr({ number: 732, auto_merge: null, head: { ref: 'data/sites-list-sync' } })],
+    })
+    await main()
+    expect(calls).toContain('POST /graphql')
+    expect(calls.some((c) => c.includes('update-branch'))).toBe(false)
+  })
+
+  it('does both for the live #732 case: 28 behind and never armed', async () => {
+    const calls = fakeApi({
+      pulls: [
+        apiPr({
+          number: 732,
+          auto_merge: null,
+          created_at: hoursAgo(72),
+          head: { ref: 'data/sites-list-sync' },
+        }),
+      ],
+      behind: { 'data/sites-list-sync': 28 },
+    })
+    // It applies both remedies AND goes red: the PR had been open three days,
+    // which is the producer-workflow defect the humans need told about. Fixing
+    // the dashboard silently would leave that invisible all over again.
+    await expect(main()).rejects.toThrow(/#732/)
+    expect(calls).toContain('PUT /repos/FreeForCharity/FFC-IN-ffcadmin.org/pulls/732/update-branch')
+    expect(calls).toContain('POST /graphql')
+  })
+
+  it('mutates nothing in dry-run', async () => {
+    process.env.DRY_RUN = 'true'
+    const calls = fakeApi({
+      pulls: [apiPr({ auto_merge: null, created_at: hoursAgo(48) })],
+      behind: { 'data/ci-status': 12 },
+    })
+    await main() // must not throw despite being stuck: nothing was attempted
+    expect(calls.some((c) => c.startsWith('PUT') || c === 'POST /graphql')).toBe(false)
+  })
+
+  it('treats an already-queued PR as progressing, not broken', async () => {
+    // The hub's lesson: a queued branch rejects an update with 422 telling you to
+    // dequeue it. Reacting to that would fight the merge queue.
+    fakeApi({
+      pulls: [apiPr({ created_at: hoursAgo(5) })],
+      behind: { 'data/ci-status': 2 },
+      updateBranch: { status: 422, message: 'you must dequeue the associated pull request' },
+    })
+    await expect(main()).resolves.toBeUndefined()
+  })
+
+  it('fails the run on a conflict a human has to resolve', async () => {
+    fakeApi({
+      pulls: [apiPr({ number: 741 })],
+      behind: { 'data/ci-status': 3 },
+      updateBranch: { status: 409, message: 'merge conflict between base and head' },
+    })
+    await expect(main()).rejects.toThrow(/merge conflict/)
+  })
+
+  it('accepts an already-enabled auto-merge as success', async () => {
+    fakeApi({
+      // Young, so the age-based report cannot mask what this asserts: a
+      // race where another actor armed auto-merge first is a success, not an error.
+      pulls: [apiPr({ auto_merge: null, created_at: hoursAgo(0.2) })],
+      graphqlError: 'Pull request Auto merge is already enabled.',
+    })
+    await expect(main()).resolves.toBeUndefined()
+  })
+
+  it('fails the run when auto-merge cannot be armed at all', async () => {
+    fakeApi({
+      pulls: [apiPr({ auto_merge: null })],
+      graphqlError: 'Auto merge is not allowed on this repository',
+    })
+    await expect(main()).rejects.toThrow(/not allowed/)
+  })
+
+  it('surfaces an API failure instead of exiting clean', async () => {
+    global.fetch = jest.fn(async () => reply(500, { message: 'server error' }))
+    await expect(main()).rejects.toThrow(/500/)
+  })
+})
+
+describe('coverage of the data workflows (drift guard)', () => {
+  const workflowsDir = path.join(process.cwd(), '.github', 'workflows')
+
+  /** Every `branch:` a create-pull-request step pushes to, with its workflow. */
+  const prBranches = () => {
+    const found = []
+    for (const file of fs.readdirSync(workflowsDir).filter((f) => f.endsWith('.yml'))) {
+      const doc = yaml.load(fs.readFileSync(path.join(workflowsDir, file), 'utf-8'))
+      for (const job of Object.values(doc?.jobs || {})) {
+        for (const step of job?.steps || []) {
+          if (!String(step?.uses || '').startsWith('peter-evans/create-pull-request')) continue
+          if (step.with?.branch) found.push({ file, branch: step.with.branch })
+        }
+      }
+    }
+    return found
+  }
+
+  it('finds the data workflows at all (a guard that finds nothing guards nothing)', () => {
+    expect(prBranches().length).toBeGreaterThanOrEqual(8)
+  })
+
+  it('sweeps every branch a data workflow opens a PR on', () => {
+    for (const { file, branch } of prBranches()) {
+      expect(isDataBranch(branch)).toBe(true) // ${file} opens a PR the reconciler must cover
+      expect(file).toBeTruthy()
+    }
+  })
+
+  it('reaches the branches whose workflow never arms auto-merge', () => {
+    // These three open data PRs and have no `gh pr merge --auto` step, so the
+    // reconciler is the only thing that can ever merge them.
+    const unarmed = ['update-sites-data.yml', 'sync-applications.yml', 'whmcs-intake.yml']
+    for (const file of unarmed) {
+      const raw = fs.readFileSync(path.join(workflowsDir, file), 'utf-8')
+      const branches = prBranches()
+        .filter((b) => b.file === file)
+        .map((b) => b.branch)
+      expect(branches.length).toBeGreaterThan(0)
+      for (const branch of branches) expect(isDataBranch(branch)).toBe(true)
+      // If someone later adds auto-merge here, this assertion is the prompt to
+      // re-read the comment in reconcile-data-prs.mjs rather than a bug.
+      expect(raw).not.toContain('pr merge --auto')
+    }
+  })
+})

--- a/scripts/reconcile-data-prs.mjs
+++ b/scripts/reconcile-data-prs.mjs
@@ -33,6 +33,8 @@
  * an API failure — silence is the failure mode it exists to remove.
  */
 
+import { pathToFileURL } from 'url'
+
 const API = 'https://api.github.com'
 
 /** Long-lived data-refresh branches all share this prefix. */
@@ -203,25 +205,29 @@ export async function main() {
   const results = []
 
   for (const pr of pulls) {
-    const plan = planFor(
-      {
-        number: pr.number,
-        headRef: pr.head.ref,
-        draft: pr.draft,
-        autoMergeEnabled: Boolean(pr.auto_merge),
-        createdAtMs: new Date(pr.created_at).getTime(),
-        behindBy: await behindBy(pr),
-      },
-      { nowMs, stuckAfterMs }
-    )
-    const result = { ...plan, actions: [], outcome: 'ok', reason: '', progressing: false }
+    const base = {
+      number: pr.number,
+      headRef: pr.head.ref,
+      draft: pr.draft,
+      autoMergeEnabled: Boolean(pr.auto_merge),
+      createdAtMs: new Date(pr.created_at).getTime(),
+    }
 
-    if (plan.draft) {
-      result.outcome = 'skipped'
-      result.reason = 'draft — left for its author'
-      results.push(result)
+    // Drafts are skipped whatever the answer, so do not spend a compare call
+    // on them — the REST budget is shared org-wide (hub AGENTS.md).
+    if (pr.draft) {
+      results.push({
+        ...planFor({ ...base, behindBy: 0 }, { nowMs, stuckAfterMs }),
+        actions: [],
+        outcome: 'skipped',
+        reason: 'draft — left for its author',
+        progressing: false,
+      })
       continue
     }
+
+    const plan = planFor({ ...base, behindBy: await behindBy(pr) }, { nowMs, stuckAfterMs })
+    const result = { ...plan, actions: [], outcome: 'ok', reason: '', progressing: false }
 
     if (plan.needsUpdate) {
       if (dryRun) {
@@ -240,8 +246,20 @@ export async function main() {
           result.actions.push('skipped update-branch (in merge queue)')
           result.progressing = true
         } else {
-          result.outcome = 'blocked'
-          result.reason = `update-branch ${status}: ${message.slice(0, 120)}`
+          // A 422 can also mean the branch is already current: another actor (a
+          // human clicking "Update branch", the queue) got there between our
+          // compare and this call. Re-read the comparison rather than pattern-
+          // matching a message string we have never observed — behind=0 means
+          // there was nothing to do, and anything else (including a comparison
+          // we cannot re-read) stays blocked rather than being swallowed.
+          const recheck = await behindBy(pr).catch(() => null)
+          if (recheck === 0) {
+            result.actions.push('branch already current, nothing to update')
+            result.behindBy = 0
+          } else {
+            result.outcome = 'blocked'
+            result.reason = `update-branch ${status}: ${message.slice(0, 120)}`
+          }
         }
       }
     }
@@ -278,7 +296,11 @@ export async function main() {
 }
 
 // Only run when executed directly, so the pure helpers can be unit-tested.
-if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+// pathToFileURL, not `file://${argv[1]}`: import.meta.url percent-encodes the
+// path, so a checkout containing a space made the naive comparison false and
+// this script exit 0 having done nothing — matching the repo idiom in
+// fleet-audit.mjs and gate3-validate.mjs. Guarded by a spawn test.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   main().catch((err) => {
     console.error(err.message)
     process.exitCode = 1

--- a/scripts/reconcile-data-prs.mjs
+++ b/scripts/reconcile-data-prs.mjs
@@ -1,0 +1,286 @@
+#!/usr/bin/env node
+/**
+ * Keep the long-lived data-refresh PRs moving on their own
+ * (FFC-Cloudflare-Automation#908).
+ *
+ * Every data workflow in this repo pushes to a long-lived `data/*` branch via
+ * peter-evans/create-pull-request and (mostly) arms auto-merge. Ruleset
+ * "Merge Queue + Branch Up-to-Date" requires the branch be current with `main`,
+ * so while one data PR waits, the others merge into `main` and it falls behind.
+ * Auto-merge stays armed but never enqueues, and nothing issues an "Update
+ * branch" — the PR hangs indefinitely at `mergeable_state: unstable`: mergeable,
+ * all checks green, no conflicts. That is why it went unseen for six hours.
+ *
+ * The race is lost AFTER the creating workflow has exited, so the creating
+ * workflow is the wrong place to watch from. This is a periodic reconciler
+ * instead. Per cycle, for each open PR on a `data/*` branch:
+ *
+ *   1. behind `main`      -> PUT /pulls/{n}/update-branch
+ *   2. auto-merge not set -> enablePullRequestAutoMerge (GraphQL)
+ *
+ * Step 2 is not redundant with the workflows: `update-sites-data.yml`,
+ * `sync-applications.yml` and `whmcs-intake.yml` open data PRs and never arm
+ * auto-merge at all, so those could not merge themselves even from behind=0.
+ * Arming centrally also covers the next data workflow that forgets.
+ *
+ * Reporting: a PR that is still un-reconciled after STUCK_AFTER_HOURS fails
+ * this run. That is deliberate — a red scheduled run is what the existing
+ * failure-alert layer (FFC-Cloudflare-Automation#843 / #832) already watches,
+ * so this builds no second alerting path.
+ *
+ * Auth: the workflow's built-in GITHUB_TOKEN (contents: write, pull-requests:
+ * write). Unlike the data generators, this script does NOT degrade to exit 0 on
+ * an API failure — silence is the failure mode it exists to remove.
+ */
+
+const API = 'https://api.github.com'
+
+/** Long-lived data-refresh branches all share this prefix. */
+export const DATA_BRANCH_PREFIX = 'data/'
+
+/** A PR un-reconciled for longer than this is reported rather than left silent. */
+export const DEFAULT_STUCK_AFTER_MS = 3 * 60 * 60 * 1000
+
+/** True for the long-lived data-refresh branches this reconciler owns. */
+export function isDataBranch(ref) {
+  return typeof ref === 'string' && ref.startsWith(DATA_BRANCH_PREFIX)
+}
+
+/**
+ * What a single PR needs, before anything is attempted. Pure.
+ *
+ * `draft` matters because auto-merge cannot be armed on a draft: a draft data PR
+ * is a human deliberately holding it, so it is skipped rather than forced.
+ */
+export function planFor(pr, { nowMs, stuckAfterMs = DEFAULT_STUCK_AFTER_MS } = {}) {
+  const ageMs = Number.isFinite(pr.createdAtMs) ? nowMs - pr.createdAtMs : 0
+  const behindBy = Number.isFinite(pr.behindBy) ? pr.behindBy : 0
+  const needsUpdate = !pr.draft && behindBy > 0
+  const needsAutoMerge = !pr.draft && !pr.autoMergeEnabled
+  return {
+    number: pr.number,
+    headRef: pr.headRef,
+    draft: Boolean(pr.draft),
+    behindBy,
+    autoMergeEnabled: Boolean(pr.autoMergeEnabled),
+    ageMs,
+    needsUpdate,
+    needsAutoMerge,
+    // Age only. Whether it is actually stuck is decided from the state AFTER
+    // this cycle's remedies — judging it from the plan would flag a PR the
+    // reconciler had just rescued.
+    old: ageMs >= stuckAfterMs,
+  }
+}
+
+/**
+ * Whether the run should fail, from the post-action results. Pure.
+ *
+ * Two ways a data PR earns a human's attention:
+ *
+ *  - `blocked` — a conflict, or an API refusal we do not understand. Needs a
+ *    human by definition, at any age.
+ *  - still open past the stuck threshold. Note this fires even when every
+ *    remedy succeeded: a data PR that has been open for hours was stuck for
+ *    hours, and the producer workflow that let it happen is worth knowing about.
+ *    Reconciliation makes the dashboards current again; it does not make the
+ *    stall un-happen.
+ *
+ * A PR the merge queue already owns is `progressing`, not stuck — the queue is
+ * mid-merge and an update would fight it. In dry-run nothing was attempted, so
+ * the verdict is reported but not enforced.
+ */
+export function decideRunOutcome(results, { dryRun = false } = {}) {
+  const blocked = results.filter((r) => r.outcome === 'blocked')
+  const stuck = results.filter(
+    (r) => !blocked.includes(r) && r.old && !r.progressing && r.outcome !== 'skipped'
+  )
+  const reasons = []
+  for (const r of blocked) reasons.push(`#${r.number} (${r.headRef}): ${r.reason}`)
+  for (const r of stuck) {
+    const hours = Math.round(r.ageMs / 3600000)
+    reasons.push(
+      r.behindBy > 0 || !r.autoMergeEnabled
+        ? `#${r.number} (${r.headRef}): still un-reconciled after ${hours}h ` +
+            `(behind=${r.behindBy}, autoMerge=${r.autoMergeEnabled})`
+        : `#${r.number} (${r.headRef}): open ${hours}h, now current and armed but not merged — ` +
+            `check the required checks and review gate on it`
+    )
+  }
+  return { failed: !dryRun && reasons.length > 0, reasons }
+}
+
+/** Job-summary markdown. Pure. */
+export function buildSummary(results, { dryRun = false, verdict } = {}) {
+  const lines = [`## Data-PR reconciler${dryRun ? ' (dry-run)' : ''}`, '']
+  if (!results.length) {
+    lines.push('No open `data/*` PRs. Nothing to reconcile.')
+    return lines.join('\n')
+  }
+  lines.push('| PR | Branch | Behind | Auto-merge | Action | Outcome |')
+  lines.push('| --- | --- | --- | --- | --- | --- |')
+  for (const r of results) {
+    lines.push(
+      `| #${r.number} | \`${r.headRef}\` | ${r.behindBy} | ${r.autoMergeEnabled ? 'yes' : 'no'} | ` +
+        `${r.actions.length ? r.actions.join(', ') : '—'} | ${r.outcome}${r.reason ? ` (${r.reason})` : ''} |`
+    )
+  }
+  if (verdict?.reasons?.length) {
+    lines.push('', '### Needs attention', '')
+    for (const reason of verdict.reasons) lines.push(`- ${reason}`)
+    if (dryRun) lines.push('', '_Dry-run: verdict reported, not enforced._')
+  }
+  return lines.join('\n')
+}
+
+const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN
+const repo = process.env.GITHUB_REPOSITORY || 'FreeForCharity/FFC-IN-ffcadmin.org'
+
+function headers() {
+  return {
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+  }
+}
+
+async function gh(path, init = {}) {
+  const res = await fetch(`${API}${path}`, { ...init, headers: headers() })
+  const text = await res.text()
+  let body = null
+  if (text) {
+    try {
+      body = JSON.parse(text)
+    } catch {
+      body = { message: text.slice(0, 200) }
+    }
+  }
+  return { ok: res.ok, status: res.status, body }
+}
+
+async function ghJson(path) {
+  const { ok, status, body } = await gh(path)
+  if (!ok) throw new Error(`GitHub API ${path} -> ${status} ${body?.message || ''}`.trim())
+  return body
+}
+
+/** Open PRs on `data/*` branches. One page: this repo never has 100 open PRs. */
+async function listDataPulls() {
+  const pulls = await ghJson(`/repos/${repo}/pulls?state=open&per_page=100`)
+  return pulls.filter((p) => isDataBranch(p.head?.ref))
+}
+
+async function behindBy(pr) {
+  const cmp = await ghJson(
+    `/repos/${repo}/compare/${encodeURIComponent(pr.base.ref)}...${encodeURIComponent(pr.head.ref)}`
+  )
+  return Number.isFinite(cmp.behind_by) ? cmp.behind_by : 0
+}
+
+async function enableAutoMerge(nodeId) {
+  const query =
+    'mutation($id:ID!){enablePullRequestAutoMerge(input:{pullRequestId:$id,mergeMethod:MERGE})' +
+    '{pullRequest{number}}}'
+  const res = await fetch(`${API}/graphql`, {
+    method: 'POST',
+    headers: headers(),
+    body: JSON.stringify({ query, variables: { id: nodeId } }),
+  })
+  const body = await res.json().catch(() => null)
+  const message = body?.errors?.map((e) => e.message).join('; ') || ''
+  return { ok: res.ok && !body?.errors, message }
+}
+
+export async function main() {
+  if (!token) throw new Error('GITHUB_TOKEN is required — refusing to report a silent success.')
+  const dryRun = /^(1|true)$/i.test(process.env.DRY_RUN || '')
+  const stuckAfterMs = process.env.STUCK_AFTER_HOURS
+    ? Number(process.env.STUCK_AFTER_HOURS) * 3600000
+    : DEFAULT_STUCK_AFTER_MS
+  const nowMs = Date.now()
+
+  const pulls = await listDataPulls()
+  const results = []
+
+  for (const pr of pulls) {
+    const plan = planFor(
+      {
+        number: pr.number,
+        headRef: pr.head.ref,
+        draft: pr.draft,
+        autoMergeEnabled: Boolean(pr.auto_merge),
+        createdAtMs: new Date(pr.created_at).getTime(),
+        behindBy: await behindBy(pr),
+      },
+      { nowMs, stuckAfterMs }
+    )
+    const result = { ...plan, actions: [], outcome: 'ok', reason: '', progressing: false }
+
+    if (plan.draft) {
+      result.outcome = 'skipped'
+      result.reason = 'draft — left for its author'
+      results.push(result)
+      continue
+    }
+
+    if (plan.needsUpdate) {
+      if (dryRun) {
+        result.actions.push('would update-branch')
+      } else {
+        const { ok, status, body } = await gh(`/repos/${repo}/pulls/${pr.number}/update-branch`, {
+          method: 'PUT',
+        })
+        const message = body?.message || ''
+        if (ok) {
+          result.actions.push('update-branch')
+          result.behindBy = 0
+        } else if (/queue/i.test(message)) {
+          // Already in the merge queue: the queue owns the branch and rejects an
+          // update. Not a failure — the PR is progressing (hub AGENTS.md).
+          result.actions.push('skipped update-branch (in merge queue)')
+          result.progressing = true
+        } else {
+          result.outcome = 'blocked'
+          result.reason = `update-branch ${status}: ${message.slice(0, 120)}`
+        }
+      }
+    }
+
+    if (plan.needsAutoMerge && result.outcome !== 'blocked') {
+      if (dryRun) {
+        result.actions.push('would enable auto-merge')
+      } else {
+        const { ok, message } = await enableAutoMerge(pr.node_id)
+        if (ok || /already enabled/i.test(message)) {
+          result.actions.push('enable auto-merge')
+          result.autoMergeEnabled = true
+        } else {
+          result.outcome = 'blocked'
+          result.reason = `enable auto-merge: ${message.slice(0, 120)}`
+        }
+      }
+    }
+
+    if (result.outcome === 'ok' && result.actions.length) result.outcome = 'reconciled'
+    results.push(result)
+  }
+
+  const verdict = decideRunOutcome(results, { dryRun })
+  const summary = buildSummary(results, { dryRun, verdict })
+  console.log(summary)
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    const { appendFileSync } = await import('fs')
+    appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${summary}\n`)
+  }
+  if (verdict.failed) {
+    throw new Error(`Data PRs need attention:\n${verdict.reasons.map((r) => `- ${r}`).join('\n')}`)
+  }
+}
+
+// Only run when executed directly, so the pure helpers can be unit-tested.
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((err) => {
+    console.error(err.message)
+    process.exitCode = 1
+  })
+}


### PR DESCRIPTION
Implements the reconciler `FreeForCharity/FFC-Cloudflare-Automation#908` asks for: a data-refresh PR that falls behind `main` recovers by itself.

> **Status:** ready for review, `mergeable_state: clean`, all 5 checks green on `dffd5b8`, 3 Copilot findings fixed and resolved. **Not enqueued and auto-merge not armed** — merging is deliberately left to a human, see the last section.

## Why a reconciler and not a fix in the creating workflow

The race is lost **after** the creating workflow has exited — it arms auto-merge and terminates, and only then do the other data PRs merge and leave this one behind. So the creating workflow is the wrong place to watch from, exactly as the issue reasons. This is a periodic sweep instead: every 30 min across `05:00–15:00 UTC`, for each open PR on a `data/*` branch:

1. behind `main` → `PUT /pulls/{n}/update-branch`
2. auto-merge not armed → `enablePullRequestAutoMerge` (GraphQL, `MERGE`)

## The second failure mode, which the issue did not capture

The issue says every data workflow arms auto-merge, naming `sync-applications.yml` and `whmcs-intake.yml` among them. On `main` today that is not the case — **three of them have no auto-merge step at all:**

```
$ grep -l 'pr merge --auto' .github/workflows/*.yml
build-roadmap-data.yml  update-campaigns-registry.yml  update-ci-status.yml
update-domain-expiry.yml  update-fleet-smoke-status.yml  update-volunteer-hours.yml
# absent: update-sites-data.yml, sync-applications.yml, whmcs-intake.yml
```

**PR #732 is the live proof.** `data/sites-list-sync`, opened by `update-sites-data.yml` on 2026-07-27, still open:

```
$ git rev-list --left-right --count origin/main...origin/data/sites-list-sync
28	1                       # behind=28, ahead=1
updated_at == created_at == 2026-07-27T10:21:04Z    # never touched since creation
auto_merge: null
```

An update-branch-only fix would have brought it to `behind=0` and left it sitting there forever, because nothing was ever going to merge it. That is why step 2 exists, and why arming centrally is better than adding the missing step to three workflows: it also covers the next data workflow that forgets.

## Reporting: no second alerting path

Per the issue's last acceptance criterion, a PR still open past `STUCK_AFTER_HOURS` (default 3) **fails the run**. A red scheduled run is what the existing failure-alert layer (`#843` / `#832`) already watches, so nothing new is built here.

Note this fires *even when every remedy succeeded* — see `still reports a long-stuck PR it managed to rescue`. Reconciliation makes the dashboards current again; it does not make the six-hour stall un-happen, and the producer workflow that allowed it is worth knowing about. Two cases are deliberately **not** reported: a PR the merge queue already owns (an update would fight the queue — hub `AGENTS.md`), and a draft data PR (a human holding it; auto-merge cannot be armed on a draft anyway).

## Files

| File | Role |
| --- | --- |
| `scripts/reconcile-data-prs.mjs` | pure decision logic (`isDataBranch`, `planFor`, `decideRunOutcome`, `buildSummary`) + the API wiring |
| `.github/workflows/reconcile-data-prs.yml` | `*/30 5-15 * * *` + `workflow_dispatch` with `dry_run`; `contents: write` + `pull-requests: write`; ungated |
| `__tests__/reconcile-data-prs.test.js` | 50 tests |

Unlike this repo's data generators, the script does **not** degrade to exit 0 on an API failure (`surfaces an API failure instead of exiting clean`) — silence is the failure mode it exists to remove.

## Review round (`dffd5b8`)

Copilot filed three findings; all fixed, replied to, and resolved. One was serious:

| Finding | Verdict |
| --- | --- |
| Entrypoint guard may never call `main()` | **Real, and the worst kind — a green run that did nothing** |
| `update-branch` 422 can mean "already up to date" | **Real** — a false `blocked` would fail runs with nothing wrong |
| Compare call spent on drafts | Real, ~0 impact; taken anyway |

On the first: the guard was `` import.meta.url === `file://${process.argv[1]}` ``. The stated cause in review (relative `argv[1]`) is **not** the mechanism — node resolves `argv[1]` to an absolute path, verified. The real defect is **percent-encoding**: `import.meta.url` encodes the path, the concatenation does not, so any checkout under a directory containing a space makes the comparison false and `main()` never runs:

```
$ node "argvtest/has space/probe.mjs"
argv[1]         = "/tmp/.../has space/probe.mjs"
import.meta.url = file:///tmp/.../has%20space/probe.mjs
naive match: false          <-- main() never runs, exit 0
```

Runner paths have no spaces so CI was never at risk. Now `pathToFileURL().href`, matching `fleet-audit.mjs:837` and `gate3-validate.mjs:382`, guarded by a **spawn** test from a `mkdtemp` directory with a space in its name — importing the module and calling `main()` directly passes whether or not `node script.mjs` ever reaches it, which is exactly the gap that hid this.

On the second: fixed by re-reading the comparison rather than pattern-matching a message string I have never observed (that is `L02`'s shape — a check that only looks like it is checking). `update-branch` 422s for both "already current" and "merge conflict"; `behind=0` is benign, and a comparison that cannot be re-read stays blocked rather than being swallowed.

## Verification

```
pnpm exec jest __tests__/reconcile-data-prs.test.js   → 50 passed
pnpm test                                            → 69 suites, 1215 tests, all passed
pnpm run lint / type-check / format:check            → clean
pnpm run build                                       → static export OK
actionlint .github/workflows/reconcile-data-prs.yml  → EXIT=0
```

**The `main()` wiring is tested against a mocked `fetch`, not just the pure helpers** — and that is what earned its keep: it caught a real defect in the first draft. `decideRunOutcome` judged "stuck" from the *pre-action* plan, so a PR the reconciler had just successfully rescued still failed the run. The pure-function tests passed happily; only exercising the whole path surfaced it.

Every structural guard was confirmed to **fail without the invariant** rather than being always-green:

| Mutation | Result |
| --- | --- |
| reconciler cron narrowed to `*/30 7-8 * * *` | 2 failed — a producer cron falls outside the window |
| `update-ci-status.yml` branch → `chore/ci-status` | 1 failed — a data PR the sweep would not reach |
| entrypoint guard reverted to `` `file://${argv[1]}` `` | 1 failed — and only the space-path test |

Reverting each returned the suite to green.

## Before merging

- The issue's evidence criterion — *"let two data PRs open simultaneously, merge one, confirm the other recovers"* — needs the workflow live on `main`, so it cannot be met from a branch. **PR #732 is the ready-made case:** dispatch `Reconcile Data PRs` with `dry_run=true` and confirm the plan reads `would update-branch, would enable auto-merge` for #732, then re-dispatch live. If #732's CSV conflicts against 28 commits of `main`, the run reports `blocked` and needs a human — the correct outcome, not a regression.
- The branch is ~14 commits behind `main`, which the merge queue rebuilds against anyway; `mergeable_state` is `clean` and the PR is not queued, so the branch has deliberately been left alone rather than pushed a merge commit that would re-trigger CI and a fresh review round for no benefit.
- `update-branch` pushes as `GITHUB_TOKEN`, and pushes by that token do not trigger `pull_request` workflows. Not a problem here because `ci.yml` already never runs on bot-authored data PRs — the required checks are the org-level CodeQL default setup, which is GitHub-managed and re-analyses regardless of actor. **If required checks on `main` ever gain a `pull_request`-triggered workflow, this reconciler will need a PAT.**

Refs FreeForCharity/FFC-Cloudflare-Automation#908