### PR TITLE
chore(data): refresh the Agentic OS status feed (conductor run 51)

### DIFF
--- a/public/data/agentic-os-status.json
+++ b/public/data/agentic-os-status.json
@@ -1,30 +1,29 @@
 {
-  "generated_at": "2026-07-30T10:29:55Z",
+  "generated_at": "2026-07-30T13:26:09Z",
   "repo": "FreeForCharity/FFC-Cloudflare-Automation",
   "backlog_issues": [
     {
-      "number": 920,
-      "title": "221 uses the KV writer identity for a read-only search: pass scope: read and move it to whmcs-prod-read (104 is the precedent)",
+      "number": 930,
+      "title": "Nothing catches a PowerShell call to a function that does not exist — add a command-resolution guard to Validate Repository",
       "state": "open",
       "assignee": null,
-      "updated_at": "2026-07-30T10:29:14Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/920",
+      "updated_at": "2026-07-30T13:25:06Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/930",
       "labels": [
-        "security",
+        "enhancement",
         "agentic-os"
       ]
     },
     {
-      "number": 928,
-      "title": "221 has been broken since 2026-07-25: `Remove-Html` was deleted but its call site was left, and the approval gate hid it for 5 days",
+      "number": 719,
+      "title": "Agentic OS Conductor Log",
       "state": "open",
       "assignee": null,
-      "updated_at": "2026-07-30T10:28:41Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/928",
+      "updated_at": "2026-07-30T13:04:57Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719",
       "labels": [
-        "bug",
         "agentic-os",
-        "priority: high"
+        "claimed"
       ]
     },
     {
@@ -32,11 +31,24 @@
       "title": "228 has never succeeded: a secrets.* reference against an environment with no secrets, and nothing catches the class",
       "state": "open",
       "assignee": null,
-      "updated_at": "2026-07-30T10:13:16Z",
+      "updated_at": "2026-07-30T10:41:45Z",
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/912",
       "labels": [
         "security",
         "agentic-os"
+      ]
+    },
+    {
+      "number": 908,
+      "title": "ffcadmin data-refresh PRs hang forever once they fall behind main — three public dashboards went stale for 6h with all checks green",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-07-30T10:37:41Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/908",
+      "labels": [
+        "bug",
+        "agentic-os",
+        "claimed"
       ]
     },
     {
@@ -50,18 +62,6 @@
         "security",
         "agentic-os",
         "priority: high"
-      ]
-    },
-    {
-      "number": 719,
-      "title": "Agentic OS Conductor Log",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-07-30T10:04:48Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719",
-      "labels": [
-        "agentic-os",
-        "claimed"
       ]
     },
     {
@@ -110,19 +110,6 @@
       "labels": [
         "enhancement",
         "agentic-os"
-      ]
-    },
-    {
-      "number": 908,
-      "title": "ffcadmin data-refresh PRs hang forever once they fall behind main — three public dashboards went stale for 6h with all checks green",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-07-30T00:46:31Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/908",
-      "labels": [
-        "bug",
-        "agentic-os",
-        "claimed"
       ]
     },
     {
@@ -583,7 +570,7 @@
       "state": "open",
       "draft": true,
       "assignee": null,
-      "updated_at": "2026-07-30T04:35:41Z",
+      "updated_at": "2026-07-30T11:03:10Z",
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/839",
       "labels": [],
       "linked_agentic_issues": [
@@ -633,20 +620,6 @@
   "in_flight_prs_rule": "Open pull requests on this repo that are agent work on this backlog: a PR is listed when it carries the agentic-os label, or when its body references an agentic-os issue (e.g. 'Closes #123' / 'Refs #123'). Referenced-issue labels are what decide it — nothing labels the pull requests themselves.",
   "open_prs_total": 6,
   "conductor_log": [
-    {
-      "author": "clarkemoyer",
-      "created_at": "2026-07-29T22:25:24Z",
-      "body": "## Clarke — decisions needed (Conductor run 47)\n\n### 1. aprilhansen.com: your run-46 approval worked. Apex is fully live. ✅\n\nYou approved both gates at ~19:39Z and the cutover completed. I verified live rather than trusting\nthe run: apex resolves to the four Pages anycast IPs, `https://aprilhansen.com/` returns **200** from\n`Server: GitHub.com` with a Let's Encrypt cert for `CN=aprilhansen.com`, serving the real site\n(\"April Hansen | The Life and Legacy of The Trendy Little Geek\").\n\nThe run's `p…",
-      "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5123992682"
-    },
-    {
-      "author": "clarkemoyer",
-      "created_at": "2026-07-29T22:42:23Z",
-      "body": "## Conductor run 47 — END (2026-07-29)\n\nGate decisions and the two things needing Clarke are in the [decisions comment](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5123992682) above; this is the outcome record.\n\n### Headline: the aprilhansen half-cutover is resolved, and it exposed a second live defect\n\nClarke approved both 120 gates at ~19:39Z in response to run 46's escalation — **finish, not revert.** Verified live rather than from the run: apex on the …",
-      "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5124124943"
-    },
     {
       "author": "clarkemoyer",
       "created_at": "2026-07-29T23:43:03Z",
@@ -702,6 +675,20 @@
       "body": "## Conductor run 50 — START (2026-07-30)\n\n**Bootstrap:** 5/5 core clones fetched. One repair: `FFC-IN-ffcadmin.org` was stranded on\n`conductor/agentic-os-feed-refresh-r49`, a branch deleted server-side after run 49's feed PR\n(#744-era) merged — `git pull` was failing with \"no such ref was fetched\". Reset to `main`\n(`7b02c63`), stale local branch deleted. All 5 clones now on `main`, 0 dirty.\n\n**Run number:** 50, taken from the newest `Conductor run N — START` on this issue (49 at\n04:04:59Z), per …",
       "truncated": true,
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5129408492"
+    },
+    {
+      "author": "clarkemoyer",
+      "created_at": "2026-07-30T10:56:42Z",
+      "body": "## Conductor run 50 — END (2026-07-30)\n\n**THE HEADLINE: eight PRs merged, and removing one approval gate exposed a workflow that has never\nworked.** #926 moved 221 off the gated writer lane. The verification dispatch proved the credential\nhalf exactly as designed — and then died on `Remove-Html`, a PowerShell function **called at\n`whmcs-application-search.ps1:122` and defined nowhere in the repo**. 221 has never been able to\nreturn a match. It was invisible for precisely as long as it was gated.…",
+      "truncated": true,
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5129930836"
+    },
+    {
+      "author": "clarkemoyer",
+      "created_at": "2026-07-30T13:04:56Z",
+      "body": "## Conductor run 51 — START\n\n`2026-07-30`, workspace `C:\\ClaudeCodeDesktop\\Claude_AI_OS_Routine`.\n\n**Bootstrap: clean.** 5/5 core clones fetched and on origin default branch, **0 dirty**. (The\nffcadmin clone was parked on last run's `conductor/agentic-os-feed-r50` branch — returned to `main`,\nnow at `14ba967`.) Tooling verified: `gh` 2.96.0 (clarkemoyer, scopes incl. `project`), `az` 2.81.0,\n`m365` 11.9.0, gcloud 552.0.0. Rate budget at start: core **4995**, graphql **4764**.\n\nRun number taken f…",
+      "truncated": true,
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5131176580"
     }
   ],
   "pending_gates": [

--- a/src/data/agentic-os-status.json
+++ b/src/data/agentic-os-status.json
@@ -1,30 +1,29 @@
 {
-  "generated_at": "2026-07-30T10:29:55Z",
+  "generated_at": "2026-07-30T13:26:09Z",
   "repo": "FreeForCharity/FFC-Cloudflare-Automation",
   "backlog_issues": [
     {
-      "number": 920,
-      "title": "221 uses the KV writer identity for a read-only search: pass scope: read and move it to whmcs-prod-read (104 is the precedent)",
+      "number": 930,
+      "title": "Nothing catches a PowerShell call to a function that does not exist — add a command-resolution guard to Validate Repository",
       "state": "open",
       "assignee": null,
-      "updated_at": "2026-07-30T10:29:14Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/920",
+      "updated_at": "2026-07-30T13:25:06Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/930",
       "labels": [
-        "security",
+        "enhancement",
         "agentic-os"
       ]
     },
     {
-      "number": 928,
-      "title": "221 has been broken since 2026-07-25: `Remove-Html` was deleted but its call site was left, and the approval gate hid it for 5 days",
+      "number": 719,
+      "title": "Agentic OS Conductor Log",
       "state": "open",
       "assignee": null,
-      "updated_at": "2026-07-30T10:28:41Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/928",
+      "updated_at": "2026-07-30T13:04:57Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719",
       "labels": [
-        "bug",
         "agentic-os",
-        "priority: high"
+        "claimed"
       ]
     },
     {
@@ -32,11 +31,24 @@
       "title": "228 has never succeeded: a secrets.* reference against an environment with no secrets, and nothing catches the class",
       "state": "open",
       "assignee": null,
-      "updated_at": "2026-07-30T10:13:16Z",
+      "updated_at": "2026-07-30T10:41:45Z",
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/912",
       "labels": [
         "security",
         "agentic-os"
+      ]
+    },
+    {
+      "number": 908,
+      "title": "ffcadmin data-refresh PRs hang forever once they fall behind main — three public dashboards went stale for 6h with all checks green",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-07-30T10:37:41Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/908",
+      "labels": [
+        "bug",
+        "agentic-os",
+        "claimed"
       ]
     },
     {
@@ -50,18 +62,6 @@
         "security",
         "agentic-os",
         "priority: high"
-      ]
-    },
-    {
-      "number": 719,
-      "title": "Agentic OS Conductor Log",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-07-30T10:04:48Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719",
-      "labels": [
-        "agentic-os",
-        "claimed"
       ]
     },
     {
@@ -110,19 +110,6 @@
       "labels": [
         "enhancement",
         "agentic-os"
-      ]
-    },
-    {
-      "number": 908,
-      "title": "ffcadmin data-refresh PRs hang forever once they fall behind main — three public dashboards went stale for 6h with all checks green",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-07-30T00:46:31Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/908",
-      "labels": [
-        "bug",
-        "agentic-os",
-        "claimed"
       ]
     },
     {
@@ -583,7 +570,7 @@
       "state": "open",
       "draft": true,
       "assignee": null,
-      "updated_at": "2026-07-30T04:35:41Z",
+      "updated_at": "2026-07-30T11:03:10Z",
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/839",
       "labels": [],
       "linked_agentic_issues": [
@@ -633,20 +620,6 @@
   "in_flight_prs_rule": "Open pull requests on this repo that are agent work on this backlog: a PR is listed when it carries the agentic-os label, or when its body references an agentic-os issue (e.g. 'Closes #123' / 'Refs #123'). Referenced-issue labels are what decide it — nothing labels the pull requests themselves.",
   "open_prs_total": 6,
   "conductor_log": [
-    {
-      "author": "clarkemoyer",
-      "created_at": "2026-07-29T22:25:24Z",
-      "body": "## Clarke — decisions needed (Conductor run 47)\n\n### 1. aprilhansen.com: your run-46 approval worked. Apex is fully live. ✅\n\nYou approved both gates at ~19:39Z and the cutover completed. I verified live rather than trusting\nthe run: apex resolves to the four Pages anycast IPs, `https://aprilhansen.com/` returns **200** from\n`Server: GitHub.com` with a Let's Encrypt cert for `CN=aprilhansen.com`, serving the real site\n(\"April Hansen | The Life and Legacy of The Trendy Little Geek\").\n\nThe run's `p…",
-      "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5123992682"
-    },
-    {
-      "author": "clarkemoyer",
-      "created_at": "2026-07-29T22:42:23Z",
-      "body": "## Conductor run 47 — END (2026-07-29)\n\nGate decisions and the two things needing Clarke are in the [decisions comment](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5123992682) above; this is the outcome record.\n\n### Headline: the aprilhansen half-cutover is resolved, and it exposed a second live defect\n\nClarke approved both 120 gates at ~19:39Z in response to run 46's escalation — **finish, not revert.** Verified live rather than from the run: apex on the …",
-      "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5124124943"
-    },
     {
       "author": "clarkemoyer",
       "created_at": "2026-07-29T23:43:03Z",
@@ -702,6 +675,20 @@
       "body": "## Conductor run 50 — START (2026-07-30)\n\n**Bootstrap:** 5/5 core clones fetched. One repair: `FFC-IN-ffcadmin.org` was stranded on\n`conductor/agentic-os-feed-refresh-r49`, a branch deleted server-side after run 49's feed PR\n(#744-era) merged — `git pull` was failing with \"no such ref was fetched\". Reset to `main`\n(`7b02c63`), stale local branch deleted. All 5 clones now on `main`, 0 dirty.\n\n**Run number:** 50, taken from the newest `Conductor run N — START` on this issue (49 at\n04:04:59Z), per …",
       "truncated": true,
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5129408492"
+    },
+    {
+      "author": "clarkemoyer",
+      "created_at": "2026-07-30T10:56:42Z",
+      "body": "## Conductor run 50 — END (2026-07-30)\n\n**THE HEADLINE: eight PRs merged, and removing one approval gate exposed a workflow that has never\nworked.** #926 moved 221 off the gated writer lane. The verification dispatch proved the credential\nhalf exactly as designed — and then died on `Remove-Html`, a PowerShell function **called at\n`whmcs-application-search.ps1:122` and defined nowhere in the repo**. 221 has never been able to\nreturn a match. It was invisible for precisely as long as it was gated.…",
+      "truncated": true,
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5129930836"
+    },
+    {
+      "author": "clarkemoyer",
+      "created_at": "2026-07-30T13:04:56Z",
+      "body": "## Conductor run 51 — START\n\n`2026-07-30`, workspace `C:\\ClaudeCodeDesktop\\Claude_AI_OS_Routine`.\n\n**Bootstrap: clean.** 5/5 core clones fetched and on origin default branch, **0 dirty**. (The\nffcadmin clone was parked on last run's `conductor/agentic-os-feed-r50` branch — returned to `main`,\nnow at `14ba967`.) Tooling verified: `gh` 2.96.0 (clarkemoyer, scopes incl. `project`), `az` 2.81.0,\n`m365` 11.9.0, gcloud 552.0.0. Rate budget at start: core **4995**, graphql **4764**.\n\nRun number taken f…",
+      "truncated": true,
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5131176580"
     }
   ],
   "pending_gates": [


### PR DESCRIPTION
Refreshes the public Agentic OS status feed at `/agentic-os/`. Data only — both copies
(`src/data/` for the build, `public/data/` for the fetch path) move together, as always.

**Hand-delivered again, and this is the 4th consecutive run that way.** 502's `deliver` job still
returns `Bad credentials` (401) at its *Generate Agentic OS status feed* step — the expired
`read-all-cbm-github-pat`, tracked on hub issue 848. The generator itself is REST-only and
authenticates with `GH_TOKEN`, per its own docstring, so it runs fine locally:

```
PYTHONIOENCODING=utf-8 GH_TOKEN=$(gh auth token) python scripts/generate-agentic-os-status.py --output …
Wrote … (47 issues, 4 of 6 open PRs, 10 log entries, 2 pending gates).
```

## What changed since the published copy

The live feed reads `generated_at 2026-07-30T10:29:55Z` — about three hours stale, and stale in a way
that matters: it predates this run's merge of hub **#931**, so the public page still shows the WHMCS
application search as broken work in flight.

| | Published (10:29:55Z) | This PR |
| --- | --- | --- |
| Backlog issues | 46 | **47** |
| In-flight PRs | 5 | **4 of 6** |
| Pending gates | 2 | **2** (unchanged, both real) |

The two gates are unchanged and correct — `111` (`cloudflare-prod-write`, waiting since 07-26 14:34Z)
and `703` (`github-prod`, since 07-27 09:12Z). Both are Clarke's decisions; neither is a platform
agent, so #924's filter is doing its job here.

The backlog number moving 46 → 47 while two issues *closed* this run (928 as fixed, 929 as its
duplicate) is not a discrepancy — the panel is single-repo hub and excludes the conductor log issue,
and new issues landed from other agents in the same window. The org-wide-vs-single-repo scope gap is
already filed as hub issue 925 and is not addressed here.

## Verification

- Regenerated from a clean pull of `main` on both repos.
- `npx prettier@3.9.6 --write` on both files: no reformatting needed, the generator's output already
  matches.
- Committed blob is LF (`git show HEAD:src/data/… | file -` → `JSON text data`), not the CRLF the
  Windows writer produces — worth stating because that trap has bitten this exact path before.
- Both copies are byte-identical to each other.
