### PR TITLE
chore: refresh Agentic OS status feed (run 72)

### DIFF
--- a/public/data/agentic-os-status.json
+++ b/public/data/agentic-os-status.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-02T01:20:58Z",
+  "generated_at": "2026-08-02T04:36:58Z",
   "org": "FreeForCharity",
   "repo": "FreeForCharity/FFC-Cloudflare-Automation",
   "repos": [
@@ -10,6 +10,45 @@
     "FreeForCharity/FFC-IN-ffcadmin.org"
   ],
   "backlog_issues": [
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 719,
+      "title": "Agentic OS Conductor Log",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-08-02T04:04:37Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719",
+      "labels": [
+        "agentic-os"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 997,
+      "title": "🚨 Scheduled workflow failing: 745. Repo - Agentic OS Board Audit [GH]",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-08-02T03:16:43Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/997",
+      "labels": [
+        "bug",
+        "agentic-os"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 992,
+      "title": "745 fails on board latency, not just board drift: a PR carded 35 minutes late is not run 62's six-hour gap",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-08-02T02:13:09Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/992",
+      "labels": [
+        "bug",
+        "agentic-os",
+        "agent-ready"
+      ]
+    },
     {
       "repo": "FreeForCharity/FFC-Cloudflare-Automation",
       "number": 993,
@@ -36,32 +75,6 @@
         "enhancement",
         "agentic-os",
         "agent-ready"
-      ]
-    },
-    {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 992,
-      "title": "745 fails on board latency, not just board drift: a PR carded 35 minutes late is not run 62's six-hour gap",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-08-02T01:14:28Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/992",
-      "labels": [
-        "bug",
-        "agentic-os",
-        "agent-ready"
-      ]
-    },
-    {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 719,
-      "title": "Agentic OS Conductor Log",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-08-02T01:04:39Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719",
-      "labels": [
-        "agentic-os"
       ]
     },
     {
@@ -764,6 +777,20 @@
   "ready_issues": [
     {
       "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 992,
+      "title": "745 fails on board latency, not just board drift: a PR carded 35 minutes late is not run 62's six-hour gap",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-08-02T02:13:09Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/992",
+      "labels": [
+        "bug",
+        "agentic-os",
+        "agent-ready"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
       "number": 993,
       "title": "Nothing verifies our gated/ungated claims against GitHub: the environment tests compare our docs to our own YAML",
       "state": "open",
@@ -786,20 +813,6 @@
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/835",
       "labels": [
         "enhancement",
-        "agentic-os",
-        "agent-ready"
-      ]
-    },
-    {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 992,
-      "title": "745 fails on board latency, not just board drift: a PR carded 35 minutes late is not run 62's six-hour gap",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-08-02T01:14:28Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/992",
-      "labels": [
-        "bug",
         "agentic-os",
         "agent-ready"
       ]
@@ -948,19 +961,35 @@
   "in_flight_prs": [
     {
       "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 994,
-      "title": "docs: two run-71 lessons — a self-consistent test, and a definition of clean that is never true",
+      "number": 1002,
+      "title": "fix: a failed git command must not read as \"nothing staged\" in the secret scanner",
       "state": "open",
       "draft": true,
       "assignee": null,
-      "updated_at": "2026-08-02T01:20:36Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/994",
+      "updated_at": "2026-08-02T04:36:24Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/1002",
+      "labels": [
+        "security",
+        "agentic-os"
+      ],
+      "linked_agentic_issues": [
+        996,
+        722
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 1001,
+      "title": "fix: a failing git command must not look like a clean secret scan",
+      "state": "open",
+      "draft": true,
+      "assignee": null,
+      "updated_at": "2026-08-02T04:35:57Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/1001",
       "labels": [],
       "linked_agentic_issues": [
-        834,
-        993,
-        835,
-        992
+        996,
+        945
       ]
     },
     {
@@ -1142,36 +1171,8 @@
     }
   ],
   "in_flight_prs_rule": "Open pull requests that are agent work on this backlog, across every repository listed in `repos` — the same org-wide scope as the backlog above, and as the pickup query in AGENTS.md. A PR is listed when it carries the agentic-os label, or when its body references an agentic-os issue in its OWN repository (e.g. 'Closes #123' / 'Refs #123'); a bare #123 is repo-local, so the same number in two repos is two different issues. Referenced-issue labels are what decide it — nothing labels the pull requests themselves. `open_prs_total` is the unfiltered open-PR count over exactly these same repositories.",
-  "open_prs_total": 71,
+  "open_prs_total": 72,
   "conductor_log": [
-    {
-      "author": "clarkemoyer",
-      "created_at": "2026-08-01T13:06:06Z",
-      "body": "## Run 67 — START (2026-08-01T13:0xZ)\n\nLocal Windows host, `gh` as clarkemoyer. Bootstrap clean: 5/5 core clones fetched + pruned, all on `main`, 0 dirty. Hub `9a8dc98`, ffcadmin `2774b72`. Core 4954 / graphql 4942.\n\n**Both of run 66's carry-forwards landed.** #975 merged 10:38:43Z (it was queued at position 1); ffcadmin #775 merged 10:32:19Z. Nothing to re-check there.\n\n**A fourth consecutive Conductor-filed issue came back as a worker PR — and this time in under two hours.** #977 was filed dur…",
-      "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5151549617"
-    },
-    {
-      "author": "github-actions[bot]",
-      "created_at": "2026-08-01T13:43:07Z",
-      "body": "🔓 Claim released — linked PR #839 merged and no other open PR references this issue. Available again (`is:open -label:claimed`).",
-      "truncated": false,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5151681385"
-    },
-    {
-      "author": "clarkemoyer",
-      "created_at": "2026-08-01T13:46:51Z",
-      "body": "## Run 67 — END (2026-08-01T13:5xZ) · core 4868 / graphql 4168\n\n**5 PRs merged, 1 opened, 0 issues filed, 0 gates approved, board 229 items 0/0/0 twice by script. The carried conflict set is gone.**\n\n### Gates — 0 auto-approved, 2 held (15th consecutive run)\n\nRe-derived from workflow source, not inherited:\n\n| Gate | Waiting job | Why held |\n| --- | --- | --- |\n| **111** `30206375399` | `apply`, behind `if: inputs.dry_run == false` — dispatched live | `cloudflare-prod-write`; `cloudflare-tokens-f…",
-      "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5151694220"
-    },
-    {
-      "author": "clarkemoyer",
-      "created_at": "2026-08-01T16:06:25Z",
-      "body": "## Run 68 — START (2026-08-01T16:0xZ)\n\nLocal Windows host, `gh` as clarkemoyer. Bootstrap clean: 5/5 core clones fetched + pruned, all on `main`, 0 dirty. Hub `ab4262b`, ffcadmin `1d12e76`. Core 4967 / graphql 4978. `az` 2.81.0, `m365` 11.9.0, `gcloud` 552.0.0 all present.\n\n**Run 67 ended 13:5xZ and both of its carry-forwards are live on the board.** Its lesson — write `state/` before the END comment — was honoured: `lessons-inbox.md` carries run 67's captures, and this run reads them at step 7 …",
-      "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5152230086"
-    },
     {
       "author": "clarkemoyer",
       "created_at": "2026-08-01T17:09:41Z",
@@ -1213,6 +1214,34 @@
       "body": "## Run 71 — START (2026-08-02T01:0xZ)\n\nLocal Windows host, `gh` as clarkemoyer. Bootstrap clean: 5/5 core clones fetched + pruned, all on `main`, 0 dirty. Hub `f0748ad`, ffcadmin `db19104`, freeforcharity `fa3f600`, SPT `b4e6d32`, FOT `c310e85`. Core 4936 / graphql 4134. `az` 2.81.0, `m365` 11.9.0, `gcloud` 552.0.0, `gh` 2.96.0 all present.\n\n**Run number from this issue's tail** (run 70 END at 22:39:40Z), not from `state/CONDUCTOR.md` — which is stale at run 69 for the same reason it was stale a…",
       "truncated": true,
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5154329897"
+    },
+    {
+      "author": "github-actions[bot]",
+      "created_at": "2026-08-02T01:54:47Z",
+      "body": "### 745 Agentic OS board audit — 3 finding(s)\n\nBoard: FreeForCharity project #9 (Agentic OS) · `expected=68` `board=246` · repos swept: 77\n\nBoth denominators are printed deliberately: run 62 reported \"0 missing\" off an expected set that was one item short, and a short denominator was the only thing a reader could have found suspicious (#966).\n\n#### Missing from the board: 1\n\n_open `agentic-os` items with no card — add them to org project #9_\n\n- [FreeForCharity/FFC-Cloudflare-Automation#997](http…",
+      "truncated": true,
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5154531426"
+    },
+    {
+      "author": "github-actions[bot]",
+      "created_at": "2026-08-02T01:56:15Z",
+      "body": "### 745 Agentic OS board audit — 3 finding(s)\n\nBoard: FreeForCharity project #9 (Agentic OS) · `expected=68` `board=246` · repos swept: 77\n\nBoth denominators are printed deliberately: run 62 reported \"0 missing\" off an expected set that was one item short, and a short denominator was the only thing a reader could have found suspicious (#966).\n\n#### Missing from the board: 1\n\n_open `agentic-os` items with no card — add them to org project #9_\n\n- [FreeForCharity/FFC-Cloudflare-Automation#997](http…",
+      "truncated": true,
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5154537537"
+    },
+    {
+      "author": "clarkemoyer",
+      "created_at": "2026-08-02T02:29:48Z",
+      "body": "## Run 71 — END (2026-08-02T02:3xZ) · core 4991 / graphql 3377\n\n**6 PRs merged (5 hub + ffcadmin #782), 4 issues filed, 1 groomed, 0 gates approved, board 249 items 0/0/0 exit 0 by the audit script itself. I merged a workflow, then filed against it, then a worker found the defect I had missed in it.**\n\n### Gates — 0 auto-approved, 2 held (18th consecutive run)\n\nRe-derived from workflow source, not inherited:\n\n| Gate | Waiting job | Why held |\n| --- | --- | --- |\n| **111** `30206375399` | `apply`…",
+      "truncated": true,
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5154684733"
+    },
+    {
+      "author": "clarkemoyer",
+      "created_at": "2026-08-02T04:04:37Z",
+      "body": "## Run 72 — START (2026-08-02T0?:0xZ)\n\nConductor online. Workspace verified, all 5 core clones fetched + fast-forwarded to `main`.\nTooling confirmed: `gh` 2.96.0 (clarkemoyer), `az` 2.81.0, CLI for M365 11.9.0, gcloud 552.0.0.\n\nRun number taken from this thread's newest START (71) + 1, per the standing rule — `state/CONDUCTOR.md`\nhas drifted again (its newest entry is run 70), which is the third drift and will be addressed in this\nrun's notes rather than carried.\n\nCarrying run 71's open threads:…",
+      "truncated": true,
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5155166029"
     }
   ],
   "pending_gates": [

--- a/src/data/agentic-os-status.json
+++ b/src/data/agentic-os-status.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-02T01:20:58Z",
+  "generated_at": "2026-08-02T04:36:58Z",
   "org": "FreeForCharity",
   "repo": "FreeForCharity/FFC-Cloudflare-Automation",
   "repos": [
@@ -10,6 +10,45 @@
     "FreeForCharity/FFC-IN-ffcadmin.org"
   ],
   "backlog_issues": [
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 719,
+      "title": "Agentic OS Conductor Log",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-08-02T04:04:37Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719",
+      "labels": [
+        "agentic-os"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 997,
+      "title": "🚨 Scheduled workflow failing: 745. Repo - Agentic OS Board Audit [GH]",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-08-02T03:16:43Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/997",
+      "labels": [
+        "bug",
+        "agentic-os"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 992,
+      "title": "745 fails on board latency, not just board drift: a PR carded 35 minutes late is not run 62's six-hour gap",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-08-02T02:13:09Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/992",
+      "labels": [
+        "bug",
+        "agentic-os",
+        "agent-ready"
+      ]
+    },
     {
       "repo": "FreeForCharity/FFC-Cloudflare-Automation",
       "number": 993,
@@ -36,32 +75,6 @@
         "enhancement",
         "agentic-os",
         "agent-ready"
-      ]
-    },
-    {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 992,
-      "title": "745 fails on board latency, not just board drift: a PR carded 35 minutes late is not run 62's six-hour gap",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-08-02T01:14:28Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/992",
-      "labels": [
-        "bug",
-        "agentic-os",
-        "agent-ready"
-      ]
-    },
-    {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 719,
-      "title": "Agentic OS Conductor Log",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-08-02T01:04:39Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719",
-      "labels": [
-        "agentic-os"
       ]
     },
     {
@@ -764,6 +777,20 @@
   "ready_issues": [
     {
       "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 992,
+      "title": "745 fails on board latency, not just board drift: a PR carded 35 minutes late is not run 62's six-hour gap",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-08-02T02:13:09Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/992",
+      "labels": [
+        "bug",
+        "agentic-os",
+        "agent-ready"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
       "number": 993,
       "title": "Nothing verifies our gated/ungated claims against GitHub: the environment tests compare our docs to our own YAML",
       "state": "open",
@@ -786,20 +813,6 @@
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/835",
       "labels": [
         "enhancement",
-        "agentic-os",
-        "agent-ready"
-      ]
-    },
-    {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 992,
-      "title": "745 fails on board latency, not just board drift: a PR carded 35 minutes late is not run 62's six-hour gap",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-08-02T01:14:28Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/992",
-      "labels": [
-        "bug",
         "agentic-os",
         "agent-ready"
       ]
@@ -948,19 +961,35 @@
   "in_flight_prs": [
     {
       "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 994,
-      "title": "docs: two run-71 lessons — a self-consistent test, and a definition of clean that is never true",
+      "number": 1002,
+      "title": "fix: a failed git command must not read as \"nothing staged\" in the secret scanner",
       "state": "open",
       "draft": true,
       "assignee": null,
-      "updated_at": "2026-08-02T01:20:36Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/994",
+      "updated_at": "2026-08-02T04:36:24Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/1002",
+      "labels": [
+        "security",
+        "agentic-os"
+      ],
+      "linked_agentic_issues": [
+        996,
+        722
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 1001,
+      "title": "fix: a failing git command must not look like a clean secret scan",
+      "state": "open",
+      "draft": true,
+      "assignee": null,
+      "updated_at": "2026-08-02T04:35:57Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/1001",
       "labels": [],
       "linked_agentic_issues": [
-        834,
-        993,
-        835,
-        992
+        996,
+        945
       ]
     },
     {
@@ -1142,36 +1171,8 @@
     }
   ],
   "in_flight_prs_rule": "Open pull requests that are agent work on this backlog, across every repository listed in `repos` — the same org-wide scope as the backlog above, and as the pickup query in AGENTS.md. A PR is listed when it carries the agentic-os label, or when its body references an agentic-os issue in its OWN repository (e.g. 'Closes #123' / 'Refs #123'); a bare #123 is repo-local, so the same number in two repos is two different issues. Referenced-issue labels are what decide it — nothing labels the pull requests themselves. `open_prs_total` is the unfiltered open-PR count over exactly these same repositories.",
-  "open_prs_total": 71,
+  "open_prs_total": 72,
   "conductor_log": [
-    {
-      "author": "clarkemoyer",
-      "created_at": "2026-08-01T13:06:06Z",
-      "body": "## Run 67 — START (2026-08-01T13:0xZ)\n\nLocal Windows host, `gh` as clarkemoyer. Bootstrap clean: 5/5 core clones fetched + pruned, all on `main`, 0 dirty. Hub `9a8dc98`, ffcadmin `2774b72`. Core 4954 / graphql 4942.\n\n**Both of run 66's carry-forwards landed.** #975 merged 10:38:43Z (it was queued at position 1); ffcadmin #775 merged 10:32:19Z. Nothing to re-check there.\n\n**A fourth consecutive Conductor-filed issue came back as a worker PR — and this time in under two hours.** #977 was filed dur…",
-      "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5151549617"
-    },
-    {
-      "author": "github-actions[bot]",
-      "created_at": "2026-08-01T13:43:07Z",
-      "body": "🔓 Claim released — linked PR #839 merged and no other open PR references this issue. Available again (`is:open -label:claimed`).",
-      "truncated": false,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5151681385"
-    },
-    {
-      "author": "clarkemoyer",
-      "created_at": "2026-08-01T13:46:51Z",
-      "body": "## Run 67 — END (2026-08-01T13:5xZ) · core 4868 / graphql 4168\n\n**5 PRs merged, 1 opened, 0 issues filed, 0 gates approved, board 229 items 0/0/0 twice by script. The carried conflict set is gone.**\n\n### Gates — 0 auto-approved, 2 held (15th consecutive run)\n\nRe-derived from workflow source, not inherited:\n\n| Gate | Waiting job | Why held |\n| --- | --- | --- |\n| **111** `30206375399` | `apply`, behind `if: inputs.dry_run == false` — dispatched live | `cloudflare-prod-write`; `cloudflare-tokens-f…",
-      "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5151694220"
-    },
-    {
-      "author": "clarkemoyer",
-      "created_at": "2026-08-01T16:06:25Z",
-      "body": "## Run 68 — START (2026-08-01T16:0xZ)\n\nLocal Windows host, `gh` as clarkemoyer. Bootstrap clean: 5/5 core clones fetched + pruned, all on `main`, 0 dirty. Hub `ab4262b`, ffcadmin `1d12e76`. Core 4967 / graphql 4978. `az` 2.81.0, `m365` 11.9.0, `gcloud` 552.0.0 all present.\n\n**Run 67 ended 13:5xZ and both of its carry-forwards are live on the board.** Its lesson — write `state/` before the END comment — was honoured: `lessons-inbox.md` carries run 67's captures, and this run reads them at step 7 …",
-      "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5152230086"
-    },
     {
       "author": "clarkemoyer",
       "created_at": "2026-08-01T17:09:41Z",
@@ -1213,6 +1214,34 @@
       "body": "## Run 71 — START (2026-08-02T01:0xZ)\n\nLocal Windows host, `gh` as clarkemoyer. Bootstrap clean: 5/5 core clones fetched + pruned, all on `main`, 0 dirty. Hub `f0748ad`, ffcadmin `db19104`, freeforcharity `fa3f600`, SPT `b4e6d32`, FOT `c310e85`. Core 4936 / graphql 4134. `az` 2.81.0, `m365` 11.9.0, `gcloud` 552.0.0, `gh` 2.96.0 all present.\n\n**Run number from this issue's tail** (run 70 END at 22:39:40Z), not from `state/CONDUCTOR.md` — which is stale at run 69 for the same reason it was stale a…",
       "truncated": true,
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5154329897"
+    },
+    {
+      "author": "github-actions[bot]",
+      "created_at": "2026-08-02T01:54:47Z",
+      "body": "### 745 Agentic OS board audit — 3 finding(s)\n\nBoard: FreeForCharity project #9 (Agentic OS) · `expected=68` `board=246` · repos swept: 77\n\nBoth denominators are printed deliberately: run 62 reported \"0 missing\" off an expected set that was one item short, and a short denominator was the only thing a reader could have found suspicious (#966).\n\n#### Missing from the board: 1\n\n_open `agentic-os` items with no card — add them to org project #9_\n\n- [FreeForCharity/FFC-Cloudflare-Automation#997](http…",
+      "truncated": true,
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5154531426"
+    },
+    {
+      "author": "github-actions[bot]",
+      "created_at": "2026-08-02T01:56:15Z",
+      "body": "### 745 Agentic OS board audit — 3 finding(s)\n\nBoard: FreeForCharity project #9 (Agentic OS) · `expected=68` `board=246` · repos swept: 77\n\nBoth denominators are printed deliberately: run 62 reported \"0 missing\" off an expected set that was one item short, and a short denominator was the only thing a reader could have found suspicious (#966).\n\n#### Missing from the board: 1\n\n_open `agentic-os` items with no card — add them to org project #9_\n\n- [FreeForCharity/FFC-Cloudflare-Automation#997](http…",
+      "truncated": true,
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5154537537"
+    },
+    {
+      "author": "clarkemoyer",
+      "created_at": "2026-08-02T02:29:48Z",
+      "body": "## Run 71 — END (2026-08-02T02:3xZ) · core 4991 / graphql 3377\n\n**6 PRs merged (5 hub + ffcadmin #782), 4 issues filed, 1 groomed, 0 gates approved, board 249 items 0/0/0 exit 0 by the audit script itself. I merged a workflow, then filed against it, then a worker found the defect I had missed in it.**\n\n### Gates — 0 auto-approved, 2 held (18th consecutive run)\n\nRe-derived from workflow source, not inherited:\n\n| Gate | Waiting job | Why held |\n| --- | --- | --- |\n| **111** `30206375399` | `apply`…",
+      "truncated": true,
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5154684733"
+    },
+    {
+      "author": "clarkemoyer",
+      "created_at": "2026-08-02T04:04:37Z",
+      "body": "## Run 72 — START (2026-08-02T0?:0xZ)\n\nConductor online. Workspace verified, all 5 core clones fetched + fast-forwarded to `main`.\nTooling confirmed: `gh` 2.96.0 (clarkemoyer), `az` 2.81.0, CLI for M365 11.9.0, gcloud 552.0.0.\n\nRun number taken from this thread's newest START (71) + 1, per the standing rule — `state/CONDUCTOR.md`\nhas drifted again (its newest entry is run 70), which is the third drift and will be addressed in this\nrun's notes rather than carried.\n\nCarrying run 71's open threads:…",
+      "truncated": true,
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5155166029"
     }
   ],
   "pending_gates": [


### PR DESCRIPTION
Routine feed refresh for the public /agentic-os page.

- `generated_at` **01:20:58Z → 04:36:58Z**
- 58 `agentic-os` issues · **14 in flight of 72 open PRs** across 5 repos · 10 log entries · **2 pending gates** (111, 703 — both still correctly held)

Hand-delivered for the 23rd time: 502's `deliver` job still 401s on the revoked `read-all-cbm-github-pat` (#848, day 6). Generated **after** this run's merge of #1000 so the feed reflects it.

Verified as committed, not as generated: both copies byte-identical (`e2a57ae9`), **0 CR bytes in the staged blobs** (the generator writes CRLF on Windows — and a Python text-mode read reports 0 either way, which is how that check can lie), `prettier@3.8.1 --check` clean.