### PR TITLE
feat(data): refresh Agentic OS public status feed (run 61)

### DIFF
--- a/public/data/agentic-os-status.json
+++ b/public/data/agentic-os-status.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-31T10:29:29Z",
+  "generated_at": "2026-07-31T14:18:35Z",
   "org": "FreeForCharity",
   "repo": "FreeForCharity/FFC-Cloudflare-Automation",
   "repos": [
@@ -12,28 +12,165 @@
   "backlog_issues": [
     {
       "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 949,
-      "title": "🚨 Scheduled workflow failing: 228. WHMCS - Fraud Review (FraudLabs Pro) [FRAUDLABS+WHMCS]",
+      "number": 834,
+      "title": "Reads-level GitHub workflows are gated on github-prod: 8 of 21 scheduled runs failed or were cancelled waiting for approval",
       "state": "open",
       "assignee": null,
-      "updated_at": "2026-07-31T10:24:26Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/949",
+      "updated_at": "2026-07-31T14:14:53Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/834",
       "labels": [
-        "bug",
+        "agentic-os",
+        "agent-ready"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 719,
+      "title": "Agentic OS Conductor Log",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-07-31T14:01:58Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719",
+      "labels": [
+        "agentic-os",
+        "claimed"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 860,
+      "title": "Standardize on Node 24, and make the templates the rehearsal surface for every fleet-wide change",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-07-31T13:39:38Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/860",
+      "labels": [
+        "enhancement",
+        "agentic-os",
+        "priority: high"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 729,
+      "title": "Repo hygiene for the cutover test target FFC-EX-technologymonastery.org (child of #726)",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-07-31T13:38:32Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/729",
+      "labels": [
         "agentic-os"
       ]
     },
     {
       "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 948,
-      "title": "737 cannot tell a citation from a claim: `Refs #N` silently hid the top backlog pickup for 6 hours",
+      "number": 788,
+      "title": "Fleet: upload-pages-artifact@v5 silently drops dot-entries — .well-known/security.txt 404s on affected sites",
       "state": "open",
       "assignee": null,
-      "updated_at": "2026-07-31T10:18:52Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/948",
+      "updated_at": "2026-07-31T13:33:15Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/788",
+      "labels": [
+        "agentic-os"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 936,
+      "title": "Fleet sync of the www smoke probe will red-line 13 sites at once: SMOKE_REQUIRE_WWW is unset everywhere",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-07-31T13:18:06Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/936",
       "labels": [
         "bug",
-        "agentic-os"
+        "agentic-os",
+        "priority: high",
+        "agent-ready"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 863,
+      "title": "Establish the canonical URL standard on FFC_Single_Page_Template (trailingSlash + sitemap + canonicals + lighthouserc)",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-07-31T13:18:04Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/863",
+      "labels": [
+        "enhancement",
+        "agentic-os",
+        "agent-ready"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 859,
+      "title": "Baseline compliance is unmeasured across the fleet — policy pages, consent and security must hold regardless of template divergence",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-07-31T13:18:02Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/859",
+      "labels": [
+        "enhancement",
+        "agentic-os",
+        "priority: high",
+        "agent-ready"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 748,
+      "title": "Conditional basePath missing: default-Pages-URL sites serve pages with 404 assets (technomonasteries, Footer_Only_Template; audit fleet)",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-07-31T13:17:59Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/748",
+      "labels": [
+        "agentic-os",
+        "agent-ready"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 724,
+      "title": "Migrate remaining value out of FFC-IN-AI-Management into the hub (inventory + first tranche)",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-07-31T13:17:57Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/724",
+      "labels": [
+        "documentation",
+        "agentic-os",
+        "agent-ready"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 922,
+      "title": "The 5-15 backlog band is unmeetable because one label counts five different things: add agent-ready",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-07-31T12:41:33Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/922",
+      "labels": [
+        "enhancement",
+        "agentic-os",
+        "claimed"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 900,
+      "title": "Process metrics: \"green, clean, and stuck in draft\" is invisible — measure time-in-draft-while-mergeable",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-07-31T12:41:30Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/900",
+      "labels": [
+        "enhancement",
+        "agentic-os",
+        "claimed"
       ]
     },
     {
@@ -42,8 +179,22 @@
       "title": "workflow-logic on Windows: 43 subprocess calls decode with cp1252, not UTF-8 — and the regression is invisible to CI",
       "state": "open",
       "assignee": null,
-      "updated_at": "2026-07-31T10:17:01Z",
+      "updated_at": "2026-07-31T12:41:15Z",
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/945",
+      "labels": [
+        "bug",
+        "agentic-os",
+        "claimed"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 949,
+      "title": "🚨 Scheduled workflow failing: 228. WHMCS - Fraud Review (FraudLabs Pro) [FRAUDLABS+WHMCS]",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-07-31T10:24:26Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/949",
       "labels": [
         "bug",
         "agentic-os"
@@ -65,38 +216,12 @@
     },
     {
       "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 719,
-      "title": "Agentic OS Conductor Log",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-07-31T10:04:54Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719",
-      "labels": [
-        "agentic-os",
-        "claimed"
-      ]
-    },
-    {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
       "number": 921,
       "title": "🚨 Scheduled workflow failing: 502. Google - Analytics Report (GA4 -> JSON) [GOOGLE]",
       "state": "open",
       "assignee": null,
       "updated_at": "2026-07-31T08:38:55Z",
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/921",
-      "labels": [
-        "bug",
-        "agentic-os"
-      ]
-    },
-    {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 899,
-      "title": "726: `if: always()` on the tracking-issue step turns any upstream failure into a misleading \"could not search for an existing tracking issue\"",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-07-31T06:44:18Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/899",
       "labels": [
         "bug",
         "agentic-os"
@@ -158,32 +283,6 @@
       "labels": [
         "agentic-os",
         "claimed"
-      ]
-    },
-    {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 729,
-      "title": "Repo hygiene for the cutover test target FFC-EX-technologymonastery.org (child of #726)",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-07-31T01:13:17Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/729",
-      "labels": [
-        "agentic-os"
-      ]
-    },
-    {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 936,
-      "title": "Fleet sync of the www smoke probe will red-line 13 sites at once: SMOKE_REQUIRE_WWW is unset everywhere",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-07-30T21:29:48Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/936",
-      "labels": [
-        "bug",
-        "agentic-os",
-        "priority: high"
       ]
     },
     {
@@ -254,32 +353,6 @@
     },
     {
       "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 922,
-      "title": "The 5-15 backlog band is unmeetable because one label counts five different things: add agent-ready",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-07-30T01:25:17Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/922",
-      "labels": [
-        "enhancement",
-        "agentic-os"
-      ]
-    },
-    {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 862,
-      "title": "Footer_Only_Template sitemap advertises non-canonical URLs (every entry redirects)",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-07-30T00:33:01Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/862",
-      "labels": [
-        "bug",
-        "agentic-os"
-      ]
-    },
-    {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
       "number": 848,
       "title": "Key Vault: both read-all GitHub PATs are dead, and the read/write split is unenforced (per-secret RBAC + liveness monitoring)",
       "state": "open",
@@ -290,44 +363,6 @@
         "security",
         "agentic-os",
         "priority: high"
-      ]
-    },
-    {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 889,
-      "title": "Two mechanical gaps the lessons ledger names but cannot close (L02 error-swallowing sites, L06 lockfile validity)",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-07-29T19:29:25Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/889",
-      "labels": [
-        "bug",
-        "agentic-os"
-      ]
-    },
-    {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 834,
-      "title": "Reads-level GitHub workflows are gated on github-prod: 8 of 21 scheduled runs failed or were cancelled waiting for approval",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-07-29T16:25:47Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/834",
-      "labels": [
-        "agentic-os"
-      ]
-    },
-    {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 900,
-      "title": "Process metrics: \"green, clean, and stuck in draft\" is invisible — measure time-in-draft-while-mergeable",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-07-28T15:17:12Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/900",
-      "labels": [
-        "enhancement",
-        "agentic-os"
       ]
     },
     {
@@ -399,53 +434,12 @@
     },
     {
       "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 863,
-      "title": "Establish the canonical URL standard on FFC_Single_Page_Template (trailingSlash + sitemap + canonicals + lighthouserc)",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-07-25T17:30:28Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/863",
-      "labels": [
-        "enhancement",
-        "agentic-os"
-      ]
-    },
-    {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
       "number": 861,
       "title": "Epic: prove the web standard on FFC first, then propagate to the fleet in order of traffic",
       "state": "open",
       "assignee": null,
       "updated_at": "2026-07-25T17:29:51Z",
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/861",
-      "labels": [
-        "enhancement",
-        "agentic-os",
-        "priority: high"
-      ]
-    },
-    {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 859,
-      "title": "Baseline compliance is unmeasured across the fleet — policy pages, consent and security must hold regardless of template divergence",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-07-25T17:00:31Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/859",
-      "labels": [
-        "enhancement",
-        "agentic-os",
-        "priority: high"
-      ]
-    },
-    {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 860,
-      "title": "Standardize on Node 24, and make the templates the rehearsal surface for every fleet-wide change",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-07-25T16:52:35Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/860",
       "labels": [
         "enhancement",
         "agentic-os",
@@ -516,18 +510,6 @@
     },
     {
       "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 788,
-      "title": "Fleet: upload-pages-artifact@v5 silently drops dot-entries — .well-known/security.txt 404s on affected sites",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-07-24T19:18:31Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/788",
-      "labels": [
-        "agentic-os"
-      ]
-    },
-    {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
       "number": 823,
       "title": "WHMCS: auto-populate client custom fields from product-order answers (order → client sync)",
       "state": "open",
@@ -561,19 +543,6 @@
       "updated_at": "2026-07-23T15:19:13Z",
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/770",
       "labels": [
-        "agentic-os"
-      ]
-    },
-    {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 724,
-      "title": "Migrate remaining value out of FFC-IN-AI-Management into the hub (inventory + first tranche)",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-07-23T15:19:00Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/724",
-      "labels": [
-        "documentation",
         "agentic-os"
       ]
     },
@@ -622,18 +591,6 @@
       "assignee": null,
       "updated_at": "2026-07-20T16:10:58Z",
       "url": "https://github.com/FreeForCharity/FFC-IN-ffcadmin.org/issues/670",
-      "labels": [
-        "agentic-os"
-      ]
-    },
-    {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 748,
-      "title": "Conditional basePath missing: default-Pages-URL sites serve pages with 404 assets (technomonasteries, Footer_Only_Template; audit fleet)",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-07-20T13:07:59Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/748",
       "labels": [
         "agentic-os"
       ]
@@ -751,12 +708,96 @@
   "in_flight_prs": [
     {
       "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 957,
+      "title": "feat(739): measure PRs that are green, clean and stuck in draft",
+      "state": "open",
+      "draft": true,
+      "assignee": null,
+      "updated_at": "2026-07-31T14:15:53Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/957",
+      "labels": [],
+      "linked_agentic_issues": [
+        900
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 956,
+      "title": "feat(922): add `agent-ready` so the 5–15 band measures work an agent can actually do",
+      "state": "open",
+      "draft": true,
+      "assignee": null,
+      "updated_at": "2026-07-31T14:15:46Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/956",
+      "labels": [],
+      "linked_agentic_issues": [
+        922,
+        835,
+        724,
+        748,
+        834,
+        859,
+        863,
+        936,
+        909
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 953,
+      "title": "fix(945): pin `encoding=utf-8` on 43 text-mode subprocess calls, and guard the class statically",
+      "state": "open",
+      "draft": false,
+      "assignee": null,
+      "updated_at": "2026-07-31T14:15:36Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/953",
+      "labels": [],
+      "linked_agentic_issues": [
+        945,
+        921,
+        943
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 958,
+      "title": "docs(safety): re-audit the environment gate map — `google-prod-write` was missing from the gated list",
+      "state": "open",
+      "draft": true,
+      "assignee": null,
+      "updated_at": "2026-07-31T14:14:35Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/958",
+      "labels": [
+        "agentic-os"
+      ],
+      "linked_agentic_issues": [
+        948
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 950,
+      "title": "docs: run-58 lessons — a crashed check that read as clean, a stash that ate a merge, and `Refs`-as-citation",
+      "state": "open",
+      "draft": true,
+      "assignee": null,
+      "updated_at": "2026-07-31T13:52:06Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/950",
+      "labels": [],
+      "linked_agentic_issues": [
+        945,
+        719,
+        948
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
       "number": 946,
       "title": "docs: run-57 lessons — cp1252 subprocess decoding, and a triage discipline",
       "state": "open",
       "draft": true,
       "assignee": null,
-      "updated_at": "2026-07-31T10:28:51Z",
+      "updated_at": "2026-07-31T10:36:29Z",
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/946",
       "labels": [],
       "linked_agentic_issues": [
@@ -771,7 +812,7 @@
       "state": "open",
       "draft": true,
       "assignee": null,
-      "updated_at": "2026-07-31T10:27:39Z",
+      "updated_at": "2026-07-31T10:35:35Z",
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/940",
       "labels": [],
       "linked_agentic_issues": [
@@ -981,36 +1022,8 @@
     }
   ],
   "in_flight_prs_rule": "Open pull requests that are agent work on this backlog, across every repository listed in `repos` — the same org-wide scope as the backlog above, and as the pickup query in AGENTS.md. A PR is listed when it carries the agentic-os label, or when its body references an agentic-os issue in its OWN repository (e.g. 'Closes #123' / 'Refs #123'); a bare #123 is repo-local, so the same number in two repos is two different issues. Referenced-issue labels are what decide it — nothing labels the pull requests themselves. `open_prs_total` is the unfiltered open-PR count over exactly these same repositories.",
-  "open_prs_total": 76,
+  "open_prs_total": 81,
   "conductor_log": [
-    {
-      "author": "clarkemoyer",
-      "created_at": "2026-07-30T22:29:34Z",
-      "body": "## Conductor run 54 — END (2026-07-30 ~23:00Z)\n\n**The public page stopped lying.** `/agentic-os` had been publishing 49 backlog issues and calling\nthat \"the backlog\"; it now publishes **57** across both repos. That is the headline, and it came from\na worker PR, not from me.\n\n### Supervised: #938 reviewed by execution, merged, verified, and its issue closed\n\nReviewed under the #935 rule — I reintroduced every defect the PR claims to defend against instead of\nreading the wiring and agreeing:\n\n| Mu…",
-      "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5136926221"
-    },
-    {
-      "author": "clarkemoyer",
-      "created_at": "2026-07-31T01:05:07Z",
-      "body": "## Conductor run 55 — START (2026-07-30 ~23:5xZ)\n\nBootstrap clean: 5/5 core clones fetched + fast-forwarded to `main`, **0 dirty**\n(`0005fdf` hub, `fa3f600` freeforcharity, `0aaf677` ffcadmin, `b4e6d32` SPT, `c310e85` FOT).\nBudget at start: core 4945, graphql 3880.\n\n**Run number taken from this log, not my notes** — `state/CONDUCTOR.md` had stalled at run 51 while\n#719 reached 54, the same drift run 44 repaired. The log is the source of truth; recovering 52-54\nfrom here before acting.\n\nPlan, in …",
-      "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5137974111"
-    },
-    {
-      "author": "clarkemoyer",
-      "created_at": "2026-07-31T01:24:21Z",
-      "body": "## Conductor run 55 — END (2026-07-31 ~01:3xZ)\n\n**A PR merged green and its central capability does nothing in production. One warning line said so.**\n\n### Supervised: #941 reviewed by execution, merged — and then found inert\n\n#941 (the #939 fix) landed **01:15:26Z** (`f8efcaa`) with 6/6 checks, 47 test cases and both\nmutations proved in its body. I dispatched 737 on `main` immediately rather than inferring from green\nCI — run 50's rule, that a workflow entering service gets driven to a **termin…",
-      "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5138106387"
-    },
-    {
-      "author": "clarkemoyer",
-      "created_at": "2026-07-31T04:04:47Z",
-      "body": "## Conductor run 56 — START (2026-07-31 ~02:0xZ)\n\n**Bootstrap:** 5/5 core clones fetched. Two were parked off `main` by run 55 and were reset:\n`FFC-Cloudflare-Automation` was on `docs/local-run-env-facts`, `FFC-IN-ffcadmin.org` on\n`chore/agentic-os-status-run55`. All 5 clean (0 dirty), all on origin default. Hub `main` at\n`f8efcaa` (#941, run 55's merge). Run number taken from the #719 tail with `--paginate` (newest\nSTART = 55).\n\n**Gates at start: 2 waiting, both write, both unchanged.**\n- `703 …",
-      "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5139137652"
-    },
     {
       "author": "clarkemoyer",
       "created_at": "2026-07-31T04:44:36Z",
@@ -1052,6 +1065,34 @@
       "body": "## Conductor run 58 — START (2026-07-31, ~09:5xZ)\n\nLocal Windows host, gh as clarkemoyer. Bootstrap clean: all 5 core clones on `main`, 0 dirty,\nfetched/pruned. Hub at `abb53cf` (#944), ffcadmin at `7c12b26` (#767).\n\nCarried in from run 57 (`state/CONDUCTOR.md`):\n- **#945** is the top unclaimed pickup (43 enumerated `subprocess(text=True)` sites, proven one-line fix).\n- **#936** still unclaimed, still gates the #738 fleet sync.\n- **Gate 111 reaps 08-02** — janitor 734's 7-day reap. After that it…",
       "truncated": true,
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5141715215"
+    },
+    {
+      "author": "clarkemoyer",
+      "created_at": "2026-07-31T10:40:21Z",
+      "body": "## Conductor run 58 — END (2026-07-31 ~11:0xZ)\n\n### Merged: #947, reviewed by reintroducing the defect\n\n`cdda8dc`. #947 moved the WHMCS and Azure lanes into 740's watch list. I did not take its\nmutation-test table on trust — I reproduced both mutations on this Windows host:\n\n| mutation | pre-existing guard | the two new tests |\n| --- | --- | --- |\n| drop 228 from the watch list | fails | both fail |\n| drop 228 **and** re-exclude it with the old rationale | **PASSES — silent** | both fail, naming…",
+      "truncated": true,
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5141994421"
+    },
+    {
+      "author": "clarkemoyer",
+      "created_at": "2026-07-31T10:40:48Z",
+      "body": "## Run 58 — correction: board went 195 → 199, not 197 → 201\n\nBoth figures in the END comment above are wrong. **195 at the start of the run, 199 at the end.**\n\nI took **197** as the baseline, but that was a *mid-run* reading — the count after I had already\nadded #947 and #948 and verified it. The true starting count was **195** (run 57 left it at 194; one\nitem arrived between runs). Then I added four items in total, not four on top of 197.\n\nVerified end state, counted rather than derived: **199 …",
+      "truncated": true,
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5141997790"
+    },
+    {
+      "author": "clarkemoyer",
+      "created_at": "2026-07-31T13:59:19Z",
+      "body": "## Run 58 — backlog closeout: 10 issues taken, 4 shipped, 4 closed, 2 handed back\n\nClarke asked for at least 10 backlog items taken over and finished without human intervention. I claimed 10 (label + `CLAIM:` comment each), and the honest outcome is that **they were not all what they looked like**.\n\n### Shipped — 4 PRs, all green on both required checks\n\n| PR | Issue | What |\n| --- | --- | --- |\n| **#953** | #945 | `encoding=utf-8` on 43 text-mode subprocess sites + a static AST guard in CI |\n| …",
+      "truncated": true,
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5143685584"
+    },
+    {
+      "author": "clarkemoyer",
+      "created_at": "2026-07-31T14:01:58Z",
+      "body": "## Run 59 — START (2026-07-31T14:01Z)\n\nBootstrap OK. All 5 core clones fetched + fast-forwarded to `main` (hub `81c9bec`, ffcadmin `baa6220`, freeforcharity `fa3f600`, SPT `b4e6d32`, FOT `c310e85`); all clean. Tooling verified: gh 2.96.0 (clarkemoyer), az 2.81.0, m365 11.9.0, gcloud 552.0.0. Budget at start: core 4945/5000, graphql 4887.\n\nRe-read AGENTS.md + docs/workflow-safety-and-approvals.md from `main` before acting.\n\nCarrying in from run 58: 4 green drafts of mine (#953, #955, #956, #957) …",
+      "truncated": true,
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5143712199"
     }
   ],
   "pending_gates": [

--- a/public/data/agentic-os-status.json
+++ b/public/data/agentic-os-status.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-31T16:22:10Z",
+  "generated_at": "2026-07-31T19:15:17Z",
   "org": "FreeForCharity",
   "repo": "FreeForCharity/FFC-Cloudflare-Automation",
   "repos": [
@@ -12,12 +12,12 @@
   "backlog_issues": [
     {
       "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 960,
-      "title": "734 janitor cancels waiting deployment gates silently — warn before the reap, and publish the real cancellation time",
+      "number": 964,
+      "title": "Ledger table has no column-count guard: a stray pipe truncates a lesson, and a reviewer 'fixing' correct escaping does the same",
       "state": "open",
       "assignee": null,
-      "updated_at": "2026-07-31T16:16:12Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/960",
+      "updated_at": "2026-07-31T19:12:18Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/964",
       "labels": [
         "agentic-os",
         "agent-ready"
@@ -29,11 +29,24 @@
       "title": "Agentic OS Conductor Log",
       "state": "open",
       "assignee": null,
-      "updated_at": "2026-07-31T16:05:52Z",
+      "updated_at": "2026-07-31T19:05:36Z",
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719",
       "labels": [
         "agentic-os",
         "claimed"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 960,
+      "title": "734 janitor cancels waiting deployment gates silently — warn before the reap, and publish the real cancellation time",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-07-31T16:16:12Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/960",
+      "labels": [
+        "agentic-os",
+        "agent-ready"
       ]
     },
     {
@@ -169,20 +182,6 @@
         "documentation",
         "agentic-os",
         "agent-ready"
-      ]
-    },
-    {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 900,
-      "title": "Process metrics: \"green, clean, and stuck in draft\" is invisible — measure time-in-draft-while-mergeable",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-07-31T12:41:30Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/900",
-      "labels": [
-        "enhancement",
-        "agentic-os",
-        "claimed"
       ]
     },
     {
@@ -693,6 +692,19 @@
   "ready_issues": [
     {
       "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 964,
+      "title": "Ledger table has no column-count guard: a stray pipe truncates a lesson, and a reviewer 'fixing' correct escaping does the same",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-07-31T19:12:18Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/964",
+      "labels": [
+        "agentic-os",
+        "agent-ready"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
       "number": 960,
       "title": "734 janitor cancels waiting deployment gates silently — warn before the reap, and publish the real cancellation time",
       "state": "open",
@@ -789,37 +801,52 @@
       ]
     }
   ],
-  "ready_count": 7,
+  "ready_count": 8,
   "ready_rule": "Open issues labeled 'agent-ready': unclaimed, unblocked, one-PR-scoped and carrying acceptance criteria — the queue a sandboxed agent can pick from now. A strict subset of backlog_issues, which stays the full 'agentic-os' topic set (epics, machine-managed rolling issues, human-blocked items and durable findings all remain counted there).",
   "in_flight_prs": [
-    {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 957,
-      "title": "feat(739): measure PRs that are green, clean and stuck in draft",
-      "state": "open",
-      "draft": false,
-      "assignee": null,
-      "updated_at": "2026-07-31T16:21:09Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/957",
-      "labels": [],
-      "linked_agentic_issues": [
-        900
-      ]
-    },
     {
       "repo": "FreeForCharity/FFC-Cloudflare-Automation",
       "number": 950,
       "title": "docs: run-58 lessons — a crashed check that read as clean, a stash that ate a merge, and `Refs`-as-citation",
       "state": "open",
-      "draft": true,
+      "draft": false,
       "assignee": null,
-      "updated_at": "2026-07-31T13:52:06Z",
+      "updated_at": "2026-07-31T19:11:04Z",
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/950",
       "labels": [],
       "linked_agentic_issues": [
         945,
         719,
         948
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 935,
+      "title": "docs(agents): review a guard by reintroducing the defect, not by reading the wiring",
+      "state": "open",
+      "draft": false,
+      "assignee": null,
+      "updated_at": "2026-07-31T19:09:26Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/935",
+      "labels": [],
+      "linked_agentic_issues": [
+        930,
+        929
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 961,
+      "title": "feat(hooks): block `grep -P`, which matches nothing here instead of erroring",
+      "state": "open",
+      "draft": true,
+      "assignee": null,
+      "updated_at": "2026-07-31T16:35:12Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/961",
+      "labels": [],
+      "linked_agentic_issues": [
+        945
       ]
     },
     {
@@ -894,21 +921,6 @@
         "agentic-os"
       ],
       "linked_agentic_issues": []
-    },
-    {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 935,
-      "title": "docs(agents): review a guard by reintroducing the defect, not by reading the wiring",
-      "state": "open",
-      "draft": true,
-      "assignee": null,
-      "updated_at": "2026-07-30T16:33:57Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/935",
-      "labels": [],
-      "linked_agentic_issues": [
-        930,
-        929
-      ]
     },
     {
       "repo": "FreeForCharity/FFC-Cloudflare-Automation",
@@ -1040,29 +1052,8 @@
     }
   ],
   "in_flight_prs_rule": "Open pull requests that are agent work on this backlog, across every repository listed in `repos` — the same org-wide scope as the backlog above, and as the pickup query in AGENTS.md. A PR is listed when it carries the agentic-os label, or when its body references an agentic-os issue in its OWN repository (e.g. 'Closes #123' / 'Refs #123'); a bare #123 is repo-local, so the same number in two repos is two different issues. Referenced-issue labels are what decide it — nothing labels the pull requests themselves. `open_prs_total` is the unfiltered open-PR count over exactly these same repositories.",
-  "open_prs_total": 78,
+  "open_prs_total": 76,
   "conductor_log": [
-    {
-      "author": "clarkemoyer",
-      "created_at": "2026-07-31T07:40:31Z",
-      "body": "## Conductor run 57 — END (2026-07-31 ~07:5xZ)\n\n### A PR declined to tick a criterion it couldn't reach, and I am the machine that could\n\n**#944 reviewed by execution and merged** (`abb53cf`). Its author, on a Linux sandbox, wrote:\n*\"The Windows criterion is NOT ticked … that confirmation needs a Windows host.\"* That was the\ncorrect call and it left exactly one gap. Baseline `d956a78` vs `ee663c5`, same shell, nothing else\nchanged:\n\n| | modules failing | `harness crashed:` | PASS | FAIL |\n| --- …",
-      "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5140537756"
-    },
-    {
-      "author": "clarkemoyer",
-      "created_at": "2026-07-31T10:04:54Z",
-      "body": "## Conductor run 58 — START (2026-07-31, ~09:5xZ)\n\nLocal Windows host, gh as clarkemoyer. Bootstrap clean: all 5 core clones on `main`, 0 dirty,\nfetched/pruned. Hub at `abb53cf` (#944), ffcadmin at `7c12b26` (#767).\n\nCarried in from run 57 (`state/CONDUCTOR.md`):\n- **#945** is the top unclaimed pickup (43 enumerated `subprocess(text=True)` sites, proven one-line fix).\n- **#936** still unclaimed, still gates the #738 fleet sync.\n- **Gate 111 reaps 08-02** — janitor 734's 7-day reap. After that it…",
-      "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5141715215"
-    },
-    {
-      "author": "clarkemoyer",
-      "created_at": "2026-07-31T10:40:21Z",
-      "body": "## Conductor run 58 — END (2026-07-31 ~11:0xZ)\n\n### Merged: #947, reviewed by reintroducing the defect\n\n`cdda8dc`. #947 moved the WHMCS and Azure lanes into 740's watch list. I did not take its\nmutation-test table on trust — I reproduced both mutations on this Windows host:\n\n| mutation | pre-existing guard | the two new tests |\n| --- | --- | --- |\n| drop 228 from the watch list | fails | both fail |\n| drop 228 **and** re-exclude it with the old rationale | **PASSES — silent** | both fail, naming…",
-      "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5141994421"
-    },
     {
       "author": "clarkemoyer",
       "created_at": "2026-07-31T10:40:48Z",
@@ -1111,6 +1102,27 @@
       "body": "## Run 60 — START (2026-07-31T16:04Z)\n\nBootstrap clean: all 5 core clones fetched and reset to `origin/main` (hub `cf7ed23`), 0 dirty. `gh` authed as `clarkemoyer`. Re-read `AGENTS.md` + `docs/workflow-safety-and-approvals.md` from the refreshed tree.\n\n**Inherited state from run 59 + the cloud worker run (15:46Z):**\n- **#956 landed unattended** as predicted — `agent-ready` is now on `main`, so this run's backlog band measures the ready queue rather than the topic label for the first time.\n- The …",
       "truncated": true,
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5144935129"
+    },
+    {
+      "author": "clarkemoyer",
+      "created_at": "2026-07-31T16:36:05Z",
+      "body": "## Run 60 — END (2026-07-31T16:4xZ) · core 4899 / graphql 4257\n\nLanding-heavy run. **6 PRs merged, 2 issues filed, 1 hook draft opened, 0 gates approved.**\n\n### ⛔ Gates — 0 auto-approved, 2 held (9th consecutive run). **Run 59's deadlines were wrong; here are the real ones.**\n\nBoth are write environments, so neither is mine to approve. No response this run — left pending.\n\nI re-derived the reap instead of inheriting it, and run 59 was **a day early on both**. The reap is\nnot a GitHub timeout: it…",
+      "truncated": true,
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5145212538"
+    },
+    {
+      "author": "clarkemoyer",
+      "created_at": "2026-07-31T16:41:50Z",
+      "body": "## Run 60 — closeout: #917 landed (2026-07-31T16:41Z)\n\nThe END entry above recorded [#917](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/917)\nas green and queued. It merged unattended at 16:41Z (`d69b837`), so the run's final tally is **6 of\n6 PRs merged** — #914, #958, #959, #957, #836, #917 — with no supervise work carried into run 61.\nBoard set to Done; the board is now clean at 0 statusless and 0 stale.\n\nBoth encoding fixes are therefore on `main`: the parent-only pin in #…",
+      "truncated": true,
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5145265958"
+    },
+    {
+      "author": "clarkemoyer",
+      "created_at": "2026-07-31T19:05:36Z",
+      "body": "## Run 61 — START (2026-07-31T18:3xZ)\n\nBootstrap clean: all 5 core clones fetched and reset to `origin/main`, 0 dirty files. Hub at\n`d69b837` (#917, landed by run 60). `gh` authed as `clarkemoyer`. Rate at open: core **4966** /\ngraphql **4858**.\n\n**Gates (step 2 preview): 2 pending, both write, both held.** Unchanged from runs 52–60 — this is\nthe 10th consecutive run holding them.\n\n| Run | Workflow | Env | Created | Reaped by 734 |\n| --- | --- | --- | --- | --- |\n| [30206375399](https://github.c…",
+      "truncated": true,
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5146519199"
     }
   ],
   "pending_gates": [

--- a/public/data/agentic-os-status.json
+++ b/public/data/agentic-os-status.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-31T14:18:35Z",
+  "generated_at": "2026-07-31T16:22:10Z",
   "org": "FreeForCharity",
   "repo": "FreeForCharity/FFC-Cloudflare-Automation",
   "repos": [
@@ -12,12 +12,12 @@
   "backlog_issues": [
     {
       "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 834,
-      "title": "Reads-level GitHub workflows are gated on github-prod: 8 of 21 scheduled runs failed or were cancelled waiting for approval",
+      "number": 960,
+      "title": "734 janitor cancels waiting deployment gates silently — warn before the reap, and publish the real cancellation time",
       "state": "open",
       "assignee": null,
-      "updated_at": "2026-07-31T14:14:53Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/834",
+      "updated_at": "2026-07-31T16:16:12Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/960",
       "labels": [
         "agentic-os",
         "agent-ready"
@@ -29,11 +29,37 @@
       "title": "Agentic OS Conductor Log",
       "state": "open",
       "assignee": null,
-      "updated_at": "2026-07-31T14:01:58Z",
+      "updated_at": "2026-07-31T16:05:52Z",
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719",
       "labels": [
         "agentic-os",
         "claimed"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 949,
+      "title": "🚨 Scheduled workflow failing: 228. WHMCS - Fraud Review (FraudLabs Pro) [FRAUDLABS+WHMCS]",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-07-31T15:01:12Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/949",
+      "labels": [
+        "bug",
+        "agentic-os"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 834,
+      "title": "Reads-level GitHub workflows are gated on github-prod: 8 of 21 scheduled runs failed or were cancelled waiting for approval",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-07-31T14:14:53Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/834",
+      "labels": [
+        "agentic-os",
+        "agent-ready"
       ]
     },
     {
@@ -147,20 +173,6 @@
     },
     {
       "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 922,
-      "title": "The 5-15 backlog band is unmeetable because one label counts five different things: add agent-ready",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-07-31T12:41:33Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/922",
-      "labels": [
-        "enhancement",
-        "agentic-os",
-        "claimed"
-      ]
-    },
-    {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
       "number": 900,
       "title": "Process metrics: \"green, clean, and stuck in draft\" is invisible — measure time-in-draft-while-mergeable",
       "state": "open",
@@ -171,33 +183,6 @@
         "enhancement",
         "agentic-os",
         "claimed"
-      ]
-    },
-    {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 945,
-      "title": "workflow-logic on Windows: 43 subprocess calls decode with cp1252, not UTF-8 — and the regression is invisible to CI",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-07-31T12:41:15Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/945",
-      "labels": [
-        "bug",
-        "agentic-os",
-        "claimed"
-      ]
-    },
-    {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 949,
-      "title": "🚨 Scheduled workflow failing: 228. WHMCS - Fraud Review (FraudLabs Pro) [FRAUDLABS+WHMCS]",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-07-31T10:24:26Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/949",
-      "labels": [
-        "bug",
-        "agentic-os"
       ]
     },
     {
@@ -705,73 +690,120 @@
       ]
     }
   ],
+  "ready_issues": [
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 960,
+      "title": "734 janitor cancels waiting deployment gates silently — warn before the reap, and publish the real cancellation time",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-07-31T16:16:12Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/960",
+      "labels": [
+        "agentic-os",
+        "agent-ready"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 834,
+      "title": "Reads-level GitHub workflows are gated on github-prod: 8 of 21 scheduled runs failed or were cancelled waiting for approval",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-07-31T14:14:53Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/834",
+      "labels": [
+        "agentic-os",
+        "agent-ready"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 936,
+      "title": "Fleet sync of the www smoke probe will red-line 13 sites at once: SMOKE_REQUIRE_WWW is unset everywhere",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-07-31T13:18:06Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/936",
+      "labels": [
+        "bug",
+        "agentic-os",
+        "priority: high",
+        "agent-ready"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 863,
+      "title": "Establish the canonical URL standard on FFC_Single_Page_Template (trailingSlash + sitemap + canonicals + lighthouserc)",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-07-31T13:18:04Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/863",
+      "labels": [
+        "enhancement",
+        "agentic-os",
+        "agent-ready"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 859,
+      "title": "Baseline compliance is unmeasured across the fleet — policy pages, consent and security must hold regardless of template divergence",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-07-31T13:18:02Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/859",
+      "labels": [
+        "enhancement",
+        "agentic-os",
+        "priority: high",
+        "agent-ready"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 748,
+      "title": "Conditional basePath missing: default-Pages-URL sites serve pages with 404 assets (technomonasteries, Footer_Only_Template; audit fleet)",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-07-31T13:17:59Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/748",
+      "labels": [
+        "agentic-os",
+        "agent-ready"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 724,
+      "title": "Migrate remaining value out of FFC-IN-AI-Management into the hub (inventory + first tranche)",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-07-31T13:17:57Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/724",
+      "labels": [
+        "documentation",
+        "agentic-os",
+        "agent-ready"
+      ]
+    }
+  ],
+  "ready_count": 7,
+  "ready_rule": "Open issues labeled 'agent-ready': unclaimed, unblocked, one-PR-scoped and carrying acceptance criteria — the queue a sandboxed agent can pick from now. A strict subset of backlog_issues, which stays the full 'agentic-os' topic set (epics, machine-managed rolling issues, human-blocked items and durable findings all remain counted there).",
   "in_flight_prs": [
     {
       "repo": "FreeForCharity/FFC-Cloudflare-Automation",
       "number": 957,
       "title": "feat(739): measure PRs that are green, clean and stuck in draft",
       "state": "open",
-      "draft": true,
+      "draft": false,
       "assignee": null,
-      "updated_at": "2026-07-31T14:15:53Z",
+      "updated_at": "2026-07-31T16:21:09Z",
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/957",
       "labels": [],
       "linked_agentic_issues": [
         900
-      ]
-    },
-    {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 956,
-      "title": "feat(922): add `agent-ready` so the 5–15 band measures work an agent can actually do",
-      "state": "open",
-      "draft": true,
-      "assignee": null,
-      "updated_at": "2026-07-31T14:15:46Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/956",
-      "labels": [],
-      "linked_agentic_issues": [
-        922,
-        835,
-        724,
-        748,
-        834,
-        859,
-        863,
-        936,
-        909
-      ]
-    },
-    {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 953,
-      "title": "fix(945): pin `encoding=utf-8` on 43 text-mode subprocess calls, and guard the class statically",
-      "state": "open",
-      "draft": false,
-      "assignee": null,
-      "updated_at": "2026-07-31T14:15:36Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/953",
-      "labels": [],
-      "linked_agentic_issues": [
-        945,
-        921,
-        943
-      ]
-    },
-    {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 958,
-      "title": "docs(safety): re-audit the environment gate map — `google-prod-write` was missing from the gated list",
-      "state": "open",
-      "draft": true,
-      "assignee": null,
-      "updated_at": "2026-07-31T14:14:35Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/958",
-      "labels": [
-        "agentic-os"
-      ],
-      "linked_agentic_issues": [
-        948
       ]
     },
     {
@@ -907,20 +939,6 @@
       ]
     },
     {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 914,
-      "title": "feat(722): fail PRs that add a large blob in any commit, not just the tip",
-      "state": "open",
-      "draft": true,
-      "assignee": null,
-      "updated_at": "2026-07-29T19:24:09Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/914",
-      "labels": [
-        "agentic-os"
-      ],
-      "linked_agentic_issues": []
-    },
-    {
       "repo": "FreeForCharity/FFC-IN-FFC_Single_Page_Template",
       "number": 432,
       "title": "fix(security): stop the inert public/_headers check from masking the only CSP that is served",
@@ -1022,36 +1040,8 @@
     }
   ],
   "in_flight_prs_rule": "Open pull requests that are agent work on this backlog, across every repository listed in `repos` — the same org-wide scope as the backlog above, and as the pickup query in AGENTS.md. A PR is listed when it carries the agentic-os label, or when its body references an agentic-os issue in its OWN repository (e.g. 'Closes #123' / 'Refs #123'); a bare #123 is repo-local, so the same number in two repos is two different issues. Referenced-issue labels are what decide it — nothing labels the pull requests themselves. `open_prs_total` is the unfiltered open-PR count over exactly these same repositories.",
-  "open_prs_total": 81,
+  "open_prs_total": 78,
   "conductor_log": [
-    {
-      "author": "clarkemoyer",
-      "created_at": "2026-07-31T04:44:36Z",
-      "body": "## Conductor run 56 — END (2026-07-31 ~05:0xZ)\n\n*(Correction to my own START: it was posted 04:04:47Z, not \"~02:0xZ\" — I wrote the header before\nbootstrap finished and did not restamp it.)*\n\n### The cross-repo claim sweep works in production, and #939 is closed\n\nA worker opened **#942** at 03:21Z against run 55's top pickup. I reviewed it **by execution, not by\nreading its body** (#935), merged it, and then proved the capability live.\n\n**The live population, measured myself rather than taken fro…",
-      "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5139354484"
-    },
-    {
-      "author": "clarkemoyer",
-      "created_at": "2026-07-31T04:51:57Z",
-      "body": "## Run 54 — correction: the paginate incident was 136× larger than I reported\n\nMy END comment said the runaway `gh api graphql --paginate` produced \"18,000 rows … ~400 GraphQL\npoints.\" **Both figures were wrong, and the reason they were wrong is the more useful finding.**\n\n**The loop was still running when I measured it.** I checked `ps`, saw no `gh` process, concluded it\nhad stopped, and sampled the output file at 18,000 rows. The file was still growing. It kept growing\nfor roughly six and a ha…",
-      "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5139396795"
-    },
-    {
-      "author": "clarkemoyer",
-      "created_at": "2026-07-31T07:06:46Z",
-      "body": "## Conductor run 57 — START (2026-07-31 07:0xZ)\n\n**Bootstrap:** 5/5 core clones fetched. Hub was parked on `conductor/lessons-r54` by run 56 and was\nreturned to `main` (`d956a78`, #942); `ffcadmin` fast-forwarded 4 commits to `6794419`. All on\norigin default. Run number taken from the `--paginate` tail of this issue: newest START = 56, so\nthis is **57**. My workspace `state/CONDUCTOR.md` had gone stale at run 54 — runs 55 and 56 exist\nonly in this log, which is the correct source of truth and is…",
-      "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5140281248"
-    },
-    {
-      "author": "clarkemoyer",
-      "created_at": "2026-07-31T07:39:14Z",
-      "body": "## Run 57 — gate decisions: 0 auto-approved, and 111 re-verified rather than re-asserted\n\n| Run | Workflow | Environment | Waiting | Decision |\n| --- | --- | --- | --- | --- |\n| [30206375399](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/actions/runs/30206375399) | **111.** Redirect Rule trendylittlegeek → aprilhansen | `cloudflare-prod-write` | since 07-26 14:34Z | **recommend approve** — Clarke only |\n| [30252940885](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/act…",
-      "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5140527805"
-    },
     {
       "author": "clarkemoyer",
       "created_at": "2026-07-31T07:40:31Z",
@@ -1093,6 +1083,34 @@
       "body": "## Run 59 — START (2026-07-31T14:01Z)\n\nBootstrap OK. All 5 core clones fetched + fast-forwarded to `main` (hub `81c9bec`, ffcadmin `baa6220`, freeforcharity `fa3f600`, SPT `b4e6d32`, FOT `c310e85`); all clean. Tooling verified: gh 2.96.0 (clarkemoyer), az 2.81.0, m365 11.9.0, gcloud 552.0.0. Budget at start: core 4945/5000, graphql 4887.\n\nRe-read AGENTS.md + docs/workflow-safety-and-approvals.md from `main` before acting.\n\nCarrying in from run 58: 4 green drafts of mine (#953, #955, #956, #957) …",
       "truncated": true,
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5143712199"
+    },
+    {
+      "author": "clarkemoyer",
+      "created_at": "2026-07-31T14:22:12Z",
+      "body": "## Run 59 — GATES: 0 auto-approved, 2 held. **111 reaps in ~48h.**\n\n### ⛔ Held — `111. DNS - Create Redirect Rule`, run [30206375399](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/actions/runs/30206375399)\n\n`trendylittlegeek.com` → `aprilhansen.com`, waiting on `cloudflare-prod-write` since 2026-07-26T14:34Z.\n\n**This dispatch is live, and the gate itself proves it** — no need to guess at the dispatch inputs, which the runs API does not expose. The `apply` job carries `if: inputs.dr…",
+      "truncated": true,
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5143907035"
+    },
+    {
+      "author": "clarkemoyer",
+      "created_at": "2026-07-31T14:31:38Z",
+      "body": "## Run 59 — END (2026-07-31T14:31Z)\n\n### Merged (2)\n- **#955** — `always()`-step guard. Was already in the merge queue while `autoMergeRequest` read null; the `enqueuePullRequest` probe is what told the truth, exactly as AGENTS.md warns.\n- **#953** — utf-8 subprocess pin across 43 call sites. Side effect worth noting: it cleared the two long-standing local failures in `test_739_process_health.py` (9 PASS/2 FAIL → 11 PASS/0 FAIL on this host).\n\n### Open (4)\n- **#956** promoted, auto-merge armed, …",
+      "truncated": true,
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5143997467"
+    },
+    {
+      "author": "clarkemoyer",
+      "created_at": "2026-07-31T15:46:27Z",
+      "body": "## Cloud worker run — landing run (3 open `agentic-os` PRs)\n\nStep 1 of the worker protocol tripped: three open PRs carried `agentic-os` (#914, #958, #959), so this run went to landing them rather than starting new work. No new issue picked, no new work PR opened.\n\n### Outcome — all three green, thread-clean, and current with `main`\n\n| PR | Was | Now |\n| --- | --- | --- |\n| [#914](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/914) large-blob guard | 2 unresolved Copilot threads…",
+      "truncated": true,
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5144753979"
+    },
+    {
+      "author": "clarkemoyer",
+      "created_at": "2026-07-31T16:05:51Z",
+      "body": "## Run 60 — START (2026-07-31T16:04Z)\n\nBootstrap clean: all 5 core clones fetched and reset to `origin/main` (hub `cf7ed23`), 0 dirty. `gh` authed as `clarkemoyer`. Re-read `AGENTS.md` + `docs/workflow-safety-and-approvals.md` from the refreshed tree.\n\n**Inherited state from run 59 + the cloud worker run (15:46Z):**\n- **#956 landed unattended** as predicted — `agent-ready` is now on `main`, so this run's backlog band measures the ready queue rather than the topic label for the first time.\n- The …",
+      "truncated": true,
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5144935129"
     }
   ],
   "pending_gates": [


### PR DESCRIPTION
Hand-delivered refresh of `public/data/agentic-os-status.json` — **14th delivery**. Generated from
live GitHub data at **2026-07-31T19:15:17Z** by `scripts/generate-agentic-os-status.py` in
FFC-Cloudflare-Automation.

## Deltas since the run-60 feed on this branch (16:22:10Z)

| Field | Was | Now |
| --- | --- | --- |
| `ready_count` | 7 | **8** |
| `open_prs_total` | 78 | 76 |
| `backlog_issues` | 52 | 52 |
| `in_flight_prs` | 17 | 17 |
| `conductor_log` | 10 | 10 |
| `pending_gates` | 2 | 2 |
| `repos` swept | 5 | 5 |

Schema unchanged — no keys added or removed.

`ready_count` 7 → 8 is issue #964, filed this run. `open_prs_total` 78 → 76 is #963 landing plus two
dependabot PRs closing.

## Why this one should merge rather than sit

**The public page is two runs stale.** The last feed to reach `main` was run 58's (`3f78488`,
10:30Z); runs 59 and 60 both refreshed this branch and left it as a draft, so
<https://ffcadmin.org/agentic-os> has been serving a 9-hour-old snapshot showing the pre-`agent-ready`
schema. Every prior delivery (runs 50–58) merged the same day it was generated — leaving it draft is
the deviation, not merging it.

Promoting and merging. This is a data-only change to one public JSON file; no code, no schema
change, no credentials.

## Verification

- Generator exited 0: `52 issues, 17 of 76 open PRs across 5 repo(s), 10 log entries, 2 pending gates`
- Re-parsed the written file as JSON — valid, and diffed key-by-key against the previous revision:
  **0 keys added, 0 removed.**
- Scanned the output for token-shaped strings (`gh[pousr]_…`, `github_pat_…`, JWT-ish pairs,
  `"secret"/"token"/"password"/"api_key"` values): **0 matches**. The feed is public by design and
  carries no credentials.
- `prettier@3.8.1` applied.

Both pending gates remain the same two write gates carried since run 52; neither is auto-approvable.
Details in the conductor log:
<https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719>
