### PR TITLE
chore(data): refresh Agentic OS status + workflow catalog (Conductor run 71)

### DIFF
--- a/public/data/agentic-os-status.json
+++ b/public/data/agentic-os-status.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-01T22:26:59Z",
+  "generated_at": "2026-08-02T01:20:58Z",
   "org": "FreeForCharity",
   "repo": "FreeForCharity/FFC-Cloudflare-Automation",
   "repos": [
@@ -12,13 +12,42 @@
   "backlog_issues": [
     {
       "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 989,
-      "title": "gh api --paginate with an array-building --jq silently emits one array per page",
+      "number": 993,
+      "title": "Nothing verifies our gated/ungated claims against GitHub: the environment tests compare our docs to our own YAML",
       "state": "open",
       "assignee": null,
-      "updated_at": "2026-08-01T22:13:24Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/989",
+      "updated_at": "2026-08-02T01:17:41Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/993",
       "labels": [
+        "security",
+        "agentic-os",
+        "agent-ready"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 835,
+      "title": "The public Agentic OS board has no auto-add: every Conductor run adds items to Project #9 by hand",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-08-02T01:15:18Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/835",
+      "labels": [
+        "enhancement",
+        "agentic-os",
+        "agent-ready"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 992,
+      "title": "745 fails on board latency, not just board drift: a PR carded 35 minutes late is not run 62's six-hour gap",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-08-02T01:14:28Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/992",
+      "labels": [
+        "bug",
         "agentic-os",
         "agent-ready"
       ]
@@ -29,10 +58,23 @@
       "title": "Agentic OS Conductor Log",
       "state": "open",
       "assignee": null,
-      "updated_at": "2026-08-01T22:04:29Z",
+      "updated_at": "2026-08-02T01:04:39Z",
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719",
       "labels": [
         "agentic-os"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 989,
+      "title": "gh api --paginate with an array-building --jq silently emits one array per page",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-08-01T22:13:24Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/989",
+      "labels": [
+        "agentic-os",
+        "agent-ready"
       ]
     },
     {
@@ -141,20 +183,6 @@
       "assignee": null,
       "updated_at": "2026-08-01T04:28:31Z",
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/971",
-      "labels": [
-        "enhancement",
-        "agentic-os",
-        "agent-ready"
-      ]
-    },
-    {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 969,
-      "title": "Schedule the Agentic OS board audit — #968 shipped the script, nothing runs it",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-08-01T04:27:39Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/969",
       "labels": [
         "enhancement",
         "agentic-os",
@@ -513,18 +541,6 @@
     },
     {
       "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 835,
-      "title": "The public Agentic OS board has no auto-add: every Conductor run adds items to Project #9 by hand",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-07-25T01:15:02Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/835",
-      "labels": [
-        "agentic-os"
-      ]
-    },
-    {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
       "number": 813,
       "title": "Epic: WHMCS fraud review via FraudLabs Pro + daily agent check (charities mis-flagged as fraud)",
       "state": "open",
@@ -748,6 +764,48 @@
   "ready_issues": [
     {
       "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 993,
+      "title": "Nothing verifies our gated/ungated claims against GitHub: the environment tests compare our docs to our own YAML",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-08-02T01:17:41Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/993",
+      "labels": [
+        "security",
+        "agentic-os",
+        "agent-ready"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 835,
+      "title": "The public Agentic OS board has no auto-add: every Conductor run adds items to Project #9 by hand",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-08-02T01:15:18Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/835",
+      "labels": [
+        "enhancement",
+        "agentic-os",
+        "agent-ready"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 992,
+      "title": "745 fails on board latency, not just board drift: a PR carded 35 minutes late is not run 62's six-hour gap",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-08-02T01:14:28Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/992",
+      "labels": [
+        "bug",
+        "agentic-os",
+        "agent-ready"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
       "number": 989,
       "title": "gh api --paginate with an array-building --jq silently emits one array per page",
       "state": "open",
@@ -809,20 +867,6 @@
       "assignee": null,
       "updated_at": "2026-08-01T04:28:31Z",
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/971",
-      "labels": [
-        "enhancement",
-        "agentic-os",
-        "agent-ready"
-      ]
-    },
-    {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 969,
-      "title": "Schedule the Agentic OS board audit — #968 shipped the script, nothing runs it",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-08-01T04:27:39Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/969",
       "labels": [
         "enhancement",
         "agentic-os",
@@ -899,26 +943,24 @@
       ]
     }
   ],
-  "ready_count": 11,
+  "ready_count": 13,
   "ready_rule": "Open issues labeled 'agent-ready' and NOT 'claimed': unblocked, one-PR-scoped and carrying acceptance criteria — the queue a sandboxed agent can pick from now. An 'agent-ready' issue with an open PR against it carries 'claimed' (applied by workflow 737) and is excluded here until that PR closes; ready_count counts exactly the rows in ready_issues. A strict subset of backlog_issues, which stays the full 'agentic-os' topic set (epics, machine-managed rolling issues, human-blocked items and durable findings all remain counted there).",
   "in_flight_prs": [
     {
       "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 990,
-      "title": "docs: three run-70 lessons — an exported guard, a per-page jq array, a five-hour window",
+      "number": 994,
+      "title": "docs: two run-71 lessons — a self-consistent test, and a definition of clean that is never true",
       "state": "open",
       "draft": true,
       "assignee": null,
-      "updated_at": "2026-08-01T22:26:34Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/990",
-      "labels": [
-        "agentic-os"
-      ],
+      "updated_at": "2026-08-02T01:20:36Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/994",
+      "labels": [],
       "linked_agentic_issues": [
-        719,
-        989,
-        848,
-        921
+        834,
+        993,
+        835,
+        992
       ]
     },
     {
@@ -1104,20 +1146,6 @@
   "conductor_log": [
     {
       "author": "clarkemoyer",
-      "created_at": "2026-08-01T10:05:51Z",
-      "body": "## Run 66 — START (2026-08-01T10:0xZ)\n\nLocal Windows host, `gh` as clarkemoyer. Bootstrap clean: 5/5 core clones fetched + pruned, all on `main`. Hub `4aa04d1`, ffcadmin `4496b73`.\n\n**Run 65 ended 07:5xZ — ~2h before this slot.** This is the shortest gap between runs so far, so the carry-in list is genuinely fresh rather than stale.\n\nConfirmed from [run 65's END](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5150097936):\n\n- **#975 (run-65 lessons L50/L51) is…",
-      "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5150952573"
-    },
-    {
-      "author": "clarkemoyer",
-      "created_at": "2026-08-01T10:35:05Z",
-      "body": "## Run 66 — END (2026-08-01T11:0xZ) · core 4922 / graphql 4061\n\n**2 PRs merged, 2 opened, 1 issue filed, 1 issue re-diagnosed and retitled, 0 gates approved, board 225 items 0/0/0.**\n\n### First, a correction about which run this is\n\n`state/` said run 64 was the last completed run. It was not — [run 65](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5150097936) had run ~2h earlier and logged a full START and END here, but never wrote its own state file. Two op…",
-      "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5151046503"
-    },
-    {
-      "author": "clarkemoyer",
       "created_at": "2026-08-01T13:06:06Z",
       "body": "## Run 67 — START (2026-08-01T13:0xZ)\n\nLocal Windows host, `gh` as clarkemoyer. Bootstrap clean: 5/5 core clones fetched + pruned, all on `main`, 0 dirty. Hub `9a8dc98`, ffcadmin `2774b72`. Core 4954 / graphql 4942.\n\n**Both of run 66's carry-forwards landed.** #975 merged 10:38:43Z (it was queued at position 1); ffcadmin #775 merged 10:32:19Z. Nothing to re-check there.\n\n**A fourth consecutive Conductor-filed issue came back as a worker PR — and this time in under two hours.** #977 was filed dur…",
       "truncated": true,
@@ -1171,6 +1199,20 @@
       "body": "## Run 70 — START (2026-08-01T22:0xZ)\n\nConductor run 70 beginning. Bootstrap complete:\n\n- Workspace `C:\\ClaudeCodeDesktop\\Claude_AI_OS_Routine` intact; all 5 core clones fetched and fast-forwarded to `main` (hub `c8a80a6` = #987, ffcadmin `794364f` = #780 run-69 feed, freeforcharity `fa3f600`, SPT `b4e6d32`, FOT `c310e85`).\n- Tooling verified: `gh` 2.96.0 (clarkemoyer, scopes incl. `project`/`workflow`), `az` 2.81.0, `m365` 11.9.0, `gcloud` 552.0.0.\n- `AGENTS.md` + `docs/workflow-safety-and-appr…",
       "truncated": true,
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5153656604"
+    },
+    {
+      "author": "clarkemoyer",
+      "created_at": "2026-08-01T22:39:40Z",
+      "body": "## Run 70 — END (2026-08-01T22:3xZ) · core 4903 / graphql 3389\n\n**2 PRs merged (#988, ffcadmin #781), 2 opened (#990 draft, #989 issue), 0 gates approved, board 239 items 0/0/0 by script, feed live-verified. No Clarke contact.**\n\n### #988 — reviewed by execution, one contract gap found, fixed on the branch, merged 22:23:42Z\n\nThe PR is careful and its central claim holds. The workflow half is sound: pages are accumulated before the scan (`739…yml:219-228`), the read is bounded by `since` **and** …",
+      "truncated": true,
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5153788389"
+    },
+    {
+      "author": "clarkemoyer",
+      "created_at": "2026-08-02T01:04:39Z",
+      "body": "## Run 71 — START (2026-08-02T01:0xZ)\n\nLocal Windows host, `gh` as clarkemoyer. Bootstrap clean: 5/5 core clones fetched + pruned, all on `main`, 0 dirty. Hub `f0748ad`, ffcadmin `db19104`, freeforcharity `fa3f600`, SPT `b4e6d32`, FOT `c310e85`. Core 4936 / graphql 4134. `az` 2.81.0, `m365` 11.9.0, `gcloud` 552.0.0, `gh` 2.96.0 all present.\n\n**Run number from this issue's tail** (run 70 END at 22:39:40Z), not from `state/CONDUCTOR.md` — which is stale at run 69 for the same reason it was stale a…",
+      "truncated": true,
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5154329897"
     }
   ],
   "pending_gates": [

--- a/public/data/workflow-catalog.json
+++ b/public/data/workflow-catalog.json
@@ -309,7 +309,7 @@
       "description": "READ-ONLY: probes whether the selected Cloudflare token has Registrar API rights (read + write). Never registers or changes anything. Wraps scripts/cloudflare-registrar-access-check.ps1.",
       "safetyLevel": "Reads",
       "approvalEnv": "\u2705 cloudflare-prod-write",
-      "guard": "never charges",
+      "guard": "never charges; but `cloudflare-tokens-from-kv` runs with **`scope: write`** \u2192 loads `wr-all-*` CF tokens, so **not auto-approvable** (#915)",
       "category": "Cloudflare / DNS / Domain",
       "categoryCode": "CF"
     },
@@ -473,6 +473,22 @@
       "categoryCode": "CF"
     },
     {
+      "number": 123,
+      "title": "Domain - Inbound Transfer Preflight (Report)",
+      "apis": [],
+      "file": "123-domain-inbound-transfer-preflight.yml",
+      "triggers": [
+        "workflow_dispatch"
+      ],
+      "environments": [],
+      "description": "READ-ONLY: probes the registry (RDAP) for the given domains, then runs scripts/domain-inbound-transfer-preflight.ps1 offline to classify how each domain held at a FOREIGN registrar (Wix / Squarespace / GoDaddy / ...) comes under FFC management -- via eNom/WHMCS, then Cloudflare nameservers.  Counterpart to workflow 115, which handles the outbound leg (eNom -> Cloudflare Registrar) and assumes the losing registrar is already eNom.  No secrets and no WHMCS credentials: RDAP is public and the preflight itself is pure offline analysis. Initiates no transfer and spends no money.  SCOPE: `domains` is required and there is no fleet-wide default. This workflow only ever looks at domains someone names explicitly -- it does not sweep the estate, and it is not a source of truth about it.  WHMCS is FFC's live record of what we hold. docs/domain-registry-truth.csv is a committed point-in-time RDAP snapshot for reference only; do not treat it as current, and do not drive work from it.  run-name echoes the requested domains so a run is identifiable in the Actions list without opening it.",
+      "safetyLevel": "Reads",
+      "approvalEnv": "none (no credentials)",
+      "guard": "read-only RDAP + offline analysis; classifies foreign-registrar domains for the eNom/WHMCS inbound path",
+      "category": "Cloudflare / DNS / Domain",
+      "categoryCode": "CF"
+    },
+    {
       "number": 201,
       "title": "WHMCS - Export Domains (Report)",
       "apis": [
@@ -488,7 +504,7 @@
       "description": "",
       "safetyLevel": "Reads",
       "approvalEnv": "whmcs-prod-read",
-      "guard": "gated only by the env approval",
+      "guard": "ungated read lane; artifacts are export catalogs",
       "category": "WHMCS",
       "categoryCode": "WHMCS"
     },
@@ -508,7 +524,7 @@
       "description": "",
       "safetyLevel": "Reads",
       "approvalEnv": "whmcs-prod-read",
-      "guard": "gated only by the env approval",
+      "guard": "ungated read lane; artifacts are export catalogs",
       "category": "WHMCS",
       "categoryCode": "WHMCS"
     },
@@ -528,7 +544,7 @@
       "description": "",
       "safetyLevel": "Reads",
       "approvalEnv": "whmcs-prod-read",
-      "guard": "gated only by the env approval",
+      "guard": "ungated read lane; artifacts are export catalogs",
       "category": "WHMCS",
       "categoryCode": "WHMCS"
     },
@@ -885,12 +901,12 @@
         "workflow_dispatch"
       ],
       "environments": [
-        "whmcs-prod"
+        "whmcs-prod-read"
       ],
-      "description": "Read-only. Sweeps GetClientsProducts (all clients) and returns the onboarding application(s) whose product custom fields contain the query substring (a domain or organization name), with personal contact fields masked. This is the domain/org -> client-id lookup that 219 (which needs a client id) and the masked triage tables cannot do. Posts the matches to the job summary and optionally back to a GitHub issue. No writes.  NOTE: uses the gated `whmcs-prod` so it runs today with a single approval; once `whmcs-prod-read` is set up it can move there (read-only workflow).",
+      "description": "Read-only. Sweeps GetClientsProducts (all clients) and returns the onboarding application(s) whose product custom fields contain the query substring (a domain or organization name), with personal contact fields masked. This is the domain/org -> client-id lookup that 219 (which needs a client id) and the masked triage tables cannot do. Posts the matches to the job summary and optionally back to a GitHub issue. No writes.  Runs on the ungated `whmcs-prod-read` lane with the READ-scoped credential (`read-all-ffc-whmcs-*`, via the ffc-admin-kv-reader identity) \u2014 matching what the job actually does. 104 is the precedent for this lane. WHMCS is a single credential, so read/write scope selects the identity, not the access.",
       "safetyLevel": "Reads",
-      "approvalEnv": "\u2705 whmcs-prod",
-      "guard": "GetClientsProducts sweep; personal contact fields masked; gated until whmcs-prod-read setup",
+      "approvalEnv": "whmcs-prod-read",
+      "guard": "GetClientsProducts sweep; personal contact fields masked; **ungated** \u2014 `whmcs-secrets-from-kv` with `scope: read` on the `READ_ALL_FFC_AZURE_*` (ffc-admin-kv-reader) identity \u2192 `read-all-ffc-whmcs-*` (#920; was \u2705 `whmcs-prod` on the writer identity, held under #915)",
       "category": "WHMCS",
       "categoryCode": "WHMCS"
     },
@@ -1059,6 +1075,26 @@
       "safetyLevel": "Writes (record field)",
       "approvalEnv": "\u2705 whmcs-prod",
       "guard": "`dry_run` (default true); one record + one field per dispatch; strict per-target allowlist of writable fields; refuses to replace a different existing value without `force`; reports `previousValue`",
+      "category": "WHMCS",
+      "categoryCode": "WHMCS"
+    },
+    {
+      "number": 231,
+      "title": "WHMCS - Domain Order Add (Register/Transfer) (Admin)",
+      "apis": [
+        "WHMCS"
+      ],
+      "file": "231-whmcs-domain-order-add.yml",
+      "triggers": [
+        "workflow_dispatch"
+      ],
+      "environments": [
+        "whmcs-prod"
+      ],
+      "description": "Places a WHMCS domain order for an existing client by wrapping scripts/whmcs-order-add.ps1 (WHMCS AddOrder). This is the entry point the inbound migration path (workflow 123 / docs/wix-domain-migration.md) needs: a charity whose domain sits at a foreign registrar has no domain product in WHMCS, so there is nothing to drive the transfer from until one is placed.  Products (group 6): transfer -> pid 41  \"Transfer your Existing Domain Name to the FFC CloudFlare\" register -> pid 39  \"Free new .org Domain Name in the FFC CloudFlare\"  SAFETY: this is the first WRITE against production billing in this area. * mode=dry-run (default) previews the AddOrder request and writes nothing. * mode=execute places a real order. Gated behind the whmcs-prod environment approval on top of that. * The underlying script skips when the client already has a non-terminated service for the product, unless allow_duplicate is set. * no_email defaults to true so a first live run cannot surprise a charity with an unexpected order confirmation. Turn it off deliberately.  Find client_id with 221 (Application Search) or 219 (Application Detail). Confirm the registrar situation first with 123 (Inbound Transfer Preflight).",
+      "safetyLevel": "Writes (dry-run default)",
+      "approvalEnv": "\u2705 whmcs-prod",
+      "guard": "`mode` (default `dry-run`) previews AddOrder and writes nothing; `execute` places a real order; pid fixed by `order_type` (41 transfer / 39 register); underlying script skips when the client already has a non-terminated service for the product unless `allow_duplicate`; `no_email` defaults true so a first live run cannot surprise a charity; price forced to 0",
       "category": "WHMCS",
       "categoryCode": "WHMCS"
     },
@@ -1247,7 +1283,7 @@
       "description": "Read-only export of Zeffy campaigns/events (GET /api/v1/campaigns) via OIDC -> Key Vault. This endpoint returns NO personal data (forms/events only: title, target, volume, dates, URLs), so the uploaded artifact is inherently safe to keep on this public repo. Dispatch-only (no schedule) while we are testing the API. One workflow per endpoint.  The `deliver` job additionally publishes a public, PII-free campaign list (docs/data/ffc-zeffy-campaigns.json \u2014 title/url/status only) as a reviewable data-update PR, so the fleet smoke engine can classify a detected donation surface as ffc-interim (FFC-owned campaign) vs charity-specific (#744). Mirrors the 502 export->deliver split (github-prod gate, CBM_TOKEN) and the 703 same-repo peter-evans data-PR pattern.",
       "safetyLevel": "Reads (+ PR delivery)",
       "approvalEnv": "zeffy-prod \u2192 \u2705 github-prod (deliver)",
-      "guard": "PII masked; the published `docs/data/ffc-zeffy-campaigns.json` is title/url/status only (no financials); `deliver` opens a reviewable data PR via CBM_TOKEN",
+      "guard": "PII masked; the published `docs/data/ffc-zeffy-campaigns.json` is title/url/status only (no financials); `deliver` opens a reviewable data PR via CBM_TOKEN; loads `wr-all-ffc-zeffy-api-key` (default `write`) **and** `wr-all-cbm-github-pat` \u2192 **not auto-approvable** (#915; on the \u2705 list 2026-07-23 \u2192 2026-07-29)",
       "category": "Zeffy",
       "categoryCode": "ZEFFY"
     },
@@ -1324,13 +1360,13 @@
         "workflow_dispatch"
       ],
       "environments": [
-        "github-prod",
+        "github-prod-read",
         "google-prod-read"
       ],
-      "description": "Read-only GA4 reporting for the FFC primary sites. Generates aggregate JSON per site and delivers it to FreeForCharity/FFC-IN-ffcadmin.org as a reviewable PR (never a direct push). PII-safe: aggregate metrics only. Requires the google-prod-read environment (report) and the approval-gated github-prod environment (delivery) + the Wave 0 foundation. The delivery PAT comes from Key Vault (`wr-all-cbm-github-pat`) over OIDC, never a GitHub secret \u2014 see #844.",
+      "description": "Read-only GA4 reporting for the FFC primary sites. Generates aggregate JSON per site and delivers it to FreeForCharity/FFC-IN-ffcadmin.org as a reviewable PR (never a direct push). PII-safe: aggregate metrics only. Requires the google-prod-read environment (report) and the ungated github-prod-read environment (delivery, #834) + the Wave 0 foundation. Opening the PR is reporting plumbing, not a Write \u2014 the data this workflow consumes is a Read. The delivery PAT comes from Key Vault (`read-all-cbm-github-pat`) over OIDC on the READER identity, never a GitHub secret \u2014 #844.",
       "safetyLevel": "Reads",
-      "approvalEnv": "google-prod-read / \u2705 github-prod",
-      "guard": "delivers JSON to ffcadmin via PR (CBM_TOKEN, github-prod approval); PII-safe aggregates. Same PR also syncs the workflow catalog and the Agentic OS status feed (`agentic-os-status.json`, generated by `scripts/generate-agentic-os-status.py`, REST-only)",
+      "approvalEnv": "google-prod-read / github-prod-read",
+      "guard": "delivers JSON to ffcadmin via PR (`read-all-cbm-github-pat` from KV, ungated lane #834); PII-safe aggregates. Same PR also syncs the workflow catalog and the Agentic OS status feed (`agentic-os-status.json`, generated by `scripts/generate-agentic-os-status.py`, REST-only)",
       "category": "Google",
       "categoryCode": "GOOGLE"
     },
@@ -1494,7 +1530,7 @@
       "description": "Generates the merged FFC sites list from the WHMCS / Cloudflare / WPMUDEV exports plus the curated base list, runs per-domain health checks, and commits both sites-list/sites_list.csv and sites-list/sites_list.json.  This repo owns the export environments (whmcs-prod, cloudflare-prod-read, wpmudev-prod) and the GitHub PAT (CBM_TOKEN in github-prod) needed to dispatch the sibling export workflows, so generation lives here. Downstream consumers (e.g. ffcadmin.org) pull the published files from this repo.",
       "safetyLevel": "Writes (data PR only)",
       "approvalEnv": "\u2705 github-prod",
-      "guard": "dispatches read-only exports 201/108/601 (601 waits on its own wpmudev-prod gate); regenerates `sites-list/` CSV+JSON; opens a data PR (never pushes to `main`); weekly Mon 08:00Z + dispatch; serialized concurrency group",
+      "guard": "dispatches read-only exports 201/108/601 (601 waits on its own wpmudev-prod gate); regenerates `sites-list/` CSV+JSON; opens a data PR (never pushes to `main`); weekly Mon 08:00Z + dispatch; serialized concurrency group; loads `wr-all-cbm-ffc-copilot-mcp-github-pat` \u2192 **held on credential scope**, not on a taxonomy gap (#915)",
       "category": "GitHub (Website + Repo)",
       "categoryCode": "GH"
     },
@@ -1650,12 +1686,12 @@
         "workflow_dispatch"
       ],
       "environments": [
-        "github-prod"
+        "github-prod-read"
       ],
-      "description": "Daily read-only audit of FreeForCharity org repository rulesets and settings drift (branch protections, merge queues, Actions policies) against the documented standard, reported as issues under the github-prod approval gate. The PAT comes from Key Vault (`wr-all-cbm-ffc-copilot-mcp-github-pat`) over OIDC, never a GitHub secret \u2014 see #844. That token (not `wr-all-cbm-github-pat`) is the one with Organization Administration read+write, which GitHub requires even to READ org rulesets via a fine-grained PAT.  Supersede-on-newer (#722): these daily runs pause at an approval gate; without this, unapproved runs pile up ~12-deep until the janitor reaps them at 7 days. cancel-in-progress cancels the older queued/waiting run the moment the next scheduled run starts, so at most ONE run ever waits at the gate. Ref-scoped so a dispatch from a PR branch can never cancel main's scheduled run. Trade-off (accepted): cancel-in-progress could interrupt an EXECUTING run, but execution lasts minutes against a 24h cadence \u2014 in practice only gate-waiting runs are ever superseded; janitor 734 remains the backstop.",
+      "description": "Daily read-only audit of FreeForCharity org repository rulesets and settings drift (branch protections, merge queues, Actions policies) against the documented standard, reported as issues.  Runs on the UNGATED github-prod-read lane (#834). A scheduled Reads workflow behind a required-reviewers gate fires at 13:00 UTC with nobody watching and waits \u2014 then either its next scheduled run cancels it (when cancel-in-progress is true, as this workflow had) or it sits until janitor 734 reaps it at 7 days. Both happened here: 3 `failure` + 2 `cancelled` across 8 scheduled runs. Either way the audit did not run on its schedule. The PAT comes from Key Vault (`read-all-cbm-ffc-copilot-mcp-github-pat`) over OIDC on the READER identity, never a GitHub secret \u2014 see #844. That token (not `read-all-cbm-github-pat`) is the one with Organization Administration read, which GitHub requires even to READ org rulesets via a fine-grained PAT.  cancel-in-progress: false (#834). Its entire justification (#722) was that gated runs piled up ~12-deep waiting for approval until janitor 734 reaped them at 7 days. Ungated, nothing ever waits, so the only run it could still cancel is an EXECUTING one \u2014 the trade-off #722 accepted as the lesser evil becomes pure downside. Ref-scoped so a dispatch from a PR branch cannot collide with main's.",
       "safetyLevel": "Reads",
-      "approvalEnv": "\u2705 github-prod",
-      "guard": "report only; CBM_TOKEN via github-prod approval",
+      "approvalEnv": "github-prod-read",
+      "guard": "report only; `read-all-cbm-ffc-copilot-mcp-github-pat` from KV over OIDC; ungated lane (#834) so the daily audit is never cancelled waiting at a gate",
       "category": "GitHub (Website + Repo)",
       "categoryCode": "GH"
     },
@@ -1787,7 +1823,7 @@
         "workflow_dispatch"
       ],
       "environments": [],
-      "description": "Cancels (or, in dry-run, just reports) workflow runs left in the `waiting` state \u2014 i.e. paused at an environment approval gate \u2014 for longer than max_age_days. Scheduled read/triage runs that no one approves otherwise stack up indefinitely and the Actions history stops reflecting real state (see the 209/210 backlog cleared manually on 2026-07-07, issue #637).  Read + cancel only; never approves a gate. Uses the ambient GITHUB_TOKEN.",
+      "description": "Cancels (or, in dry-run, just reports) workflow runs left in the `waiting` state \u2014 i.e. paused at an environment approval gate \u2014 for longer than max_age_days. Scheduled read/triage runs that no one approves otherwise stack up indefinitely and the Actions history stops reflecting real state (see the 209/210 backlog cleared manually on 2026-07-07, issue #637).  It also warns before it reaps: a run inside the last warn_days of its life is reported to the Conductor Log with the exact instant it will be cancelled, and anything actually cancelled is reported too. Before #960 the only output was core.summary on this job \u2014 a page no human opens \u2014 so a gate that had waited a week on a human reviewer was destroyed silently, and the deadlines circulated by hand were wrong by a day (this is a daily cron, so a run dies at the first 06:31Z tick AFTER it crosses the threshold, not at the threshold).  Read + cancel only; never approves a gate. Uses the ambient GITHUB_TOKEN.",
       "safetyLevel": "Writes (cancels runs)",
       "approvalEnv": "\u2014",
       "guard": "cancels runs left waiting >N days at a gate; never approves; dispatch dry-run supported",
@@ -1806,12 +1842,12 @@
         "workflow_dispatch"
       ],
       "environments": [
-        "github-prod"
+        "github-prod-read"
       ],
-      "description": "Regenerates data/dependabot-affected-repos.json (the org repo inventory that feeds the smoke-protected Dependabot waves) and delivers it as an auto-merging PR. Migrated from FFC-IN-ClarkeMoyerAdmin. Uses the github-prod environment so the PR is opened with a real PAT \u2014 a PR opened by GITHUB_TOKEN does not trigger the pull_request checks / Copilot review this repo requires, so it would never satisfy branch protection. The PAT comes from Key Vault (`wr-all-cbm-github-pat`) over OIDC, never a GitHub secret \u2014 see #844. Read-only against the org; PR-only.",
+      "description": "Regenerates data/dependabot-affected-repos.json (the org repo inventory that feeds the smoke-protected Dependabot waves) and delivers it as an auto-merging PR. Migrated from FFC-IN-ClarkeMoyerAdmin. Runs on the UNGATED github-prod-read lane (#834): the org inventory it consumes is a Read, and a weekly gated run fires at 06:15 UTC with nobody watching. It still needs a real PAT \u2014 a PR opened by GITHUB_TOKEN does not trigger the pull_request checks / Copilot review this repo requires, so it would never satisfy branch protection. The PAT comes from Key Vault (`read-all-cbm-github-pat`) over OIDC on the READER identity, never a GitHub secret \u2014 see #844. Read-only against the org; PR-only.",
       "safetyLevel": "Reads",
-      "approvalEnv": "\u2705 github-prod",
-      "guard": "weekly org inventory (feeds smoke-protected waves); PR-only + auto-merge",
+      "approvalEnv": "github-prod-read",
+      "guard": "weekly org inventory (feeds smoke-protected waves); PR-only + auto-merge; `read-all-cbm-github-pat` from KV over OIDC on the ungated lane (#834)",
       "category": "GitHub (Website + Repo)",
       "categoryCode": "GH"
     },
@@ -1848,10 +1884,10 @@
         "workflow_dispatch"
       ],
       "environments": [],
-      "description": "Mechanizes the AGENTS.md work-claiming protocol (available = `is:open -label:claimed`). Two independent triggers:  1. Event-driven label sync (pull_request): parse Closes/Fixes/Refs #N from the PR body and add `claimed` to those open hub issues while the PR is active; remove it when the last open linked PR closes/merges. 2. Daily sweep (schedule): release stale hand-labeled claims \u2014 issues labeled `claimed` with no open linked PR and no activity for 48h \u2014 in this repo, so an abandoned claim frees itself. (ffcadmin needs its own sweep: cross-repo writes require CBM_TOKEN, which lives only in the gated github-prod environment \u2014 unusable for an ungated daily job.)  Writes issues/labels only; no external API; ungated. The decision logic lives in scripts/claim-sync-lib.js (unit-tested in tests/workflow-logic/).",
+      "description": "Mechanizes the AGENTS.md work-claiming protocol (available = `is:open -label:claimed`). Two independent triggers:  1. Event-driven label sync (pull_request): parse Closes/Fixes/Refs #N from the PR body and add `claimed` to those open hub issues while the PR is active; remove it when the last open linked PR closes/merges. It also comments ON THE PR naming what it just claimed \u2014 `Refs #N` is both the claiming form and how people write a citation, and only the PR author can tell which they meant (#948). 2. Daily sweep (schedule): reconcile this repo's `claimed` labels against every open PR in the org. The pickup query in AGENTS.md is org-wide but trigger 1 is repo-local, so a hub issue implemented by a PR in a template or site repo read as unclaimed and invited a duplicate (#939). The sweep claims those, releases a claim once the last open PR referencing the issue \u2014 in any repo \u2014 is closed or merged, and still releases a stale hand-labeled claim after 48h of inactivity. It also REPORTS (never releases) claims whose only claimant is a draft PR older than 48h \u2014 a draft suppresses a pickup exactly as hard as a ready PR (#948). Cross-repo is READ-only here: every write targets this repo's own issues, so the ambient token suffices. (ffcadmin still needs its own sweep for ITS issues: cross-repo writes require CBM_TOKEN, which lives only in the gated github-prod environment \u2014 unusable for an ungated daily job.)  Writes issues/labels only; no external API; ungated. The decision logic lives in scripts/claim-sync-lib.js (unit-tested in tests/workflow-logic/).",
       "safetyLevel": "Writes (issues/labels only)",
       "approvalEnv": "\u2014",
-      "guard": "syncs `claimed` label from linked PRs (pull_request event, GITHUB_TOKEN) + daily sweep of expired claims (no open linked PR + 48h idle) in this repo (ambient GITHUB_TOKEN \u2014 CBM_TOKEN is gated-env-only and empty on schedule); no external API, ungated; sweep `dry_run` via dispatch",
+      "guard": "syncs `claimed` label from linked PRs (pull_request event, GITHUB_TOKEN) + daily sweep reconciling this repo's claims against every open PR in the org \u2014 one `search/issues` read, writes only this repo's issues (ambient GITHUB_TOKEN \u2014 CBM_TOKEN is gated-env-only and empty on schedule); releases when no open PR in any repo still references the issue, or after 48h idle for a hand-labeled claim; no external API, ungated; sweep `dry_run` via dispatch",
       "category": "GitHub (Website + Repo)",
       "categoryCode": "GH"
     },
@@ -1905,7 +1941,7 @@
         "workflow_dispatch"
       ],
       "environments": [],
-      "description": "Watches every scheduled hub workflow (726 drift audit, 734 janitor, 738 smoke drift, Google 502 analytics + 504 GTM backups, and the other cron-driven monitors \u2014 the authoritative list is WATCHED_WORKFLOWS below). For each one it upserts ONE rolling alert issue PER WATCHED WORKFLOW, and closes that issue on the next success of that same workflow. The marker is keyed by workflow name precisely so a green run of one watched workflow can never close another's alert \u2014 with a dozen workflows watched, a shared marker would let a weekly job's success silently clear a daily job's outage.  POLL, NOT `workflow_run` (#843). This workflow used to trigger on the `workflow_run` completed event. That event has NEVER fired in this repository \u2014 `?event=workflow_run` returns 0 runs all time, while sibling repos show hundreds \u2014 so both this alerter and the Google one (732, now retired into this file) were `active` and had produced exactly zero runs. The alerting layer was dead for six days and nothing could tell us, because a `workflow_run` watcher cannot be tested on demand. The poll can: `workflow_dispatch` below is REQUIRED, not a convenience \u2014 it is what makes this alerter provable.  BEHAVIOUR CHANGE, deliberate: the event saw *every* run; the poll sees only the LATEST completed default-branch run per workflow, so a failure that self-heals between polls is missed. That is an acceptable \u2014 arguably better \u2014 fit, because the rolling issue answers \"is this workflow currently broken?\", which is exactly what latest-run state models. Do not add cursor/state tracking to chase the transient case; it would trade away the simplicity that makes this verifiable.  Consequence worth knowing: the poll model only makes sense for SCHEDULED workflows. For a dispatch-only workflow the \"latest run\" is whatever a human last ran by hand \u2014 a stale red would alert forever and a stale green would mean nothing. `test_watched_workflows_are_actually_scheduled` enforces that, and it is why 501 (workflow_dispatch/workflow_call only) is excluded even though retired 732 watched it.  Ambient GITHUB_TOKEN only, no environment: \u2014 the alerter must never be blocked by the very gate it is watching. Reports `cancelled` as well as `failure`: a run cancelled before it reaches a runner (the 2026-07-24 726 incident) executes zero steps and is exactly the kind of silent breakage this workflow exists to surface.  It does NOT alert on a declined or expired approval gate. Those also surface as run-level `failure`, so the run conclusion alone cannot tell \"the job broke\" from \"a human said no\"; the job list can, and `actions: read` already allows reading it. See the discriminator in the step below.",
+      "description": "Watches every scheduled hub workflow (726 drift audit, 734 janitor, 738 smoke drift, Google 502 analytics + 504 GTM backups, and the other cron-driven monitors \u2014 the authoritative list is WATCHED_WORKFLOWS below). For each one it upserts ONE rolling alert issue PER WATCHED WORKFLOW, and closes that issue on the next success of that same workflow. The marker is keyed by workflow name precisely so a green run of one watched workflow can never close another's alert \u2014 with a dozen workflows watched, a shared marker would let a weekly job's success silently clear a daily job's outage.  COVERAGE IS NOW EVERY SCHEDULED WORKFLOW BUT THIS ONE (#932). The watch list originally stopped at \"hub plumbing\" because that was #832's scope; the WHMCS lane (209/210/225/228) and the Azure inventory (320) were excluded for being out of that ticket's scope, not for being unwatchable. The evidence went the other way: 228 failed all four of its scheduled runs, 07-27 through 07-30, and no mechanism said a word \u2014 it surfaced only because a conductor audited `main`'s failure list by hand (#912). The lanes carrying live credentials and a payment/fraud pipeline were the ones with no alerting. Nothing about a WHMCS or Azure cron makes the poll unsound, so the only remaining exclusion is this workflow itself, which cannot watch itself without looping (#752).  POLL, NOT `workflow_run` (#843). This workflow used to trigger on the `workflow_run` completed event. That event has NEVER fired in this repository \u2014 `?event=workflow_run` returns 0 runs all time, while sibling repos show hundreds \u2014 so both this alerter and the Google one (732, now retired into this file) were `active` and had produced exactly zero runs. The alerting layer was dead for six days and nothing could tell us, because a `workflow_run` watcher cannot be tested on demand. The poll can: `workflow_dispatch` below is REQUIRED, not a convenience \u2014 it is what makes this alerter provable.  BEHAVIOUR CHANGE, deliberate: the event saw *every* run; the poll sees only the LATEST completed default-branch run per workflow, so a failure that self-heals between polls is missed. That is an acceptable \u2014 arguably better \u2014 fit, because the rolling issue answers \"is this workflow currently broken?\", which is exactly what latest-run state models. Do not add cursor/state tracking to chase the transient case; it would trade away the simplicity that makes this verifiable.  Consequence worth knowing: the poll model only makes sense for SCHEDULED workflows. For a dispatch-only workflow the \"latest run\" is whatever a human last ran by hand \u2014 a stale red would alert forever and a stale green would mean nothing. `test_watched_workflows_are_actually_scheduled` enforces that, and it is why 501 (workflow_dispatch/workflow_call only) is excluded even though retired 732 watched it.  Ambient GITHUB_TOKEN only, no environment: \u2014 the alerter must never be blocked by the very gate it is watching. Reports `cancelled` as well as `failure`: a run cancelled before it reaches a runner (the 2026-07-24 726 incident) executes zero steps and is exactly the kind of silent breakage this workflow exists to surface.  It does NOT alert on a declined or expired approval gate. Those also surface as run-level `failure`, so the run conclusion alone cannot tell \"the job broke\" from \"a human said no\"; the job list can, and `actions: read` already allows reading it. See the discriminator in the step below.",
       "safetyLevel": "Writes (issues only)",
       "approvalEnv": "\u2014",
       "guard": "**polls** every scheduled hub workflow twice hourly (`schedule` + `workflow_dispatch`; the `workflow_run` event has never fired in this repo \u2014 #843) and upserts one rolling issue per watched workflow (marker keyed by workflow name, so only that workflow's own green run closes it); absorbs the retired 732 Google lane (502/504); reports `cancelled`/`timed_out` as well as `failure`, latest completed default-branch run only; does **not** alert on a declined/expired approval gate (no job `failure` + \u22651 job `cancelled` \u21d2 logged via `core.notice`, not an alert) \u2014 an unreadable job list still alerts, and a watched name matching no workflow fails the run loudly; ambient GITHUB_TOKEN, no external API, ungated by design (must not be blocked by the gate it watches)",
@@ -1924,10 +1960,10 @@
         "workflow_dispatch"
       ],
       "environments": [],
-      "description": "Weekly audit of whether each Node app in the FFC-EX fleet has dependency-vulnerability detection wired at all. A repo counts as covered only when it has BOTH `.github/workflows/security-audit.yml` and an `audit:high` script in package.json \u2014 the workflow without the script fails on every run, the script without the workflow never runs. Findings are upserted into a single rolling issue that auto-closes once the fleet is fully covered.  Why (#838): 34 of the 44 Node FFC-EX repos had no detection of any kind, so a published advisory against a charity site was invisible until somebody swept by hand \u2014 and nothing was measuring that, which is why #822's scope was estimated at 13 repos when the real number was 38. This workflow re-derives the fleet from the org listing every run rather than trusting a count carried between sessions.  Read-only: GITHUB_TOKEN reads public repo contents org-wide and lists the org's public repos; the only write is the rolling issue in THIS repo. No external API, no environment gate. It reports coverage only and never bumps a dependency \u2014 remediation belongs to #822. Classification/report logic lives in scripts/fleet-audit-coverage-lib.js (unit-tested under tests/workflow-logic/).",
+      "description": "Weekly audit of whether each Node app in the FFC-EX fleet has dependency-vulnerability detection wired at all. A repo counts as covered only when it has BOTH `.github/workflows/security-audit.yml` and an `audit:high` script in package.json \u2014 the workflow without the script fails on every run, the script without the workflow never runs. Findings are upserted into a single rolling issue that auto-closes once the fleet is fully covered.  Why (#838): 34 of the 44 Node FFC-EX repos had no detection of any kind, so a published advisory against a charity site was invisible until somebody swept by hand \u2014 and nothing was measuring that, which is why #822's scope was estimated at 13 repos when the real number was 38. This workflow re-derives the fleet from the org listing every run rather than trusting a count carried between sessions.  It also answers the question presence cannot (#889, ledger L06): does each repo's package-lock.json actually RESOLVE? A lockfile that exists but is out of sync with package.json makes `npm ci` exit non-zero, so the nightly audit installs nothing, scans nothing and reports clean \u2014 a covered repo that is not being scanned. The verdict comes from running the real `npm ci --dry-run`, not from re-implementing npm's sync check, so this audit cannot hold a second opinion about semver from the one the fleet's own audits run on.  Read-only: GITHUB_TOKEN reads public repo contents org-wide and lists the org's public repos; the only write is the rolling issue in THIS repo. The lockfile stage additionally reads the npm registry (unauthenticated, no credential, and `npm ci --dry-run` downloads no package) \u2014 that is the one external API this workflow touches, and it is read-only. No environment gate. It reports coverage only and never bumps a dependency \u2014 remediation belongs to 822. Classification/report logic lives in scripts/fleet-audit-coverage-lib.js (unit-tested under tests/workflow-logic/).  Cost of the resolution check: one lockfile download plus one short npm run per Node repo (~44). That is the trade 742 declined \u2014 it never downloads a lockfile because it runs on demand across the whole fleet and writes files. This job is weekly and read-only, so it can afford to be the place that measures.",
       "safetyLevel": "Reads",
       "approvalEnv": "\u2014",
-      "guard": "weekly coverage audit of dependency-vulnerability detection across the FFC-EX fleet (a repo counts as covered only with BOTH `security-audit.yml` and an `audit:high` script); rolling issue upsert/close on any gap; reports only \u2014 never bumps a dependency or writes to a fleet repo; GITHUB_TOKEN (public reads + own-repo issue), no external API, ungated",
+      "guard": "weekly coverage audit of dependency-vulnerability detection across the FFC-EX fleet (a repo counts as covered only with BOTH `security-audit.yml` and an `audit:high` script) PLUS a lockfile-resolution check \u2014 real `npm ci --dry-run` per Node repo, since a lockfile that exists but does not resolve makes the nightly audit scan nothing (#889, ledger L06); rolling issue upsert/close on any gap; reports only \u2014 never bumps a dependency or writes to a fleet repo; GITHUB_TOKEN (public reads + own-repo issue), npm registry read-only, ungated",
       "category": "GitHub (Website + Repo)",
       "categoryCode": "GH"
     },
@@ -1965,6 +2001,46 @@
       "safetyLevel": "Reads",
       "approvalEnv": "\u2014",
       "guard": "weekly audit of the security headers each FFC-delivered site ACTUALLY SERVES (HSTS, X-Content-Type-Options, X-Frame-Options, Referrer-Policy, Permissions-Policy, CSP), measured by fetching the live response and never by looking for a file in a repo \u2014 `public/_headers` is inert on this stack, so a source-file check reports coverage that does not exist (#884); scope is every domain in an FFC Cloudflare zone (derived column, not the curated host category); report-only CSP does not count as a CSP and a `<meta>` tag satisfies nothing; rolling issue upsert/close on any gap; plain HTTPS GETs to public sites, no credentials, no external API, GITHUB_TOKEN for the issue only, ungated",
+      "category": "GitHub (Website + Repo)",
+      "categoryCode": "GH"
+    },
+    {
+      "number": 744,
+      "title": "Repo - Public Feed Freshness",
+      "apis": [
+        "GH"
+      ],
+      "file": "744-repo-public-feed-freshness.yml",
+      "triggers": [
+        "schedule",
+        "workflow_dispatch"
+      ],
+      "environments": [],
+      "description": "Daily outcome check on the PUBLISHED Agentic OS status feed in FFC-IN-ffcadmin.org \u2014 the data behind https://ffcadmin.org/agentic-os/.  Why (#977): three separate mechanisms are supposed to keep that page current, and none of them checks whether its data is fresh. #921 (via 740) watches whether 502 succeeds, not whether its PR merged. #908 watches data-refresh PRs hanging behind main, not the publisher never opening one. #771 watches drift between the two copies, not both being equally stale. All three are PROCESS checks, and every one of them was green while the public feed sat three days old \u2014 502's deliver job had been failing since 2026-07-29 on a dead PAT (#848), and nobody connected the two.  This workflow asserts the outcome instead: how old is the timestamp the public page is actually serving. That catches all three causes above plus the next unknown one, and it is cheap.  Both published copies are checked and reported by path, because they are written separately and can disagree (#771).  A path that is missing, unreadable, or carries an absent, empty, non-ISO or future `generated_at` is reported as a FINDING, never as fresh. \"Could not check\" and \"checked, fine\" are different answers, and collapsing them is the exact fail-open this workflow exists to close (ledger L02).  Credentials: NONE beyond the ambient GITHUB_TOKEN. The two files are public and the only write is one issue in this repository. Using `read-all-cbm-github-pat` here would be circular: a freshness monitor that depends on the credential whose death it exists to reveal goes dark at precisely the moment it is needed. No Key Vault access, no environment, no approval gate.  Classification + report logic lives in scripts/public-feed-freshness-lib.js (unit-tested under tests/workflow-logic/).",
+      "safetyLevel": "Reads",
+      "approvalEnv": "\u2014",
+      "guard": "daily OUTCOME check on the published Agentic OS status feed in `FFC-IN-ffcadmin.org` (`agentic-os-status.json`, both the `public/data/` and `src/data/` copies), asserting how old the timestamp the public page actually serves is \u2014 the three existing mechanisms are all PROCESS checks (#921 watches whether 502 succeeds, #908 watches PRs stuck behind `main`, #771 watches drift between the two copies) and every one of them was green while the page sat three days stale (#977); stale after 36h, so one missed daily tick does not report; a path that is missing, unreadable, or carries an absent/empty/non-ISO/future `generated_at` is a finding and never a pass, and a registered path the run produced no observation for is reported rather than skipped; rolling issue upsert/close; **deliberately holds no Key Vault credential** \u2014 ambient GITHUB_TOKEN only, since a monitor depending on the credential whose death it reveals goes dark when it is needed; ungated",
+      "category": "GitHub (Website + Repo)",
+      "categoryCode": "GH"
+    },
+    {
+      "number": 745,
+      "title": "Repo - Agentic OS Board Audit",
+      "apis": [
+        "GH"
+      ],
+      "file": "745-agentic-os-board-audit.yml",
+      "triggers": [
+        "schedule",
+        "workflow_dispatch"
+      ],
+      "environments": [
+        "github-prod-read"
+      ],
+      "description": "Runs scripts/audit-agentic-os-board.py daily against the public \"Agentic OS\" board (org project #9) and reports to the Conductor Log (#719) when \u2014 and only when \u2014 the audit has something to say.  WHY A WORKFLOW AND NOT A SCRIPT (#969). The script landed in #968 and works: it found four real defects the first time it was pointed at the live board. But nothing invoked it, and a script that runs when a human remembers to run it is the same category of assurance as not having it. The board has NO auto-add automation \u2014 org project #9 enables only `Auto-add sub-issues`, while `Item closed` and `Pull request merged` are disabled \u2014 so every card and every Status transition is placed by hand, and that is not going to change. This audit is the compensating control, and a compensating control on a manual process has to be automatic or it inherits the same failure mode. It had already failed twice in two runs by the time #969 was filed, in both directions, and run 62's mess sat unnoticed for ~6 hours.  UNGATED, DELIBERATELY. `github-prod-read` has no required reviewers. A daily read-only audit pinned to a gated environment parks at an approval gate that nobody is watching at 07:47 UTC and is eventually reaped by janitor 734 \u2014 which is #834 exactly, and what tests/workflow-logic/test_gated_env_hygiene.py exists to prevent.  THE CREDENTIAL IS NOT read-all-cbm-github-pat, and that is a deviation from 969's text. The audit needs a real PAT \u2014 the ambient GITHUB_TOKEN is repository-scoped and cannot read an ORG-level ProjectsV2 board \u2014 but the secret #969 named has been dead since 2026-07-29T22:26Z (#848: 502's deliver job has failed on a 401 every day since). Wiring a new daily workflow to it would ship a guaranteed-red cron and manufacture a 740 alert on its first tick. This follows 726 instead: the same reader identity on the same ungated lane, loading read-all-cbm-ffc-copilot-mcp-github-pat, which 321 reported live on 2026-08-01T10:05Z. Key Vault stays the single source of truth (#844); rotation is a new KV version and no GitHub change.  SILENT WHEN CLEAN, following 734 and #967. A daily \"the board is clean\" comment on #719 trains everyone to stop reading the thread. Silence is reserved for the one outcome that established something: the audit ran, read both sides, and found nothing. An audit that could not complete is reported, never skipped.  Read-only against GitHub: no card is added, no Status is set, nothing is closed. The only write of any kind is the Conductor Log comment, which uses the ambient GITHUB_TOKEN and never the Key Vault PAT \u2014 an own-repo issue write belongs on the ambient token (#834's lesson from 726).",
+      "safetyLevel": "Reads",
+      "approvalEnv": "github-prod-read",
+      "guard": "daily audit of the public Agentic OS board (org project #9) against the real backlog, running `scripts/audit-agentic-os-board.py` \u2014 which #968 shipped and nothing invoked, making it assurance only when a human remembered (#969); the board has NO auto-add so every card and Status is placed by hand and the audit is the compensating control, which on a manual process has to be automatic or it inherits the same failure mode; reports the three sets (missing from board / no Status / closed-or-merged but not `Done`) to the Conductor Log and is SILENT when clean, following 734; a run that could not read one of its two sides is reported as INCOMPLETE and never as clean, since the script exits 1 for both findings and enumeration failure and the exit code alone cannot tell them apart; read-only against GitHub (adds no card, sets no Status, closes nothing), Key Vault PAT on the reader identity for the org-level ProjectsV2 read the ambient token cannot do, ambient GITHUB_TOKEN for the issue comment, ungated",
       "category": "GitHub (Website + Repo)",
       "categoryCode": "GH"
     },

--- a/src/data/agentic-os-status.json
+++ b/src/data/agentic-os-status.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-01T22:26:59Z",
+  "generated_at": "2026-08-02T01:20:58Z",
   "org": "FreeForCharity",
   "repo": "FreeForCharity/FFC-Cloudflare-Automation",
   "repos": [
@@ -12,13 +12,42 @@
   "backlog_issues": [
     {
       "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 989,
-      "title": "gh api --paginate with an array-building --jq silently emits one array per page",
+      "number": 993,
+      "title": "Nothing verifies our gated/ungated claims against GitHub: the environment tests compare our docs to our own YAML",
       "state": "open",
       "assignee": null,
-      "updated_at": "2026-08-01T22:13:24Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/989",
+      "updated_at": "2026-08-02T01:17:41Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/993",
       "labels": [
+        "security",
+        "agentic-os",
+        "agent-ready"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 835,
+      "title": "The public Agentic OS board has no auto-add: every Conductor run adds items to Project #9 by hand",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-08-02T01:15:18Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/835",
+      "labels": [
+        "enhancement",
+        "agentic-os",
+        "agent-ready"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 992,
+      "title": "745 fails on board latency, not just board drift: a PR carded 35 minutes late is not run 62's six-hour gap",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-08-02T01:14:28Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/992",
+      "labels": [
+        "bug",
         "agentic-os",
         "agent-ready"
       ]
@@ -29,10 +58,23 @@
       "title": "Agentic OS Conductor Log",
       "state": "open",
       "assignee": null,
-      "updated_at": "2026-08-01T22:04:29Z",
+      "updated_at": "2026-08-02T01:04:39Z",
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719",
       "labels": [
         "agentic-os"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 989,
+      "title": "gh api --paginate with an array-building --jq silently emits one array per page",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-08-01T22:13:24Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/989",
+      "labels": [
+        "agentic-os",
+        "agent-ready"
       ]
     },
     {
@@ -141,20 +183,6 @@
       "assignee": null,
       "updated_at": "2026-08-01T04:28:31Z",
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/971",
-      "labels": [
-        "enhancement",
-        "agentic-os",
-        "agent-ready"
-      ]
-    },
-    {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 969,
-      "title": "Schedule the Agentic OS board audit — #968 shipped the script, nothing runs it",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-08-01T04:27:39Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/969",
       "labels": [
         "enhancement",
         "agentic-os",
@@ -513,18 +541,6 @@
     },
     {
       "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 835,
-      "title": "The public Agentic OS board has no auto-add: every Conductor run adds items to Project #9 by hand",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-07-25T01:15:02Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/835",
-      "labels": [
-        "agentic-os"
-      ]
-    },
-    {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
       "number": 813,
       "title": "Epic: WHMCS fraud review via FraudLabs Pro + daily agent check (charities mis-flagged as fraud)",
       "state": "open",
@@ -748,6 +764,48 @@
   "ready_issues": [
     {
       "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 993,
+      "title": "Nothing verifies our gated/ungated claims against GitHub: the environment tests compare our docs to our own YAML",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-08-02T01:17:41Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/993",
+      "labels": [
+        "security",
+        "agentic-os",
+        "agent-ready"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 835,
+      "title": "The public Agentic OS board has no auto-add: every Conductor run adds items to Project #9 by hand",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-08-02T01:15:18Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/835",
+      "labels": [
+        "enhancement",
+        "agentic-os",
+        "agent-ready"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 992,
+      "title": "745 fails on board latency, not just board drift: a PR carded 35 minutes late is not run 62's six-hour gap",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-08-02T01:14:28Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/992",
+      "labels": [
+        "bug",
+        "agentic-os",
+        "agent-ready"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
       "number": 989,
       "title": "gh api --paginate with an array-building --jq silently emits one array per page",
       "state": "open",
@@ -809,20 +867,6 @@
       "assignee": null,
       "updated_at": "2026-08-01T04:28:31Z",
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/971",
-      "labels": [
-        "enhancement",
-        "agentic-os",
-        "agent-ready"
-      ]
-    },
-    {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 969,
-      "title": "Schedule the Agentic OS board audit — #968 shipped the script, nothing runs it",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-08-01T04:27:39Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/969",
       "labels": [
         "enhancement",
         "agentic-os",
@@ -899,26 +943,24 @@
       ]
     }
   ],
-  "ready_count": 11,
+  "ready_count": 13,
   "ready_rule": "Open issues labeled 'agent-ready' and NOT 'claimed': unblocked, one-PR-scoped and carrying acceptance criteria — the queue a sandboxed agent can pick from now. An 'agent-ready' issue with an open PR against it carries 'claimed' (applied by workflow 737) and is excluded here until that PR closes; ready_count counts exactly the rows in ready_issues. A strict subset of backlog_issues, which stays the full 'agentic-os' topic set (epics, machine-managed rolling issues, human-blocked items and durable findings all remain counted there).",
   "in_flight_prs": [
     {
       "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 990,
-      "title": "docs: three run-70 lessons — an exported guard, a per-page jq array, a five-hour window",
+      "number": 994,
+      "title": "docs: two run-71 lessons — a self-consistent test, and a definition of clean that is never true",
       "state": "open",
       "draft": true,
       "assignee": null,
-      "updated_at": "2026-08-01T22:26:34Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/990",
-      "labels": [
-        "agentic-os"
-      ],
+      "updated_at": "2026-08-02T01:20:36Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/994",
+      "labels": [],
       "linked_agentic_issues": [
-        719,
-        989,
-        848,
-        921
+        834,
+        993,
+        835,
+        992
       ]
     },
     {
@@ -1104,20 +1146,6 @@
   "conductor_log": [
     {
       "author": "clarkemoyer",
-      "created_at": "2026-08-01T10:05:51Z",
-      "body": "## Run 66 — START (2026-08-01T10:0xZ)\n\nLocal Windows host, `gh` as clarkemoyer. Bootstrap clean: 5/5 core clones fetched + pruned, all on `main`. Hub `4aa04d1`, ffcadmin `4496b73`.\n\n**Run 65 ended 07:5xZ — ~2h before this slot.** This is the shortest gap between runs so far, so the carry-in list is genuinely fresh rather than stale.\n\nConfirmed from [run 65's END](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5150097936):\n\n- **#975 (run-65 lessons L50/L51) is…",
-      "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5150952573"
-    },
-    {
-      "author": "clarkemoyer",
-      "created_at": "2026-08-01T10:35:05Z",
-      "body": "## Run 66 — END (2026-08-01T11:0xZ) · core 4922 / graphql 4061\n\n**2 PRs merged, 2 opened, 1 issue filed, 1 issue re-diagnosed and retitled, 0 gates approved, board 225 items 0/0/0.**\n\n### First, a correction about which run this is\n\n`state/` said run 64 was the last completed run. It was not — [run 65](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5150097936) had run ~2h earlier and logged a full START and END here, but never wrote its own state file. Two op…",
-      "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5151046503"
-    },
-    {
-      "author": "clarkemoyer",
       "created_at": "2026-08-01T13:06:06Z",
       "body": "## Run 67 — START (2026-08-01T13:0xZ)\n\nLocal Windows host, `gh` as clarkemoyer. Bootstrap clean: 5/5 core clones fetched + pruned, all on `main`, 0 dirty. Hub `9a8dc98`, ffcadmin `2774b72`. Core 4954 / graphql 4942.\n\n**Both of run 66's carry-forwards landed.** #975 merged 10:38:43Z (it was queued at position 1); ffcadmin #775 merged 10:32:19Z. Nothing to re-check there.\n\n**A fourth consecutive Conductor-filed issue came back as a worker PR — and this time in under two hours.** #977 was filed dur…",
       "truncated": true,
@@ -1171,6 +1199,20 @@
       "body": "## Run 70 — START (2026-08-01T22:0xZ)\n\nConductor run 70 beginning. Bootstrap complete:\n\n- Workspace `C:\\ClaudeCodeDesktop\\Claude_AI_OS_Routine` intact; all 5 core clones fetched and fast-forwarded to `main` (hub `c8a80a6` = #987, ffcadmin `794364f` = #780 run-69 feed, freeforcharity `fa3f600`, SPT `b4e6d32`, FOT `c310e85`).\n- Tooling verified: `gh` 2.96.0 (clarkemoyer, scopes incl. `project`/`workflow`), `az` 2.81.0, `m365` 11.9.0, `gcloud` 552.0.0.\n- `AGENTS.md` + `docs/workflow-safety-and-appr…",
       "truncated": true,
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5153656604"
+    },
+    {
+      "author": "clarkemoyer",
+      "created_at": "2026-08-01T22:39:40Z",
+      "body": "## Run 70 — END (2026-08-01T22:3xZ) · core 4903 / graphql 3389\n\n**2 PRs merged (#988, ffcadmin #781), 2 opened (#990 draft, #989 issue), 0 gates approved, board 239 items 0/0/0 by script, feed live-verified. No Clarke contact.**\n\n### #988 — reviewed by execution, one contract gap found, fixed on the branch, merged 22:23:42Z\n\nThe PR is careful and its central claim holds. The workflow half is sound: pages are accumulated before the scan (`739…yml:219-228`), the read is bounded by `since` **and** …",
+      "truncated": true,
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5153788389"
+    },
+    {
+      "author": "clarkemoyer",
+      "created_at": "2026-08-02T01:04:39Z",
+      "body": "## Run 71 — START (2026-08-02T01:0xZ)\n\nLocal Windows host, `gh` as clarkemoyer. Bootstrap clean: 5/5 core clones fetched + pruned, all on `main`, 0 dirty. Hub `f0748ad`, ffcadmin `db19104`, freeforcharity `fa3f600`, SPT `b4e6d32`, FOT `c310e85`. Core 4936 / graphql 4134. `az` 2.81.0, `m365` 11.9.0, `gcloud` 552.0.0, `gh` 2.96.0 all present.\n\n**Run number from this issue's tail** (run 70 END at 22:39:40Z), not from `state/CONDUCTOR.md` — which is stale at run 69 for the same reason it was stale a…",
+      "truncated": true,
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5154329897"
     }
   ],
   "pending_gates": [

--- a/src/data/workflow-catalog.json
+++ b/src/data/workflow-catalog.json
@@ -309,7 +309,7 @@
       "description": "READ-ONLY: probes whether the selected Cloudflare token has Registrar API rights (read + write). Never registers or changes anything. Wraps scripts/cloudflare-registrar-access-check.ps1.",
       "safetyLevel": "Reads",
       "approvalEnv": "\u2705 cloudflare-prod-write",
-      "guard": "never charges",
+      "guard": "never charges; but `cloudflare-tokens-from-kv` runs with **`scope: write`** \u2192 loads `wr-all-*` CF tokens, so **not auto-approvable** (#915)",
       "category": "Cloudflare / DNS / Domain",
       "categoryCode": "CF"
     },
@@ -473,6 +473,22 @@
       "categoryCode": "CF"
     },
     {
+      "number": 123,
+      "title": "Domain - Inbound Transfer Preflight (Report)",
+      "apis": [],
+      "file": "123-domain-inbound-transfer-preflight.yml",
+      "triggers": [
+        "workflow_dispatch"
+      ],
+      "environments": [],
+      "description": "READ-ONLY: probes the registry (RDAP) for the given domains, then runs scripts/domain-inbound-transfer-preflight.ps1 offline to classify how each domain held at a FOREIGN registrar (Wix / Squarespace / GoDaddy / ...) comes under FFC management -- via eNom/WHMCS, then Cloudflare nameservers.  Counterpart to workflow 115, which handles the outbound leg (eNom -> Cloudflare Registrar) and assumes the losing registrar is already eNom.  No secrets and no WHMCS credentials: RDAP is public and the preflight itself is pure offline analysis. Initiates no transfer and spends no money.  SCOPE: `domains` is required and there is no fleet-wide default. This workflow only ever looks at domains someone names explicitly -- it does not sweep the estate, and it is not a source of truth about it.  WHMCS is FFC's live record of what we hold. docs/domain-registry-truth.csv is a committed point-in-time RDAP snapshot for reference only; do not treat it as current, and do not drive work from it.  run-name echoes the requested domains so a run is identifiable in the Actions list without opening it.",
+      "safetyLevel": "Reads",
+      "approvalEnv": "none (no credentials)",
+      "guard": "read-only RDAP + offline analysis; classifies foreign-registrar domains for the eNom/WHMCS inbound path",
+      "category": "Cloudflare / DNS / Domain",
+      "categoryCode": "CF"
+    },
+    {
       "number": 201,
       "title": "WHMCS - Export Domains (Report)",
       "apis": [
@@ -488,7 +504,7 @@
       "description": "",
       "safetyLevel": "Reads",
       "approvalEnv": "whmcs-prod-read",
-      "guard": "gated only by the env approval",
+      "guard": "ungated read lane; artifacts are export catalogs",
       "category": "WHMCS",
       "categoryCode": "WHMCS"
     },
@@ -508,7 +524,7 @@
       "description": "",
       "safetyLevel": "Reads",
       "approvalEnv": "whmcs-prod-read",
-      "guard": "gated only by the env approval",
+      "guard": "ungated read lane; artifacts are export catalogs",
       "category": "WHMCS",
       "categoryCode": "WHMCS"
     },
@@ -528,7 +544,7 @@
       "description": "",
       "safetyLevel": "Reads",
       "approvalEnv": "whmcs-prod-read",
-      "guard": "gated only by the env approval",
+      "guard": "ungated read lane; artifacts are export catalogs",
       "category": "WHMCS",
       "categoryCode": "WHMCS"
     },
@@ -885,12 +901,12 @@
         "workflow_dispatch"
       ],
       "environments": [
-        "whmcs-prod"
+        "whmcs-prod-read"
       ],
-      "description": "Read-only. Sweeps GetClientsProducts (all clients) and returns the onboarding application(s) whose product custom fields contain the query substring (a domain or organization name), with personal contact fields masked. This is the domain/org -> client-id lookup that 219 (which needs a client id) and the masked triage tables cannot do. Posts the matches to the job summary and optionally back to a GitHub issue. No writes.  NOTE: uses the gated `whmcs-prod` so it runs today with a single approval; once `whmcs-prod-read` is set up it can move there (read-only workflow).",
+      "description": "Read-only. Sweeps GetClientsProducts (all clients) and returns the onboarding application(s) whose product custom fields contain the query substring (a domain or organization name), with personal contact fields masked. This is the domain/org -> client-id lookup that 219 (which needs a client id) and the masked triage tables cannot do. Posts the matches to the job summary and optionally back to a GitHub issue. No writes.  Runs on the ungated `whmcs-prod-read` lane with the READ-scoped credential (`read-all-ffc-whmcs-*`, via the ffc-admin-kv-reader identity) \u2014 matching what the job actually does. 104 is the precedent for this lane. WHMCS is a single credential, so read/write scope selects the identity, not the access.",
       "safetyLevel": "Reads",
-      "approvalEnv": "\u2705 whmcs-prod",
-      "guard": "GetClientsProducts sweep; personal contact fields masked; gated until whmcs-prod-read setup",
+      "approvalEnv": "whmcs-prod-read",
+      "guard": "GetClientsProducts sweep; personal contact fields masked; **ungated** \u2014 `whmcs-secrets-from-kv` with `scope: read` on the `READ_ALL_FFC_AZURE_*` (ffc-admin-kv-reader) identity \u2192 `read-all-ffc-whmcs-*` (#920; was \u2705 `whmcs-prod` on the writer identity, held under #915)",
       "category": "WHMCS",
       "categoryCode": "WHMCS"
     },
@@ -1059,6 +1075,26 @@
       "safetyLevel": "Writes (record field)",
       "approvalEnv": "\u2705 whmcs-prod",
       "guard": "`dry_run` (default true); one record + one field per dispatch; strict per-target allowlist of writable fields; refuses to replace a different existing value without `force`; reports `previousValue`",
+      "category": "WHMCS",
+      "categoryCode": "WHMCS"
+    },
+    {
+      "number": 231,
+      "title": "WHMCS - Domain Order Add (Register/Transfer) (Admin)",
+      "apis": [
+        "WHMCS"
+      ],
+      "file": "231-whmcs-domain-order-add.yml",
+      "triggers": [
+        "workflow_dispatch"
+      ],
+      "environments": [
+        "whmcs-prod"
+      ],
+      "description": "Places a WHMCS domain order for an existing client by wrapping scripts/whmcs-order-add.ps1 (WHMCS AddOrder). This is the entry point the inbound migration path (workflow 123 / docs/wix-domain-migration.md) needs: a charity whose domain sits at a foreign registrar has no domain product in WHMCS, so there is nothing to drive the transfer from until one is placed.  Products (group 6): transfer -> pid 41  \"Transfer your Existing Domain Name to the FFC CloudFlare\" register -> pid 39  \"Free new .org Domain Name in the FFC CloudFlare\"  SAFETY: this is the first WRITE against production billing in this area. * mode=dry-run (default) previews the AddOrder request and writes nothing. * mode=execute places a real order. Gated behind the whmcs-prod environment approval on top of that. * The underlying script skips when the client already has a non-terminated service for the product, unless allow_duplicate is set. * no_email defaults to true so a first live run cannot surprise a charity with an unexpected order confirmation. Turn it off deliberately.  Find client_id with 221 (Application Search) or 219 (Application Detail). Confirm the registrar situation first with 123 (Inbound Transfer Preflight).",
+      "safetyLevel": "Writes (dry-run default)",
+      "approvalEnv": "\u2705 whmcs-prod",
+      "guard": "`mode` (default `dry-run`) previews AddOrder and writes nothing; `execute` places a real order; pid fixed by `order_type` (41 transfer / 39 register); underlying script skips when the client already has a non-terminated service for the product unless `allow_duplicate`; `no_email` defaults true so a first live run cannot surprise a charity; price forced to 0",
       "category": "WHMCS",
       "categoryCode": "WHMCS"
     },
@@ -1247,7 +1283,7 @@
       "description": "Read-only export of Zeffy campaigns/events (GET /api/v1/campaigns) via OIDC -> Key Vault. This endpoint returns NO personal data (forms/events only: title, target, volume, dates, URLs), so the uploaded artifact is inherently safe to keep on this public repo. Dispatch-only (no schedule) while we are testing the API. One workflow per endpoint.  The `deliver` job additionally publishes a public, PII-free campaign list (docs/data/ffc-zeffy-campaigns.json \u2014 title/url/status only) as a reviewable data-update PR, so the fleet smoke engine can classify a detected donation surface as ffc-interim (FFC-owned campaign) vs charity-specific (#744). Mirrors the 502 export->deliver split (github-prod gate, CBM_TOKEN) and the 703 same-repo peter-evans data-PR pattern.",
       "safetyLevel": "Reads (+ PR delivery)",
       "approvalEnv": "zeffy-prod \u2192 \u2705 github-prod (deliver)",
-      "guard": "PII masked; the published `docs/data/ffc-zeffy-campaigns.json` is title/url/status only (no financials); `deliver` opens a reviewable data PR via CBM_TOKEN",
+      "guard": "PII masked; the published `docs/data/ffc-zeffy-campaigns.json` is title/url/status only (no financials); `deliver` opens a reviewable data PR via CBM_TOKEN; loads `wr-all-ffc-zeffy-api-key` (default `write`) **and** `wr-all-cbm-github-pat` \u2192 **not auto-approvable** (#915; on the \u2705 list 2026-07-23 \u2192 2026-07-29)",
       "category": "Zeffy",
       "categoryCode": "ZEFFY"
     },
@@ -1324,13 +1360,13 @@
         "workflow_dispatch"
       ],
       "environments": [
-        "github-prod",
+        "github-prod-read",
         "google-prod-read"
       ],
-      "description": "Read-only GA4 reporting for the FFC primary sites. Generates aggregate JSON per site and delivers it to FreeForCharity/FFC-IN-ffcadmin.org as a reviewable PR (never a direct push). PII-safe: aggregate metrics only. Requires the google-prod-read environment (report) and the approval-gated github-prod environment (delivery) + the Wave 0 foundation. The delivery PAT comes from Key Vault (`wr-all-cbm-github-pat`) over OIDC, never a GitHub secret \u2014 see #844.",
+      "description": "Read-only GA4 reporting for the FFC primary sites. Generates aggregate JSON per site and delivers it to FreeForCharity/FFC-IN-ffcadmin.org as a reviewable PR (never a direct push). PII-safe: aggregate metrics only. Requires the google-prod-read environment (report) and the ungated github-prod-read environment (delivery, #834) + the Wave 0 foundation. Opening the PR is reporting plumbing, not a Write \u2014 the data this workflow consumes is a Read. The delivery PAT comes from Key Vault (`read-all-cbm-github-pat`) over OIDC on the READER identity, never a GitHub secret \u2014 #844.",
       "safetyLevel": "Reads",
-      "approvalEnv": "google-prod-read / \u2705 github-prod",
-      "guard": "delivers JSON to ffcadmin via PR (CBM_TOKEN, github-prod approval); PII-safe aggregates. Same PR also syncs the workflow catalog and the Agentic OS status feed (`agentic-os-status.json`, generated by `scripts/generate-agentic-os-status.py`, REST-only)",
+      "approvalEnv": "google-prod-read / github-prod-read",
+      "guard": "delivers JSON to ffcadmin via PR (`read-all-cbm-github-pat` from KV, ungated lane #834); PII-safe aggregates. Same PR also syncs the workflow catalog and the Agentic OS status feed (`agentic-os-status.json`, generated by `scripts/generate-agentic-os-status.py`, REST-only)",
       "category": "Google",
       "categoryCode": "GOOGLE"
     },
@@ -1494,7 +1530,7 @@
       "description": "Generates the merged FFC sites list from the WHMCS / Cloudflare / WPMUDEV exports plus the curated base list, runs per-domain health checks, and commits both sites-list/sites_list.csv and sites-list/sites_list.json.  This repo owns the export environments (whmcs-prod, cloudflare-prod-read, wpmudev-prod) and the GitHub PAT (CBM_TOKEN in github-prod) needed to dispatch the sibling export workflows, so generation lives here. Downstream consumers (e.g. ffcadmin.org) pull the published files from this repo.",
       "safetyLevel": "Writes (data PR only)",
       "approvalEnv": "\u2705 github-prod",
-      "guard": "dispatches read-only exports 201/108/601 (601 waits on its own wpmudev-prod gate); regenerates `sites-list/` CSV+JSON; opens a data PR (never pushes to `main`); weekly Mon 08:00Z + dispatch; serialized concurrency group",
+      "guard": "dispatches read-only exports 201/108/601 (601 waits on its own wpmudev-prod gate); regenerates `sites-list/` CSV+JSON; opens a data PR (never pushes to `main`); weekly Mon 08:00Z + dispatch; serialized concurrency group; loads `wr-all-cbm-ffc-copilot-mcp-github-pat` \u2192 **held on credential scope**, not on a taxonomy gap (#915)",
       "category": "GitHub (Website + Repo)",
       "categoryCode": "GH"
     },
@@ -1650,12 +1686,12 @@
         "workflow_dispatch"
       ],
       "environments": [
-        "github-prod"
+        "github-prod-read"
       ],
-      "description": "Daily read-only audit of FreeForCharity org repository rulesets and settings drift (branch protections, merge queues, Actions policies) against the documented standard, reported as issues under the github-prod approval gate. The PAT comes from Key Vault (`wr-all-cbm-ffc-copilot-mcp-github-pat`) over OIDC, never a GitHub secret \u2014 see #844. That token (not `wr-all-cbm-github-pat`) is the one with Organization Administration read+write, which GitHub requires even to READ org rulesets via a fine-grained PAT.  Supersede-on-newer (#722): these daily runs pause at an approval gate; without this, unapproved runs pile up ~12-deep until the janitor reaps them at 7 days. cancel-in-progress cancels the older queued/waiting run the moment the next scheduled run starts, so at most ONE run ever waits at the gate. Ref-scoped so a dispatch from a PR branch can never cancel main's scheduled run. Trade-off (accepted): cancel-in-progress could interrupt an EXECUTING run, but execution lasts minutes against a 24h cadence \u2014 in practice only gate-waiting runs are ever superseded; janitor 734 remains the backstop.",
+      "description": "Daily read-only audit of FreeForCharity org repository rulesets and settings drift (branch protections, merge queues, Actions policies) against the documented standard, reported as issues.  Runs on the UNGATED github-prod-read lane (#834). A scheduled Reads workflow behind a required-reviewers gate fires at 13:00 UTC with nobody watching and waits \u2014 then either its next scheduled run cancels it (when cancel-in-progress is true, as this workflow had) or it sits until janitor 734 reaps it at 7 days. Both happened here: 3 `failure` + 2 `cancelled` across 8 scheduled runs. Either way the audit did not run on its schedule. The PAT comes from Key Vault (`read-all-cbm-ffc-copilot-mcp-github-pat`) over OIDC on the READER identity, never a GitHub secret \u2014 see #844. That token (not `read-all-cbm-github-pat`) is the one with Organization Administration read, which GitHub requires even to READ org rulesets via a fine-grained PAT.  cancel-in-progress: false (#834). Its entire justification (#722) was that gated runs piled up ~12-deep waiting for approval until janitor 734 reaped them at 7 days. Ungated, nothing ever waits, so the only run it could still cancel is an EXECUTING one \u2014 the trade-off #722 accepted as the lesser evil becomes pure downside. Ref-scoped so a dispatch from a PR branch cannot collide with main's.",
       "safetyLevel": "Reads",
-      "approvalEnv": "\u2705 github-prod",
-      "guard": "report only; CBM_TOKEN via github-prod approval",
+      "approvalEnv": "github-prod-read",
+      "guard": "report only; `read-all-cbm-ffc-copilot-mcp-github-pat` from KV over OIDC; ungated lane (#834) so the daily audit is never cancelled waiting at a gate",
       "category": "GitHub (Website + Repo)",
       "categoryCode": "GH"
     },
@@ -1787,7 +1823,7 @@
         "workflow_dispatch"
       ],
       "environments": [],
-      "description": "Cancels (or, in dry-run, just reports) workflow runs left in the `waiting` state \u2014 i.e. paused at an environment approval gate \u2014 for longer than max_age_days. Scheduled read/triage runs that no one approves otherwise stack up indefinitely and the Actions history stops reflecting real state (see the 209/210 backlog cleared manually on 2026-07-07, issue #637).  Read + cancel only; never approves a gate. Uses the ambient GITHUB_TOKEN.",
+      "description": "Cancels (or, in dry-run, just reports) workflow runs left in the `waiting` state \u2014 i.e. paused at an environment approval gate \u2014 for longer than max_age_days. Scheduled read/triage runs that no one approves otherwise stack up indefinitely and the Actions history stops reflecting real state (see the 209/210 backlog cleared manually on 2026-07-07, issue #637).  It also warns before it reaps: a run inside the last warn_days of its life is reported to the Conductor Log with the exact instant it will be cancelled, and anything actually cancelled is reported too. Before #960 the only output was core.summary on this job \u2014 a page no human opens \u2014 so a gate that had waited a week on a human reviewer was destroyed silently, and the deadlines circulated by hand were wrong by a day (this is a daily cron, so a run dies at the first 06:31Z tick AFTER it crosses the threshold, not at the threshold).  Read + cancel only; never approves a gate. Uses the ambient GITHUB_TOKEN.",
       "safetyLevel": "Writes (cancels runs)",
       "approvalEnv": "\u2014",
       "guard": "cancels runs left waiting >N days at a gate; never approves; dispatch dry-run supported",
@@ -1806,12 +1842,12 @@
         "workflow_dispatch"
       ],
       "environments": [
-        "github-prod"
+        "github-prod-read"
       ],
-      "description": "Regenerates data/dependabot-affected-repos.json (the org repo inventory that feeds the smoke-protected Dependabot waves) and delivers it as an auto-merging PR. Migrated from FFC-IN-ClarkeMoyerAdmin. Uses the github-prod environment so the PR is opened with a real PAT \u2014 a PR opened by GITHUB_TOKEN does not trigger the pull_request checks / Copilot review this repo requires, so it would never satisfy branch protection. The PAT comes from Key Vault (`wr-all-cbm-github-pat`) over OIDC, never a GitHub secret \u2014 see #844. Read-only against the org; PR-only.",
+      "description": "Regenerates data/dependabot-affected-repos.json (the org repo inventory that feeds the smoke-protected Dependabot waves) and delivers it as an auto-merging PR. Migrated from FFC-IN-ClarkeMoyerAdmin. Runs on the UNGATED github-prod-read lane (#834): the org inventory it consumes is a Read, and a weekly gated run fires at 06:15 UTC with nobody watching. It still needs a real PAT \u2014 a PR opened by GITHUB_TOKEN does not trigger the pull_request checks / Copilot review this repo requires, so it would never satisfy branch protection. The PAT comes from Key Vault (`read-all-cbm-github-pat`) over OIDC on the READER identity, never a GitHub secret \u2014 see #844. Read-only against the org; PR-only.",
       "safetyLevel": "Reads",
-      "approvalEnv": "\u2705 github-prod",
-      "guard": "weekly org inventory (feeds smoke-protected waves); PR-only + auto-merge",
+      "approvalEnv": "github-prod-read",
+      "guard": "weekly org inventory (feeds smoke-protected waves); PR-only + auto-merge; `read-all-cbm-github-pat` from KV over OIDC on the ungated lane (#834)",
       "category": "GitHub (Website + Repo)",
       "categoryCode": "GH"
     },
@@ -1848,10 +1884,10 @@
         "workflow_dispatch"
       ],
       "environments": [],
-      "description": "Mechanizes the AGENTS.md work-claiming protocol (available = `is:open -label:claimed`). Two independent triggers:  1. Event-driven label sync (pull_request): parse Closes/Fixes/Refs #N from the PR body and add `claimed` to those open hub issues while the PR is active; remove it when the last open linked PR closes/merges. 2. Daily sweep (schedule): release stale hand-labeled claims \u2014 issues labeled `claimed` with no open linked PR and no activity for 48h \u2014 in this repo, so an abandoned claim frees itself. (ffcadmin needs its own sweep: cross-repo writes require CBM_TOKEN, which lives only in the gated github-prod environment \u2014 unusable for an ungated daily job.)  Writes issues/labels only; no external API; ungated. The decision logic lives in scripts/claim-sync-lib.js (unit-tested in tests/workflow-logic/).",
+      "description": "Mechanizes the AGENTS.md work-claiming protocol (available = `is:open -label:claimed`). Two independent triggers:  1. Event-driven label sync (pull_request): parse Closes/Fixes/Refs #N from the PR body and add `claimed` to those open hub issues while the PR is active; remove it when the last open linked PR closes/merges. It also comments ON THE PR naming what it just claimed \u2014 `Refs #N` is both the claiming form and how people write a citation, and only the PR author can tell which they meant (#948). 2. Daily sweep (schedule): reconcile this repo's `claimed` labels against every open PR in the org. The pickup query in AGENTS.md is org-wide but trigger 1 is repo-local, so a hub issue implemented by a PR in a template or site repo read as unclaimed and invited a duplicate (#939). The sweep claims those, releases a claim once the last open PR referencing the issue \u2014 in any repo \u2014 is closed or merged, and still releases a stale hand-labeled claim after 48h of inactivity. It also REPORTS (never releases) claims whose only claimant is a draft PR older than 48h \u2014 a draft suppresses a pickup exactly as hard as a ready PR (#948). Cross-repo is READ-only here: every write targets this repo's own issues, so the ambient token suffices. (ffcadmin still needs its own sweep for ITS issues: cross-repo writes require CBM_TOKEN, which lives only in the gated github-prod environment \u2014 unusable for an ungated daily job.)  Writes issues/labels only; no external API; ungated. The decision logic lives in scripts/claim-sync-lib.js (unit-tested in tests/workflow-logic/).",
       "safetyLevel": "Writes (issues/labels only)",
       "approvalEnv": "\u2014",
-      "guard": "syncs `claimed` label from linked PRs (pull_request event, GITHUB_TOKEN) + daily sweep of expired claims (no open linked PR + 48h idle) in this repo (ambient GITHUB_TOKEN \u2014 CBM_TOKEN is gated-env-only and empty on schedule); no external API, ungated; sweep `dry_run` via dispatch",
+      "guard": "syncs `claimed` label from linked PRs (pull_request event, GITHUB_TOKEN) + daily sweep reconciling this repo's claims against every open PR in the org \u2014 one `search/issues` read, writes only this repo's issues (ambient GITHUB_TOKEN \u2014 CBM_TOKEN is gated-env-only and empty on schedule); releases when no open PR in any repo still references the issue, or after 48h idle for a hand-labeled claim; no external API, ungated; sweep `dry_run` via dispatch",
       "category": "GitHub (Website + Repo)",
       "categoryCode": "GH"
     },
@@ -1905,7 +1941,7 @@
         "workflow_dispatch"
       ],
       "environments": [],
-      "description": "Watches every scheduled hub workflow (726 drift audit, 734 janitor, 738 smoke drift, Google 502 analytics + 504 GTM backups, and the other cron-driven monitors \u2014 the authoritative list is WATCHED_WORKFLOWS below). For each one it upserts ONE rolling alert issue PER WATCHED WORKFLOW, and closes that issue on the next success of that same workflow. The marker is keyed by workflow name precisely so a green run of one watched workflow can never close another's alert \u2014 with a dozen workflows watched, a shared marker would let a weekly job's success silently clear a daily job's outage.  POLL, NOT `workflow_run` (#843). This workflow used to trigger on the `workflow_run` completed event. That event has NEVER fired in this repository \u2014 `?event=workflow_run` returns 0 runs all time, while sibling repos show hundreds \u2014 so both this alerter and the Google one (732, now retired into this file) were `active` and had produced exactly zero runs. The alerting layer was dead for six days and nothing could tell us, because a `workflow_run` watcher cannot be tested on demand. The poll can: `workflow_dispatch` below is REQUIRED, not a convenience \u2014 it is what makes this alerter provable.  BEHAVIOUR CHANGE, deliberate: the event saw *every* run; the poll sees only the LATEST completed default-branch run per workflow, so a failure that self-heals between polls is missed. That is an acceptable \u2014 arguably better \u2014 fit, because the rolling issue answers \"is this workflow currently broken?\", which is exactly what latest-run state models. Do not add cursor/state tracking to chase the transient case; it would trade away the simplicity that makes this verifiable.  Consequence worth knowing: the poll model only makes sense for SCHEDULED workflows. For a dispatch-only workflow the \"latest run\" is whatever a human last ran by hand \u2014 a stale red would alert forever and a stale green would mean nothing. `test_watched_workflows_are_actually_scheduled` enforces that, and it is why 501 (workflow_dispatch/workflow_call only) is excluded even though retired 732 watched it.  Ambient GITHUB_TOKEN only, no environment: \u2014 the alerter must never be blocked by the very gate it is watching. Reports `cancelled` as well as `failure`: a run cancelled before it reaches a runner (the 2026-07-24 726 incident) executes zero steps and is exactly the kind of silent breakage this workflow exists to surface.  It does NOT alert on a declined or expired approval gate. Those also surface as run-level `failure`, so the run conclusion alone cannot tell \"the job broke\" from \"a human said no\"; the job list can, and `actions: read` already allows reading it. See the discriminator in the step below.",
+      "description": "Watches every scheduled hub workflow (726 drift audit, 734 janitor, 738 smoke drift, Google 502 analytics + 504 GTM backups, and the other cron-driven monitors \u2014 the authoritative list is WATCHED_WORKFLOWS below). For each one it upserts ONE rolling alert issue PER WATCHED WORKFLOW, and closes that issue on the next success of that same workflow. The marker is keyed by workflow name precisely so a green run of one watched workflow can never close another's alert \u2014 with a dozen workflows watched, a shared marker would let a weekly job's success silently clear a daily job's outage.  COVERAGE IS NOW EVERY SCHEDULED WORKFLOW BUT THIS ONE (#932). The watch list originally stopped at \"hub plumbing\" because that was #832's scope; the WHMCS lane (209/210/225/228) and the Azure inventory (320) were excluded for being out of that ticket's scope, not for being unwatchable. The evidence went the other way: 228 failed all four of its scheduled runs, 07-27 through 07-30, and no mechanism said a word \u2014 it surfaced only because a conductor audited `main`'s failure list by hand (#912). The lanes carrying live credentials and a payment/fraud pipeline were the ones with no alerting. Nothing about a WHMCS or Azure cron makes the poll unsound, so the only remaining exclusion is this workflow itself, which cannot watch itself without looping (#752).  POLL, NOT `workflow_run` (#843). This workflow used to trigger on the `workflow_run` completed event. That event has NEVER fired in this repository \u2014 `?event=workflow_run` returns 0 runs all time, while sibling repos show hundreds \u2014 so both this alerter and the Google one (732, now retired into this file) were `active` and had produced exactly zero runs. The alerting layer was dead for six days and nothing could tell us, because a `workflow_run` watcher cannot be tested on demand. The poll can: `workflow_dispatch` below is REQUIRED, not a convenience \u2014 it is what makes this alerter provable.  BEHAVIOUR CHANGE, deliberate: the event saw *every* run; the poll sees only the LATEST completed default-branch run per workflow, so a failure that self-heals between polls is missed. That is an acceptable \u2014 arguably better \u2014 fit, because the rolling issue answers \"is this workflow currently broken?\", which is exactly what latest-run state models. Do not add cursor/state tracking to chase the transient case; it would trade away the simplicity that makes this verifiable.  Consequence worth knowing: the poll model only makes sense for SCHEDULED workflows. For a dispatch-only workflow the \"latest run\" is whatever a human last ran by hand \u2014 a stale red would alert forever and a stale green would mean nothing. `test_watched_workflows_are_actually_scheduled` enforces that, and it is why 501 (workflow_dispatch/workflow_call only) is excluded even though retired 732 watched it.  Ambient GITHUB_TOKEN only, no environment: \u2014 the alerter must never be blocked by the very gate it is watching. Reports `cancelled` as well as `failure`: a run cancelled before it reaches a runner (the 2026-07-24 726 incident) executes zero steps and is exactly the kind of silent breakage this workflow exists to surface.  It does NOT alert on a declined or expired approval gate. Those also surface as run-level `failure`, so the run conclusion alone cannot tell \"the job broke\" from \"a human said no\"; the job list can, and `actions: read` already allows reading it. See the discriminator in the step below.",
       "safetyLevel": "Writes (issues only)",
       "approvalEnv": "\u2014",
       "guard": "**polls** every scheduled hub workflow twice hourly (`schedule` + `workflow_dispatch`; the `workflow_run` event has never fired in this repo \u2014 #843) and upserts one rolling issue per watched workflow (marker keyed by workflow name, so only that workflow's own green run closes it); absorbs the retired 732 Google lane (502/504); reports `cancelled`/`timed_out` as well as `failure`, latest completed default-branch run only; does **not** alert on a declined/expired approval gate (no job `failure` + \u22651 job `cancelled` \u21d2 logged via `core.notice`, not an alert) \u2014 an unreadable job list still alerts, and a watched name matching no workflow fails the run loudly; ambient GITHUB_TOKEN, no external API, ungated by design (must not be blocked by the gate it watches)",
@@ -1924,10 +1960,10 @@
         "workflow_dispatch"
       ],
       "environments": [],
-      "description": "Weekly audit of whether each Node app in the FFC-EX fleet has dependency-vulnerability detection wired at all. A repo counts as covered only when it has BOTH `.github/workflows/security-audit.yml` and an `audit:high` script in package.json \u2014 the workflow without the script fails on every run, the script without the workflow never runs. Findings are upserted into a single rolling issue that auto-closes once the fleet is fully covered.  Why (#838): 34 of the 44 Node FFC-EX repos had no detection of any kind, so a published advisory against a charity site was invisible until somebody swept by hand \u2014 and nothing was measuring that, which is why #822's scope was estimated at 13 repos when the real number was 38. This workflow re-derives the fleet from the org listing every run rather than trusting a count carried between sessions.  Read-only: GITHUB_TOKEN reads public repo contents org-wide and lists the org's public repos; the only write is the rolling issue in THIS repo. No external API, no environment gate. It reports coverage only and never bumps a dependency \u2014 remediation belongs to #822. Classification/report logic lives in scripts/fleet-audit-coverage-lib.js (unit-tested under tests/workflow-logic/).",
+      "description": "Weekly audit of whether each Node app in the FFC-EX fleet has dependency-vulnerability detection wired at all. A repo counts as covered only when it has BOTH `.github/workflows/security-audit.yml` and an `audit:high` script in package.json \u2014 the workflow without the script fails on every run, the script without the workflow never runs. Findings are upserted into a single rolling issue that auto-closes once the fleet is fully covered.  Why (#838): 34 of the 44 Node FFC-EX repos had no detection of any kind, so a published advisory against a charity site was invisible until somebody swept by hand \u2014 and nothing was measuring that, which is why #822's scope was estimated at 13 repos when the real number was 38. This workflow re-derives the fleet from the org listing every run rather than trusting a count carried between sessions.  It also answers the question presence cannot (#889, ledger L06): does each repo's package-lock.json actually RESOLVE? A lockfile that exists but is out of sync with package.json makes `npm ci` exit non-zero, so the nightly audit installs nothing, scans nothing and reports clean \u2014 a covered repo that is not being scanned. The verdict comes from running the real `npm ci --dry-run`, not from re-implementing npm's sync check, so this audit cannot hold a second opinion about semver from the one the fleet's own audits run on.  Read-only: GITHUB_TOKEN reads public repo contents org-wide and lists the org's public repos; the only write is the rolling issue in THIS repo. The lockfile stage additionally reads the npm registry (unauthenticated, no credential, and `npm ci --dry-run` downloads no package) \u2014 that is the one external API this workflow touches, and it is read-only. No environment gate. It reports coverage only and never bumps a dependency \u2014 remediation belongs to 822. Classification/report logic lives in scripts/fleet-audit-coverage-lib.js (unit-tested under tests/workflow-logic/).  Cost of the resolution check: one lockfile download plus one short npm run per Node repo (~44). That is the trade 742 declined \u2014 it never downloads a lockfile because it runs on demand across the whole fleet and writes files. This job is weekly and read-only, so it can afford to be the place that measures.",
       "safetyLevel": "Reads",
       "approvalEnv": "\u2014",
-      "guard": "weekly coverage audit of dependency-vulnerability detection across the FFC-EX fleet (a repo counts as covered only with BOTH `security-audit.yml` and an `audit:high` script); rolling issue upsert/close on any gap; reports only \u2014 never bumps a dependency or writes to a fleet repo; GITHUB_TOKEN (public reads + own-repo issue), no external API, ungated",
+      "guard": "weekly coverage audit of dependency-vulnerability detection across the FFC-EX fleet (a repo counts as covered only with BOTH `security-audit.yml` and an `audit:high` script) PLUS a lockfile-resolution check \u2014 real `npm ci --dry-run` per Node repo, since a lockfile that exists but does not resolve makes the nightly audit scan nothing (#889, ledger L06); rolling issue upsert/close on any gap; reports only \u2014 never bumps a dependency or writes to a fleet repo; GITHUB_TOKEN (public reads + own-repo issue), npm registry read-only, ungated",
       "category": "GitHub (Website + Repo)",
       "categoryCode": "GH"
     },
@@ -1965,6 +2001,46 @@
       "safetyLevel": "Reads",
       "approvalEnv": "\u2014",
       "guard": "weekly audit of the security headers each FFC-delivered site ACTUALLY SERVES (HSTS, X-Content-Type-Options, X-Frame-Options, Referrer-Policy, Permissions-Policy, CSP), measured by fetching the live response and never by looking for a file in a repo \u2014 `public/_headers` is inert on this stack, so a source-file check reports coverage that does not exist (#884); scope is every domain in an FFC Cloudflare zone (derived column, not the curated host category); report-only CSP does not count as a CSP and a `<meta>` tag satisfies nothing; rolling issue upsert/close on any gap; plain HTTPS GETs to public sites, no credentials, no external API, GITHUB_TOKEN for the issue only, ungated",
+      "category": "GitHub (Website + Repo)",
+      "categoryCode": "GH"
+    },
+    {
+      "number": 744,
+      "title": "Repo - Public Feed Freshness",
+      "apis": [
+        "GH"
+      ],
+      "file": "744-repo-public-feed-freshness.yml",
+      "triggers": [
+        "schedule",
+        "workflow_dispatch"
+      ],
+      "environments": [],
+      "description": "Daily outcome check on the PUBLISHED Agentic OS status feed in FFC-IN-ffcadmin.org \u2014 the data behind https://ffcadmin.org/agentic-os/.  Why (#977): three separate mechanisms are supposed to keep that page current, and none of them checks whether its data is fresh. #921 (via 740) watches whether 502 succeeds, not whether its PR merged. #908 watches data-refresh PRs hanging behind main, not the publisher never opening one. #771 watches drift between the two copies, not both being equally stale. All three are PROCESS checks, and every one of them was green while the public feed sat three days old \u2014 502's deliver job had been failing since 2026-07-29 on a dead PAT (#848), and nobody connected the two.  This workflow asserts the outcome instead: how old is the timestamp the public page is actually serving. That catches all three causes above plus the next unknown one, and it is cheap.  Both published copies are checked and reported by path, because they are written separately and can disagree (#771).  A path that is missing, unreadable, or carries an absent, empty, non-ISO or future `generated_at` is reported as a FINDING, never as fresh. \"Could not check\" and \"checked, fine\" are different answers, and collapsing them is the exact fail-open this workflow exists to close (ledger L02).  Credentials: NONE beyond the ambient GITHUB_TOKEN. The two files are public and the only write is one issue in this repository. Using `read-all-cbm-github-pat` here would be circular: a freshness monitor that depends on the credential whose death it exists to reveal goes dark at precisely the moment it is needed. No Key Vault access, no environment, no approval gate.  Classification + report logic lives in scripts/public-feed-freshness-lib.js (unit-tested under tests/workflow-logic/).",
+      "safetyLevel": "Reads",
+      "approvalEnv": "\u2014",
+      "guard": "daily OUTCOME check on the published Agentic OS status feed in `FFC-IN-ffcadmin.org` (`agentic-os-status.json`, both the `public/data/` and `src/data/` copies), asserting how old the timestamp the public page actually serves is \u2014 the three existing mechanisms are all PROCESS checks (#921 watches whether 502 succeeds, #908 watches PRs stuck behind `main`, #771 watches drift between the two copies) and every one of them was green while the page sat three days stale (#977); stale after 36h, so one missed daily tick does not report; a path that is missing, unreadable, or carries an absent/empty/non-ISO/future `generated_at` is a finding and never a pass, and a registered path the run produced no observation for is reported rather than skipped; rolling issue upsert/close; **deliberately holds no Key Vault credential** \u2014 ambient GITHUB_TOKEN only, since a monitor depending on the credential whose death it reveals goes dark when it is needed; ungated",
+      "category": "GitHub (Website + Repo)",
+      "categoryCode": "GH"
+    },
+    {
+      "number": 745,
+      "title": "Repo - Agentic OS Board Audit",
+      "apis": [
+        "GH"
+      ],
+      "file": "745-agentic-os-board-audit.yml",
+      "triggers": [
+        "schedule",
+        "workflow_dispatch"
+      ],
+      "environments": [
+        "github-prod-read"
+      ],
+      "description": "Runs scripts/audit-agentic-os-board.py daily against the public \"Agentic OS\" board (org project #9) and reports to the Conductor Log (#719) when \u2014 and only when \u2014 the audit has something to say.  WHY A WORKFLOW AND NOT A SCRIPT (#969). The script landed in #968 and works: it found four real defects the first time it was pointed at the live board. But nothing invoked it, and a script that runs when a human remembers to run it is the same category of assurance as not having it. The board has NO auto-add automation \u2014 org project #9 enables only `Auto-add sub-issues`, while `Item closed` and `Pull request merged` are disabled \u2014 so every card and every Status transition is placed by hand, and that is not going to change. This audit is the compensating control, and a compensating control on a manual process has to be automatic or it inherits the same failure mode. It had already failed twice in two runs by the time #969 was filed, in both directions, and run 62's mess sat unnoticed for ~6 hours.  UNGATED, DELIBERATELY. `github-prod-read` has no required reviewers. A daily read-only audit pinned to a gated environment parks at an approval gate that nobody is watching at 07:47 UTC and is eventually reaped by janitor 734 \u2014 which is #834 exactly, and what tests/workflow-logic/test_gated_env_hygiene.py exists to prevent.  THE CREDENTIAL IS NOT read-all-cbm-github-pat, and that is a deviation from 969's text. The audit needs a real PAT \u2014 the ambient GITHUB_TOKEN is repository-scoped and cannot read an ORG-level ProjectsV2 board \u2014 but the secret #969 named has been dead since 2026-07-29T22:26Z (#848: 502's deliver job has failed on a 401 every day since). Wiring a new daily workflow to it would ship a guaranteed-red cron and manufacture a 740 alert on its first tick. This follows 726 instead: the same reader identity on the same ungated lane, loading read-all-cbm-ffc-copilot-mcp-github-pat, which 321 reported live on 2026-08-01T10:05Z. Key Vault stays the single source of truth (#844); rotation is a new KV version and no GitHub change.  SILENT WHEN CLEAN, following 734 and #967. A daily \"the board is clean\" comment on #719 trains everyone to stop reading the thread. Silence is reserved for the one outcome that established something: the audit ran, read both sides, and found nothing. An audit that could not complete is reported, never skipped.  Read-only against GitHub: no card is added, no Status is set, nothing is closed. The only write of any kind is the Conductor Log comment, which uses the ambient GITHUB_TOKEN and never the Key Vault PAT \u2014 an own-repo issue write belongs on the ambient token (#834's lesson from 726).",
+      "safetyLevel": "Reads",
+      "approvalEnv": "github-prod-read",
+      "guard": "daily audit of the public Agentic OS board (org project #9) against the real backlog, running `scripts/audit-agentic-os-board.py` \u2014 which #968 shipped and nothing invoked, making it assurance only when a human remembered (#969); the board has NO auto-add so every card and Status is placed by hand and the audit is the compensating control, which on a manual process has to be automatic or it inherits the same failure mode; reports the three sets (missing from board / no Status / closed-or-merged but not `Done`) to the Conductor Log and is SILENT when clean, following 734; a run that could not read one of its two sides is reported as INCOMPLETE and never as clean, since the script exits 1 for both findings and enumeration failure and the exit code alone cannot tell them apart; read-only against GitHub (adds no card, sets no Status, closes nothing), Key Vault PAT on the reader identity for the org-level ProjectsV2 read the ambient token cannot do, ambient GITHUB_TOKEN for the issue comment, ungated",
       "category": "GitHub (Website + Repo)",
       "categoryCode": "GH"
     },


### PR DESCRIPTION
Hand delivery of the public feed, generated **after** this run's merges so it describes the state it reports.

## Why by hand

502's `deliver` job has been failing since 2026-07-29 on the dead `read-all-cbm-github-pat` (**#848** / FFC-Cloudflare-Automation#921) — day 5. Until that secret is reminted, every feed refresh is a Conductor hand-delivery.

## Both copies, deliberately

`src/data/` **and** `public/data/` — `/agentic-os` serves from `public/`, `src/` is the render input. Updating one and not the other ships a refresh that announces itself while the live page keeps showing the previous snapshot. That has now happened in **both** directions (runs 57–61 updated only `public/`, run 69 only `src/`), which is why it is lessons-ledger **L65** and why FFC-IN-ffcadmin.org#771 is the guard that should make it impossible.

Verified after pre-commit prettier, not before: both pairs **byte-identical**, **0 CR bytes** (the generator emits CRLF on Windows; normalised before `git add`).

## What moved

| | |
| --- | --- |
| Generated | `2026-08-02T01:20:58Z` |
| Ready issues | **13** — now includes #992 and #993, filed this run, and #835, groomed to `agent-ready` |
| In flight | 13 PRs, incl. FFC-Cloudflare-Automation#994 (run-71 lessons) |
| Pending gates | **2** — the standing pair, unchanged for 18 runs |
| Catalog | picks up **745. Repo - Agentic OS Board Audit [GH]**, merged this run as #991 |

Refs FFC-Cloudflare-Automation#848, #921, #991.