### PR TITLE
chore(data): refresh Agentic OS status feed (502 deliver is 401-blocked)

### DIFF
--- a/public/data/agentic-os-status.json
+++ b/public/data/agentic-os-status.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-29T13:06:35Z",
+  "generated_at": "2026-07-30T01:07:08Z",
   "repo": "FreeForCharity/FFC-Cloudflare-Automation",
   "backlog_issues": [
     {
@@ -7,11 +7,142 @@
       "title": "Agentic OS Conductor Log",
       "state": "open",
       "assignee": null,
-      "updated_at": "2026-07-29T13:03:07Z",
+      "updated_at": "2026-07-30T01:05:05Z",
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719",
       "labels": [
         "agentic-os",
         "claimed"
+      ]
+    },
+    {
+      "number": 908,
+      "title": "ffcadmin data-refresh PRs hang forever once they fall behind main — three public dashboards went stale for 6h with all checks green",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-07-30T00:46:31Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/908",
+      "labels": [
+        "bug",
+        "agentic-os",
+        "claimed"
+      ]
+    },
+    {
+      "number": 862,
+      "title": "Footer_Only_Template sitemap advertises non-canonical URLs (every entry redirects)",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-07-30T00:33:01Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/862",
+      "labels": [
+        "bug",
+        "agentic-os"
+      ]
+    },
+    {
+      "number": 848,
+      "title": "Key Vault: both read-all GitHub PATs are dead, and the read/write split is unenforced (per-secret RBAC + liveness monitoring)",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-07-29T22:31:30Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/848",
+      "labels": [
+        "security",
+        "agentic-os",
+        "priority: high"
+      ]
+    },
+    {
+      "number": 921,
+      "title": "🚨 Scheduled workflow failing: 502. Google - Analytics Report (GA4 -> JSON) [GOOGLE]",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-07-29T22:30:50Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/921",
+      "labels": [
+        "bug",
+        "agentic-os"
+      ]
+    },
+    {
+      "number": 920,
+      "title": "221 uses the KV writer identity for a read-only search: pass scope: read and move it to whmcs-prod-read (104 is the precedent)",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-07-29T22:24:36Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/920",
+      "labels": [
+        "security",
+        "agentic-os"
+      ]
+    },
+    {
+      "number": 919,
+      "title": "Enforce the credential-scope condition for Conductor auto-approval (the grep that would do it misses 114 and 221)",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-07-29T22:24:13Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/919",
+      "labels": [
+        "security",
+        "agentic-os"
+      ]
+    },
+    {
+      "number": 918,
+      "title": "www is unverified across the fleet: aprilhansen.com serves 526 on www, and both the cutover and the smoke reported OK",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-07-29T22:23:41Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/918",
+      "labels": [
+        "bug",
+        "agentic-os"
+      ]
+    },
+    {
+      "number": 889,
+      "title": "Two mechanical gaps the lessons ledger names but cannot close (L02 error-swallowing sites, L06 lockfile validity)",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-07-29T19:29:25Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/889",
+      "labels": [
+        "bug",
+        "agentic-os"
+      ]
+    },
+    {
+      "number": 832,
+      "title": "Scheduled workflow failures are invisible: extend the rolling failure-alert to 726/734/738",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-07-29T19:26:21Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/832",
+      "labels": [
+        "agentic-os"
+      ]
+    },
+    {
+      "number": 834,
+      "title": "Reads-level GitHub workflows are gated on github-prod: 8 of 21 scheduled runs failed or were cancelled waiting for approval",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-07-29T16:25:47Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/834",
+      "labels": [
+        "agentic-os"
+      ]
+    },
+    {
+      "number": 912,
+      "title": "228 has never succeeded: a secrets.* reference against an environment with no secrets, and nothing catches the class",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-07-29T16:18:46Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/912",
+      "labels": [
+        "agentic-os"
       ]
     },
     {
@@ -25,29 +156,6 @@
         "bug",
         "agentic-os",
         "priority: high"
-      ]
-    },
-    {
-      "number": 834,
-      "title": "Reads-level GitHub workflows are gated on github-prod: 8 of 21 scheduled runs failed or were cancelled waiting for approval",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-07-29T12:38:40Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/834",
-      "labels": [
-        "agentic-os"
-      ]
-    },
-    {
-      "number": 906,
-      "title": "🚨 Scheduled workflow failing: 726. Repo - Rulesets + Settings Drift Audit [Org]",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-07-29T12:38:28Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/906",
-      "labels": [
-        "bug",
-        "agentic-os"
       ]
     },
     {
@@ -115,18 +223,6 @@
       ]
     },
     {
-      "number": 889,
-      "title": "Two mechanical gaps the lessons ledger names but cannot close (L02 error-swallowing sites, L06 lockfile validity)",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-07-27T18:21:17Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/889",
-      "labels": [
-        "bug",
-        "agentic-os"
-      ]
-    },
-    {
       "number": 841,
       "title": "Fleet security-audit coverage gap: Node repos with no vulnerability detection",
       "state": "open",
@@ -177,19 +273,6 @@
       ]
     },
     {
-      "number": 848,
-      "title": "Key Vault: both read-all GitHub PATs are dead, and the read/write split is unenforced (per-secret RBAC + liveness monitoring)",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-07-26T15:24:08Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/848",
-      "labels": [
-        "security",
-        "agentic-os",
-        "priority: high"
-      ]
-    },
-    {
       "number": 865,
       "title": "No per-charity traffic data — the traffic-ordered rollout has nothing to order by",
       "state": "open",
@@ -200,17 +283,6 @@
         "enhancement",
         "agentic-os",
         "claimed"
-      ]
-    },
-    {
-      "number": 832,
-      "title": "Scheduled workflow failures are invisible: extend the rolling failure-alert to 726/734/738",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-07-26T00:32:13Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/832",
-      "labels": [
-        "agentic-os"
       ]
     },
     {
@@ -234,18 +306,6 @@
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/863",
       "labels": [
         "enhancement",
-        "agentic-os"
-      ]
-    },
-    {
-      "number": 862,
-      "title": "Footer_Only_Template sitemap advertises non-canonical URLs (every entry redirects)",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-07-25T17:30:27Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/862",
-      "labels": [
-        "bug",
         "agentic-os"
       ]
     },
@@ -515,77 +575,145 @@
       ]
     }
   ],
-  "in_flight_prs": [],
+  "in_flight_prs": [
+    {
+      "number": 887,
+      "title": "fix(702): repair srcset in static clones instead of shipping broken images",
+      "state": "open",
+      "draft": true,
+      "assignee": null,
+      "updated_at": "2026-07-29T22:49:56Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/887",
+      "labels": [],
+      "linked_agentic_issues": [
+        900
+      ]
+    },
+    {
+      "number": 858,
+      "title": "feat(701,702): add dry-run modes; fix the $LASTEXITCODE bug that broke 720's",
+      "state": "open",
+      "draft": false,
+      "assignee": null,
+      "updated_at": "2026-07-29T22:36:13Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/858",
+      "labels": [],
+      "linked_agentic_issues": [
+        844
+      ]
+    },
+    {
+      "number": 825,
+      "title": "feat: WHMCS 229 - populate client fields from product answers (Refs #823)",
+      "state": "open",
+      "draft": true,
+      "assignee": null,
+      "updated_at": "2026-07-29T22:20:22Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/825",
+      "labels": [],
+      "linked_agentic_issues": [
+        823
+      ]
+    },
+    {
+      "number": 839,
+      "title": "docs(claude): two local-run env facts — UTF-8 on gh JSON output, and don't confirm a gate approval from the POST",
+      "state": "open",
+      "draft": true,
+      "assignee": null,
+      "updated_at": "2026-07-29T19:33:24Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/839",
+      "labels": [],
+      "linked_agentic_issues": [
+        719
+      ]
+    },
+    {
+      "number": 914,
+      "title": "feat(722): fail PRs that add a large blob in any commit, not just the tip",
+      "state": "open",
+      "draft": true,
+      "assignee": null,
+      "updated_at": "2026-07-29T19:24:09Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/914",
+      "labels": [
+        "agentic-os"
+      ],
+      "linked_agentic_issues": []
+    }
+  ],
+  "in_flight_prs_rule": "Open pull requests on this repo that are agent work on this backlog: a PR is listed when it carries the agentic-os label, or when its body references an agentic-os issue (e.g. 'Closes #123' / 'Refs #123'). Referenced-issue labels are what decide it — nothing labels the pull requests themselves.",
+  "open_prs_total": 8,
   "conductor_log": [
     {
       "author": "clarkemoyer",
-      "created_at": "2026-07-28T09:17:24Z",
-      "body": "## Cloud worker run — 2026-07-28 · landing run (3 open `agentic-os` PRs)\n\nThree open PRs carry the `agentic-os` label, so per the standing rule this run went to landing them rather than starting new work. **No new work PR opened, no code pushed.**\n\n### Finding: all three are one click from the merge queue\n\n| PR | State | Checks | Threads | `mergeable_state` | Blocked on |\n| --- | --- | --- | --- | --- | --- |\n| [#898](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/898) — GA4 ze…",
+      "created_at": "2026-07-29T13:29:43Z",
+      "body": "## Conductor run 44 — END (2026-07-29)\n\n### ⚠️ CLARKE — 2 things need you\n\n**1. `github-prod-read` has no secrets, and it has taken down all three scheduled GitHub reads.** (#834, reopened)\n\nThe ungated lane merged today (#837 → `a35dadc`), but the environment was created without the two Azure OIDC identifiers every other read environment carries. 726 has now failed **three times today** (06:15, 12:29, 12:35) at its own preflight guard; last success was 07-25.\n\n```\n##[error]READ_ALL_FFC_AZURE_KV…",
       "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5102245300"
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5118418110"
     },
     {
       "author": "clarkemoyer",
-      "created_at": "2026-07-28T12:17:17Z",
-      "body": "## Agentic-OS worker run — 2026-07-28 (landing run)\n\nThree `agentic-os` PRs open (#898, #897, #837) ≥ 3, so per the standing rule this run was spent landing rather than starting new work. No new work PR opened.\n\n### State of the three\n\n| PR | CI | Review threads | `mergeable_state` | Blocker |\n| --- | --- | --- | --- | --- |\n| #897 — issue-body values reached pwsh as script text | ✅ 7/7 | none | `clean` | **none — promotable now** |\n| #898 — empty GA4 result is zero traffic | ✅ 7/7 | none | `cle…",
+      "created_at": "2026-07-29T16:04:54Z",
+      "body": "## Conductor run 45 — START (2026-07-29)\n\nBootstrap OK. All 5 core clones fetched, `origin/main`, 0 dirty (hub @ `73d8351`). gh 2.96.0 as `clarkemoyer`.\n\nEntry state: rate limit core 4949. Open `agentic-os` issues: **45** (band 5–15). Open hub PRs: **9** (8 draft). Pending gates: **3** — the same three write gates run 44 put on Clarke's plate 2.5h ago (120 bulk cutover, 111 redirect rule, 703 sites list). No new gates, so no re-nag is due.\n\nFirst action per run 44's own instruction: **dispatch 7…",
       "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5104029794"
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5120376440"
     },
     {
       "author": "clarkemoyer",
-      "created_at": "2026-07-28T15:17:46Z",
-      "body": "## Cloud worker — landing run, 2026-07-28 ~15:1xZ\n\nFourth landing run today. Three open `agentic-os` PRs (#837, #897, #898) met the ≥3 threshold, so no new work PR was opened.\n\n### State: unchanged from the [09:17Z](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5102245300) run, and re-verified rather than assumed\n\n| PR | Checks | Threads | `mergeable_state` | Behind `main`? |\n| --- | --- | --- | --- | --- |\n| #898 | 7/7 green | 0 | `clean` | no — base **is**…",
+      "created_at": "2026-07-29T16:27:20Z",
+      "body": "## Conductor run 45 — END (2026-07-29)\n\n### ✅ CLARKE — one thing came OFF your plate, nothing was added\n\n**`github-prod-read` never needed you.** Run 44 asked you to add two environment secrets and said it could not be done any other way. That was wrong, and two API reads showed it:\n\n| Check | Result |\n| --- | --- |\n| `gh api repos/…/actions/variables` | `READ_ALL_FFC_AZURE_KV_CLIENT_ID` + `_TENANT_ID` **already set as repo Variables** |\n| `az ad app federated-credential list` | `gha-FFC-Cloudfl…",
       "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5106037258"
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5120637460"
     },
     {
       "author": "clarkemoyer",
-      "created_at": "2026-07-28T18:17:29Z",
-      "body": "## Cloud worker — landing run, 2026-07-28 ~16:2xZ\n\nFifth landing run today. Threshold met (#837, #897, #898 open) → no new work PR.\n\n**Deliberately short.** The [15:17Z run](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5106037258) left a standing rule — diff your intended comment against the previous run's before posting, and if the finding is identical, do not restate it on the same channel. It is identical. So this entry records only what is new, and the …",
+      "created_at": "2026-07-29T19:04:39Z",
+      "body": "## Conductor run 46 — START (2026-07-29)\n\nLocal supervisor booted. Workspace verified, all 5 core clones fetched clean at `origin/main`:\n\n| Repo | HEAD |\n| --- | --- |\n| FFC-Cloudflare-Automation | `105b90e` |\n| FFC-IN-freeforcharity.org | `fa3f600` |\n| FFC-IN-ffcadmin.org | `9c4b035` |\n| FFC-IN-FFC_Single_Page_Template | `b4e6d32` |\n| FFC-IN-Footer_Only_Template | `c310e85` |\n\nToolchain present: gh 2.96.0 (authed `clarkemoyer`), git 2.51.0, az 2.81.0, m365 11.9.0, gcloud 552.0.0.\n\n**Carried in …",
       "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5108035838"
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5122318810"
     },
     {
       "author": "clarkemoyer",
-      "created_at": "2026-07-28T21:18:36Z",
-      "body": "## Landing run — all 3 open `agentic-os` PRs are queue-ready; the only blocker is human\n\nCloud worker, 2026-07-28. Three open `agentic-os` PRs (≥3), so per the standing rule this run was spent landing them rather than starting new work. **No new PR opened.**\n\nI am not asserting a run number — per the `AGENTS.md` pagination trap (an unpaginated comment read slices the *oldest* page of a 100+-comment issue), guessing one from a partial read is exactly the documented failure. Please index this by d…",
+      "created_at": "2026-07-29T19:28:32Z",
+      "body": "## Conductor run 46 — END (2026-07-29)\n\n### ⚠️ CLARKE — one decision, and it is three days old\n\n**`aprilhansen.com` is half cut over, and has been since 07-26.** Your bulk-cutover dispatch (run [30206714334](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/actions/runs/30206714334), `dry_run=false`) is a two-job workflow. Job one already ran:\n\n```\n[aprilhansen.com] Committing public/CNAME: 'staging.aprilhansen.com' -> 'aprilhansen.com'\n[aprilhansen.com] CNAME commit OK.\n[aprilhansen.c…",
       "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5109784204"
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5122554967"
     },
     {
       "author": "clarkemoyer",
-      "created_at": "2026-07-29T00:16:52Z",
-      "body": "## Cloud worker — landing run, 2026-07-29 ~00:1xZ\n\nSixth landing run in the series. Threshold met (#837, #897, #898 open) → no new work PR. Following the [15:17Z](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5106037258) anti-restatement rule and the [18:17Z](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5108035838) corollary — log every run, spend the words only on what moved.\n\n### Unchanged (re-verified, not carried fo…",
+      "created_at": "2026-07-29T22:05:16Z",
+      "body": "## Conductor run 47 — START (2026-07-29)\n\nLocal privileged Conductor booting. Bootstrap clean: all 5 core clones at `origin/main`\n(hub `5d583d4`), no dirty trees; `gh` 2.96.0 / `az` 2.81.0 / `m365` 11.9.0 / `gcloud` 552.0.0 all\npresent and authed. Core rate limit 4965 remaining at start.\n\nRun number taken as **47** from the newest START in this thread (run 46) + 1, per the standing\ndoctrine.\n\nCarried forward from run 46 as this run's agenda:\n- **Gate 120 (aprilhansen half-cutover) is no longer i…",
       "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5111203877"
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5123840991"
     },
     {
       "author": "clarkemoyer",
-      "created_at": "2026-07-29T03:17:27Z",
-      "body": "## Worker run — 2026-07-29 · landing run, queue is human-blocked\n\nRule 1 fired: **3 open `agentic-os` PRs** (#897, #898, #837), so this run went to landing them and started no new work.\n\n**Result: there is nothing left for a worker to do on any of the three.** All are `mergeable_state: clean`, **0 commits behind `main`** (`0a5b2a4`), fully green, and free of unresolved review threads. I verified the combined tree rather than trusting the pairwise result from the prior run — #897 + #837 + #898 me…",
+      "created_at": "2026-07-29T22:25:24Z",
+      "body": "## Clarke — decisions needed (Conductor run 47)\n\n### 1. aprilhansen.com: your run-46 approval worked. Apex is fully live. ✅\n\nYou approved both gates at ~19:39Z and the cutover completed. I verified live rather than trusting\nthe run: apex resolves to the four Pages anycast IPs, `https://aprilhansen.com/` returns **200** from\n`Server: GitHub.com` with a Let's Encrypt cert for `CN=aprilhansen.com`, serving the real site\n(\"April Hansen | The Life and Legacy of The Trendy Little Geek\").\n\nThe run's `p…",
       "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5112387913"
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5123992682"
     },
     {
       "author": "clarkemoyer",
-      "created_at": "2026-07-29T06:19:55Z",
-      "body": "## Cloud worker run — 2026-07-29 ~06:2xZ — landing pass (3 open `agentic-os` PRs, no new work started)\n\nPer the ≥3 rule: #897, #898 and #837 are open, so this run landed rather than started. **All three are green, clean, and blocked only on @clarkemoyer.** No code was pushed and nothing was promoted.\n\n### State of the three (verified, not assumed)\n\n| PR | Checks | Threads | vs `main` | Blocked on |\n| --- | --- | --- | --- | --- |\n| **#897** security — untrusted issue input reaching `pwsh` in 701…",
+      "created_at": "2026-07-29T22:42:23Z",
+      "body": "## Conductor run 47 — END (2026-07-29)\n\nGate decisions and the two things needing Clarke are in the [decisions comment](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5123992682) above; this is the outcome record.\n\n### Headline: the aprilhansen half-cutover is resolved, and it exposed a second live defect\n\nClarke approved both 120 gates at ~19:39Z in response to run 46's escalation — **finish, not revert.** Verified live rather than from the run: apex on the …",
       "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5113962547"
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5124124943"
     },
     {
       "author": "clarkemoyer",
-      "created_at": "2026-07-29T09:15:34Z",
-      "body": "## Landing run 2026-07-29 ~09:15Z — third consecutive fully-blocked pass. The queue itself has stalled.\n\nRule 1 fired again (3 open `agentic-os` PRs), so this run went to landing rather than new work. **Nothing was landable, and nothing has changed since the two runs earlier today** ([03:17Z on #897](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/897#issuecomment-5112386564), [06:19Z on #837](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/837#issuecomment-5113…",
+      "created_at": "2026-07-29T23:43:03Z",
+      "body": "## Conductor run 47 — correction to the END log\n\n**One claim in my END comment above is wrong, and it would have cost a future run a real step.** I wrote:\n\n> Recorded for future runs: **PRs are not on this board — only issues.**\n\nThat is false. PRs **are** tracked on board #9:\n\n| PR | On board | Status |\n| --- | --- | --- |\n| #839 | yes | In Review |\n| #836 | yes | In Review |\n| #914 | yes | In Review |\n| #917 | **no — my omission** | now added, In Review |\n\nI generalized from a four-PR sample (…",
       "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5115599477"
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5124531535"
     },
     {
       "author": "clarkemoyer",
-      "created_at": "2026-07-29T13:03:07Z",
-      "body": "## Conductor run 44 — START (2026-07-29)\n\nBootstrap OK. Tooling verified: gh 2.96.0 (clarkemoyer, keyring), az 2.81.0, m365 11.9.0, gcloud 552.0.0, git 2.51.0. All 5 core clones fetched and clean at `origin/main` (hub @ `a35dadc`).\n\nEntry state: rate limit core 4949 / graphql 4944. Open `agentic-os` issues: **43** (band is 5–15 — grooming is this run's headline). Open hub PRs: 11. Pending deployment gates: **5** (3 x `github-prod`, 2 x `cloudflare-prod-write`).\n\nWorking steps 2–8; END comment to…",
+      "created_at": "2026-07-30T01:05:05Z",
+      "body": "## Conductor run 48 — START (2026-07-30)\n\nLocal privileged Conductor booting. Bootstrap clean: all 5 core clones ff-pulled to `origin/main`,\n0 dirty trees (hub `241d316`, ffcadmin `9c4b035`, freeforcharity `fa3f600`, SPT `b4e6d32`,\nFOT `c310e85`). Core rate limit **4976/5000**, graphql 4675 — GraphQL fully refilled after run 47's\nself-inflicted exhaustion.\n\nRun number taken as **48** from the newest START in this thread (run 47) + 1, per standing doctrine.\nNote for the record: `state\\CONDUCTOR.m…",
       "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5118114670"
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5125114593"
     }
   ],
   "pending_gates": [
@@ -595,13 +723,6 @@
       "environment": "cloudflare-prod-write",
       "created_at": "2026-07-26T14:34:56Z",
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/actions/runs/30206375399"
-    },
-    {
-      "run_id": 30206714334,
-      "workflow_name": "Bulk cutover staging->apex (dry_run=false, skip_dns=false, skip_cname=false)",
-      "environment": "cloudflare-prod-write",
-      "created_at": "2026-07-26T14:44:30Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/actions/runs/30206714334"
     },
     {
       "run_id": 30252940885,

--- a/src/data/agentic-os-status.json
+++ b/src/data/agentic-os-status.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-29T13:06:35Z",
+  "generated_at": "2026-07-30T01:07:08Z",
   "repo": "FreeForCharity/FFC-Cloudflare-Automation",
   "backlog_issues": [
     {
@@ -7,11 +7,142 @@
       "title": "Agentic OS Conductor Log",
       "state": "open",
       "assignee": null,
-      "updated_at": "2026-07-29T13:03:07Z",
+      "updated_at": "2026-07-30T01:05:05Z",
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719",
       "labels": [
         "agentic-os",
         "claimed"
+      ]
+    },
+    {
+      "number": 908,
+      "title": "ffcadmin data-refresh PRs hang forever once they fall behind main — three public dashboards went stale for 6h with all checks green",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-07-30T00:46:31Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/908",
+      "labels": [
+        "bug",
+        "agentic-os",
+        "claimed"
+      ]
+    },
+    {
+      "number": 862,
+      "title": "Footer_Only_Template sitemap advertises non-canonical URLs (every entry redirects)",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-07-30T00:33:01Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/862",
+      "labels": [
+        "bug",
+        "agentic-os"
+      ]
+    },
+    {
+      "number": 848,
+      "title": "Key Vault: both read-all GitHub PATs are dead, and the read/write split is unenforced (per-secret RBAC + liveness monitoring)",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-07-29T22:31:30Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/848",
+      "labels": [
+        "security",
+        "agentic-os",
+        "priority: high"
+      ]
+    },
+    {
+      "number": 921,
+      "title": "🚨 Scheduled workflow failing: 502. Google - Analytics Report (GA4 -> JSON) [GOOGLE]",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-07-29T22:30:50Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/921",
+      "labels": [
+        "bug",
+        "agentic-os"
+      ]
+    },
+    {
+      "number": 920,
+      "title": "221 uses the KV writer identity for a read-only search: pass scope: read and move it to whmcs-prod-read (104 is the precedent)",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-07-29T22:24:36Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/920",
+      "labels": [
+        "security",
+        "agentic-os"
+      ]
+    },
+    {
+      "number": 919,
+      "title": "Enforce the credential-scope condition for Conductor auto-approval (the grep that would do it misses 114 and 221)",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-07-29T22:24:13Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/919",
+      "labels": [
+        "security",
+        "agentic-os"
+      ]
+    },
+    {
+      "number": 918,
+      "title": "www is unverified across the fleet: aprilhansen.com serves 526 on www, and both the cutover and the smoke reported OK",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-07-29T22:23:41Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/918",
+      "labels": [
+        "bug",
+        "agentic-os"
+      ]
+    },
+    {
+      "number": 889,
+      "title": "Two mechanical gaps the lessons ledger names but cannot close (L02 error-swallowing sites, L06 lockfile validity)",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-07-29T19:29:25Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/889",
+      "labels": [
+        "bug",
+        "agentic-os"
+      ]
+    },
+    {
+      "number": 832,
+      "title": "Scheduled workflow failures are invisible: extend the rolling failure-alert to 726/734/738",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-07-29T19:26:21Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/832",
+      "labels": [
+        "agentic-os"
+      ]
+    },
+    {
+      "number": 834,
+      "title": "Reads-level GitHub workflows are gated on github-prod: 8 of 21 scheduled runs failed or were cancelled waiting for approval",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-07-29T16:25:47Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/834",
+      "labels": [
+        "agentic-os"
+      ]
+    },
+    {
+      "number": 912,
+      "title": "228 has never succeeded: a secrets.* reference against an environment with no secrets, and nothing catches the class",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-07-29T16:18:46Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/912",
+      "labels": [
+        "agentic-os"
       ]
     },
     {
@@ -25,29 +156,6 @@
         "bug",
         "agentic-os",
         "priority: high"
-      ]
-    },
-    {
-      "number": 834,
-      "title": "Reads-level GitHub workflows are gated on github-prod: 8 of 21 scheduled runs failed or were cancelled waiting for approval",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-07-29T12:38:40Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/834",
-      "labels": [
-        "agentic-os"
-      ]
-    },
-    {
-      "number": 906,
-      "title": "🚨 Scheduled workflow failing: 726. Repo - Rulesets + Settings Drift Audit [Org]",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-07-29T12:38:28Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/906",
-      "labels": [
-        "bug",
-        "agentic-os"
       ]
     },
     {
@@ -115,18 +223,6 @@
       ]
     },
     {
-      "number": 889,
-      "title": "Two mechanical gaps the lessons ledger names but cannot close (L02 error-swallowing sites, L06 lockfile validity)",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-07-27T18:21:17Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/889",
-      "labels": [
-        "bug",
-        "agentic-os"
-      ]
-    },
-    {
       "number": 841,
       "title": "Fleet security-audit coverage gap: Node repos with no vulnerability detection",
       "state": "open",
@@ -177,19 +273,6 @@
       ]
     },
     {
-      "number": 848,
-      "title": "Key Vault: both read-all GitHub PATs are dead, and the read/write split is unenforced (per-secret RBAC + liveness monitoring)",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-07-26T15:24:08Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/848",
-      "labels": [
-        "security",
-        "agentic-os",
-        "priority: high"
-      ]
-    },
-    {
       "number": 865,
       "title": "No per-charity traffic data — the traffic-ordered rollout has nothing to order by",
       "state": "open",
@@ -200,17 +283,6 @@
         "enhancement",
         "agentic-os",
         "claimed"
-      ]
-    },
-    {
-      "number": 832,
-      "title": "Scheduled workflow failures are invisible: extend the rolling failure-alert to 726/734/738",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-07-26T00:32:13Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/832",
-      "labels": [
-        "agentic-os"
       ]
     },
     {
@@ -234,18 +306,6 @@
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/863",
       "labels": [
         "enhancement",
-        "agentic-os"
-      ]
-    },
-    {
-      "number": 862,
-      "title": "Footer_Only_Template sitemap advertises non-canonical URLs (every entry redirects)",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-07-25T17:30:27Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/862",
-      "labels": [
-        "bug",
         "agentic-os"
       ]
     },
@@ -515,77 +575,145 @@
       ]
     }
   ],
-  "in_flight_prs": [],
+  "in_flight_prs": [
+    {
+      "number": 887,
+      "title": "fix(702): repair srcset in static clones instead of shipping broken images",
+      "state": "open",
+      "draft": true,
+      "assignee": null,
+      "updated_at": "2026-07-29T22:49:56Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/887",
+      "labels": [],
+      "linked_agentic_issues": [
+        900
+      ]
+    },
+    {
+      "number": 858,
+      "title": "feat(701,702): add dry-run modes; fix the $LASTEXITCODE bug that broke 720's",
+      "state": "open",
+      "draft": false,
+      "assignee": null,
+      "updated_at": "2026-07-29T22:36:13Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/858",
+      "labels": [],
+      "linked_agentic_issues": [
+        844
+      ]
+    },
+    {
+      "number": 825,
+      "title": "feat: WHMCS 229 - populate client fields from product answers (Refs #823)",
+      "state": "open",
+      "draft": true,
+      "assignee": null,
+      "updated_at": "2026-07-29T22:20:22Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/825",
+      "labels": [],
+      "linked_agentic_issues": [
+        823
+      ]
+    },
+    {
+      "number": 839,
+      "title": "docs(claude): two local-run env facts — UTF-8 on gh JSON output, and don't confirm a gate approval from the POST",
+      "state": "open",
+      "draft": true,
+      "assignee": null,
+      "updated_at": "2026-07-29T19:33:24Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/839",
+      "labels": [],
+      "linked_agentic_issues": [
+        719
+      ]
+    },
+    {
+      "number": 914,
+      "title": "feat(722): fail PRs that add a large blob in any commit, not just the tip",
+      "state": "open",
+      "draft": true,
+      "assignee": null,
+      "updated_at": "2026-07-29T19:24:09Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/914",
+      "labels": [
+        "agentic-os"
+      ],
+      "linked_agentic_issues": []
+    }
+  ],
+  "in_flight_prs_rule": "Open pull requests on this repo that are agent work on this backlog: a PR is listed when it carries the agentic-os label, or when its body references an agentic-os issue (e.g. 'Closes #123' / 'Refs #123'). Referenced-issue labels are what decide it — nothing labels the pull requests themselves.",
+  "open_prs_total": 8,
   "conductor_log": [
     {
       "author": "clarkemoyer",
-      "created_at": "2026-07-28T09:17:24Z",
-      "body": "## Cloud worker run — 2026-07-28 · landing run (3 open `agentic-os` PRs)\n\nThree open PRs carry the `agentic-os` label, so per the standing rule this run went to landing them rather than starting new work. **No new work PR opened, no code pushed.**\n\n### Finding: all three are one click from the merge queue\n\n| PR | State | Checks | Threads | `mergeable_state` | Blocked on |\n| --- | --- | --- | --- | --- | --- |\n| [#898](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/898) — GA4 ze…",
+      "created_at": "2026-07-29T13:29:43Z",
+      "body": "## Conductor run 44 — END (2026-07-29)\n\n### ⚠️ CLARKE — 2 things need you\n\n**1. `github-prod-read` has no secrets, and it has taken down all three scheduled GitHub reads.** (#834, reopened)\n\nThe ungated lane merged today (#837 → `a35dadc`), but the environment was created without the two Azure OIDC identifiers every other read environment carries. 726 has now failed **three times today** (06:15, 12:29, 12:35) at its own preflight guard; last success was 07-25.\n\n```\n##[error]READ_ALL_FFC_AZURE_KV…",
       "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5102245300"
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5118418110"
     },
     {
       "author": "clarkemoyer",
-      "created_at": "2026-07-28T12:17:17Z",
-      "body": "## Agentic-OS worker run — 2026-07-28 (landing run)\n\nThree `agentic-os` PRs open (#898, #897, #837) ≥ 3, so per the standing rule this run was spent landing rather than starting new work. No new work PR opened.\n\n### State of the three\n\n| PR | CI | Review threads | `mergeable_state` | Blocker |\n| --- | --- | --- | --- | --- |\n| #897 — issue-body values reached pwsh as script text | ✅ 7/7 | none | `clean` | **none — promotable now** |\n| #898 — empty GA4 result is zero traffic | ✅ 7/7 | none | `cle…",
+      "created_at": "2026-07-29T16:04:54Z",
+      "body": "## Conductor run 45 — START (2026-07-29)\n\nBootstrap OK. All 5 core clones fetched, `origin/main`, 0 dirty (hub @ `73d8351`). gh 2.96.0 as `clarkemoyer`.\n\nEntry state: rate limit core 4949. Open `agentic-os` issues: **45** (band 5–15). Open hub PRs: **9** (8 draft). Pending gates: **3** — the same three write gates run 44 put on Clarke's plate 2.5h ago (120 bulk cutover, 111 redirect rule, 703 sites list). No new gates, so no re-nag is due.\n\nFirst action per run 44's own instruction: **dispatch 7…",
       "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5104029794"
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5120376440"
     },
     {
       "author": "clarkemoyer",
-      "created_at": "2026-07-28T15:17:46Z",
-      "body": "## Cloud worker — landing run, 2026-07-28 ~15:1xZ\n\nFourth landing run today. Three open `agentic-os` PRs (#837, #897, #898) met the ≥3 threshold, so no new work PR was opened.\n\n### State: unchanged from the [09:17Z](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5102245300) run, and re-verified rather than assumed\n\n| PR | Checks | Threads | `mergeable_state` | Behind `main`? |\n| --- | --- | --- | --- | --- |\n| #898 | 7/7 green | 0 | `clean` | no — base **is**…",
+      "created_at": "2026-07-29T16:27:20Z",
+      "body": "## Conductor run 45 — END (2026-07-29)\n\n### ✅ CLARKE — one thing came OFF your plate, nothing was added\n\n**`github-prod-read` never needed you.** Run 44 asked you to add two environment secrets and said it could not be done any other way. That was wrong, and two API reads showed it:\n\n| Check | Result |\n| --- | --- |\n| `gh api repos/…/actions/variables` | `READ_ALL_FFC_AZURE_KV_CLIENT_ID` + `_TENANT_ID` **already set as repo Variables** |\n| `az ad app federated-credential list` | `gha-FFC-Cloudfl…",
       "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5106037258"
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5120637460"
     },
     {
       "author": "clarkemoyer",
-      "created_at": "2026-07-28T18:17:29Z",
-      "body": "## Cloud worker — landing run, 2026-07-28 ~16:2xZ\n\nFifth landing run today. Threshold met (#837, #897, #898 open) → no new work PR.\n\n**Deliberately short.** The [15:17Z run](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5106037258) left a standing rule — diff your intended comment against the previous run's before posting, and if the finding is identical, do not restate it on the same channel. It is identical. So this entry records only what is new, and the …",
+      "created_at": "2026-07-29T19:04:39Z",
+      "body": "## Conductor run 46 — START (2026-07-29)\n\nLocal supervisor booted. Workspace verified, all 5 core clones fetched clean at `origin/main`:\n\n| Repo | HEAD |\n| --- | --- |\n| FFC-Cloudflare-Automation | `105b90e` |\n| FFC-IN-freeforcharity.org | `fa3f600` |\n| FFC-IN-ffcadmin.org | `9c4b035` |\n| FFC-IN-FFC_Single_Page_Template | `b4e6d32` |\n| FFC-IN-Footer_Only_Template | `c310e85` |\n\nToolchain present: gh 2.96.0 (authed `clarkemoyer`), git 2.51.0, az 2.81.0, m365 11.9.0, gcloud 552.0.0.\n\n**Carried in …",
       "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5108035838"
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5122318810"
     },
     {
       "author": "clarkemoyer",
-      "created_at": "2026-07-28T21:18:36Z",
-      "body": "## Landing run — all 3 open `agentic-os` PRs are queue-ready; the only blocker is human\n\nCloud worker, 2026-07-28. Three open `agentic-os` PRs (≥3), so per the standing rule this run was spent landing them rather than starting new work. **No new PR opened.**\n\nI am not asserting a run number — per the `AGENTS.md` pagination trap (an unpaginated comment read slices the *oldest* page of a 100+-comment issue), guessing one from a partial read is exactly the documented failure. Please index this by d…",
+      "created_at": "2026-07-29T19:28:32Z",
+      "body": "## Conductor run 46 — END (2026-07-29)\n\n### ⚠️ CLARKE — one decision, and it is three days old\n\n**`aprilhansen.com` is half cut over, and has been since 07-26.** Your bulk-cutover dispatch (run [30206714334](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/actions/runs/30206714334), `dry_run=false`) is a two-job workflow. Job one already ran:\n\n```\n[aprilhansen.com] Committing public/CNAME: 'staging.aprilhansen.com' -> 'aprilhansen.com'\n[aprilhansen.com] CNAME commit OK.\n[aprilhansen.c…",
       "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5109784204"
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5122554967"
     },
     {
       "author": "clarkemoyer",
-      "created_at": "2026-07-29T00:16:52Z",
-      "body": "## Cloud worker — landing run, 2026-07-29 ~00:1xZ\n\nSixth landing run in the series. Threshold met (#837, #897, #898 open) → no new work PR. Following the [15:17Z](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5106037258) anti-restatement rule and the [18:17Z](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5108035838) corollary — log every run, spend the words only on what moved.\n\n### Unchanged (re-verified, not carried fo…",
+      "created_at": "2026-07-29T22:05:16Z",
+      "body": "## Conductor run 47 — START (2026-07-29)\n\nLocal privileged Conductor booting. Bootstrap clean: all 5 core clones at `origin/main`\n(hub `5d583d4`), no dirty trees; `gh` 2.96.0 / `az` 2.81.0 / `m365` 11.9.0 / `gcloud` 552.0.0 all\npresent and authed. Core rate limit 4965 remaining at start.\n\nRun number taken as **47** from the newest START in this thread (run 46) + 1, per the standing\ndoctrine.\n\nCarried forward from run 46 as this run's agenda:\n- **Gate 120 (aprilhansen half-cutover) is no longer i…",
       "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5111203877"
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5123840991"
     },
     {
       "author": "clarkemoyer",
-      "created_at": "2026-07-29T03:17:27Z",
-      "body": "## Worker run — 2026-07-29 · landing run, queue is human-blocked\n\nRule 1 fired: **3 open `agentic-os` PRs** (#897, #898, #837), so this run went to landing them and started no new work.\n\n**Result: there is nothing left for a worker to do on any of the three.** All are `mergeable_state: clean`, **0 commits behind `main`** (`0a5b2a4`), fully green, and free of unresolved review threads. I verified the combined tree rather than trusting the pairwise result from the prior run — #897 + #837 + #898 me…",
+      "created_at": "2026-07-29T22:25:24Z",
+      "body": "## Clarke — decisions needed (Conductor run 47)\n\n### 1. aprilhansen.com: your run-46 approval worked. Apex is fully live. ✅\n\nYou approved both gates at ~19:39Z and the cutover completed. I verified live rather than trusting\nthe run: apex resolves to the four Pages anycast IPs, `https://aprilhansen.com/` returns **200** from\n`Server: GitHub.com` with a Let's Encrypt cert for `CN=aprilhansen.com`, serving the real site\n(\"April Hansen | The Life and Legacy of The Trendy Little Geek\").\n\nThe run's `p…",
       "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5112387913"
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5123992682"
     },
     {
       "author": "clarkemoyer",
-      "created_at": "2026-07-29T06:19:55Z",
-      "body": "## Cloud worker run — 2026-07-29 ~06:2xZ — landing pass (3 open `agentic-os` PRs, no new work started)\n\nPer the ≥3 rule: #897, #898 and #837 are open, so this run landed rather than started. **All three are green, clean, and blocked only on @clarkemoyer.** No code was pushed and nothing was promoted.\n\n### State of the three (verified, not assumed)\n\n| PR | Checks | Threads | vs `main` | Blocked on |\n| --- | --- | --- | --- | --- |\n| **#897** security — untrusted issue input reaching `pwsh` in 701…",
+      "created_at": "2026-07-29T22:42:23Z",
+      "body": "## Conductor run 47 — END (2026-07-29)\n\nGate decisions and the two things needing Clarke are in the [decisions comment](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5123992682) above; this is the outcome record.\n\n### Headline: the aprilhansen half-cutover is resolved, and it exposed a second live defect\n\nClarke approved both 120 gates at ~19:39Z in response to run 46's escalation — **finish, not revert.** Verified live rather than from the run: apex on the …",
       "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5113962547"
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5124124943"
     },
     {
       "author": "clarkemoyer",
-      "created_at": "2026-07-29T09:15:34Z",
-      "body": "## Landing run 2026-07-29 ~09:15Z — third consecutive fully-blocked pass. The queue itself has stalled.\n\nRule 1 fired again (3 open `agentic-os` PRs), so this run went to landing rather than new work. **Nothing was landable, and nothing has changed since the two runs earlier today** ([03:17Z on #897](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/897#issuecomment-5112386564), [06:19Z on #837](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/837#issuecomment-5113…",
+      "created_at": "2026-07-29T23:43:03Z",
+      "body": "## Conductor run 47 — correction to the END log\n\n**One claim in my END comment above is wrong, and it would have cost a future run a real step.** I wrote:\n\n> Recorded for future runs: **PRs are not on this board — only issues.**\n\nThat is false. PRs **are** tracked on board #9:\n\n| PR | On board | Status |\n| --- | --- | --- |\n| #839 | yes | In Review |\n| #836 | yes | In Review |\n| #914 | yes | In Review |\n| #917 | **no — my omission** | now added, In Review |\n\nI generalized from a four-PR sample (…",
       "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5115599477"
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5124531535"
     },
     {
       "author": "clarkemoyer",
-      "created_at": "2026-07-29T13:03:07Z",
-      "body": "## Conductor run 44 — START (2026-07-29)\n\nBootstrap OK. Tooling verified: gh 2.96.0 (clarkemoyer, keyring), az 2.81.0, m365 11.9.0, gcloud 552.0.0, git 2.51.0. All 5 core clones fetched and clean at `origin/main` (hub @ `a35dadc`).\n\nEntry state: rate limit core 4949 / graphql 4944. Open `agentic-os` issues: **43** (band is 5–15 — grooming is this run's headline). Open hub PRs: 11. Pending deployment gates: **5** (3 x `github-prod`, 2 x `cloudflare-prod-write`).\n\nWorking steps 2–8; END comment to…",
+      "created_at": "2026-07-30T01:05:05Z",
+      "body": "## Conductor run 48 — START (2026-07-30)\n\nLocal privileged Conductor booting. Bootstrap clean: all 5 core clones ff-pulled to `origin/main`,\n0 dirty trees (hub `241d316`, ffcadmin `9c4b035`, freeforcharity `fa3f600`, SPT `b4e6d32`,\nFOT `c310e85`). Core rate limit **4976/5000**, graphql 4675 — GraphQL fully refilled after run 47's\nself-inflicted exhaustion.\n\nRun number taken as **48** from the newest START in this thread (run 47) + 1, per standing doctrine.\nNote for the record: `state\\CONDUCTOR.m…",
       "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5118114670"
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5125114593"
     }
   ],
   "pending_gates": [
@@ -595,13 +723,6 @@
       "environment": "cloudflare-prod-write",
       "created_at": "2026-07-26T14:34:56Z",
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/actions/runs/30206375399"
-    },
-    {
-      "run_id": 30206714334,
-      "workflow_name": "Bulk cutover staging->apex (dry_run=false, skip_dns=false, skip_cname=false)",
-      "environment": "cloudflare-prod-write",
-      "created_at": "2026-07-26T14:44:30Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/actions/runs/30206714334"
     },
     {
       "run_id": 30252940885,


### PR DESCRIPTION
## Why this is a hand-delivered data PR

The public `/agentic-os` page has been frozen at `generated_at: 2026-07-29T13:06:35Z`. It is not merely stale — it is **wrong**:

| Panel | Published (frozen) | Reality this run |
| --- | --- | --- |
| `pending_gates` | **3** — still advertises the gate that resolved 07-29 19:47Z | **2** (111 redirect, 703 sites list) |
| `in_flight_prs` | **0** — the #909 dead panel | **5** of 8 open PRs |
| `backlog_issues` | 43 | 48 |
| `generated_at` | 2026-07-29T13:06:35Z | 2026-07-30T01:07:08Z |

A public status page that misreports which approvals are outstanding is worse than one that is obviously old, so this is worth a manual delivery rather than waiting.

## Root cause is not in this repo

Workflow **502**'s `deliver` job dies at the **`Generate Agentic OS status feed`** step:

```
error: GitHub API 401 for https://api.github.com/repos/.../issues?labels=agentic-os&state=open
  "message": "Bad credentials",
  "status": "401"
```

The Key Vault secret `read-all-cbm-github-pat` is revoked — FreeForCharity/FFC-Cloudflare-Automation#848. Re-verified this run by **dispatching** 502 rather than reading Key Vault ([run 30504676163](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/actions/runs/30504676163)): `smoke` ✅, `report` ✅, `deliver` ❌ 401. The credential is present and non-empty, so the empty-guard cannot catch it.

## How this was produced

`scripts/generate-agentic-os-status.py` is standalone and **REST-only** by design ("so it runs anywhere a token is present"), so the Conductor ran it with its own credentials and is delivering the output by the same branch + PR route `deliver` would have used. No workflow change, no credential change, and the automated path resumes on its own once the PAT is rotated.

## Also included: the generator-side half of #909

The published feed predates the #909 fix, so this is the first feed to carry `in_flight_prs_rule` and `open_prs_total: 8`. A panel reading zero can now be distinguished from a panel that is broken. **The renderer does not read these keys yet** — `src/app/agentic-os/page.tsx` still branches on `in_flight_prs.length`, so that remains open work; this PR only makes the data available.

## Verification

- Staged blob parses as JSON; `generated_at` / gate count / PR count all match live GitHub state at 01:07Z.
- Diff is data-only — two copies of one file (`src/data` render + `public/data` stable URL), exactly the pair 502's `deliver` writes.
- `prettier` ran via the pre-commit hook.

Refs FreeForCharity/FFC-Cloudflare-Automation#848
Refs FreeForCharity/FFC-Cloudflare-Automation#909