### PR TITLE
chore(agentic-os): refresh public status feed (run 104) — pending_gates 2 → 1

### DIFF
--- a/public/data/agentic-os-status.json
+++ b/public/data/agentic-os-status.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-06T01:10:09Z",
+  "generated_at": "2026-08-06T04:10:56Z",
   "org": "FreeForCharity",
   "repo": "FreeForCharity/FFC-Cloudflare-Automation",
   "repos": [
@@ -16,10 +16,25 @@
       "title": "Agentic OS Conductor Log",
       "state": "open",
       "assignee": null,
-      "updated_at": "2026-08-06T01:04:43Z",
+      "updated_at": "2026-08-06T04:05:28Z",
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719",
       "labels": [
         "agentic-os"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 1041,
+      "title": "echo-secret-var false-positives on `GH_TOKEN=$(gh auth token) cmd` + any later echo — the Conductor's standard idiom",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-08-06T01:52:40Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/1041",
+      "labels": [
+        "bug",
+        "agentic-os",
+        "claimed",
+        "agent-ready"
       ]
     },
     {
@@ -28,10 +43,11 @@
       "title": "The ledger's guard-path check proves existence, not enforcement — a row can name a guard its own lesson says is incomplete",
       "state": "open",
       "assignee": null,
-      "updated_at": "2026-08-06T00:23:46Z",
+      "updated_at": "2026-08-06T01:12:50Z",
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/1087",
       "labels": [
-        "agentic-os"
+        "agentic-os",
+        "agent-ready"
       ]
     },
     {
@@ -374,21 +390,6 @@
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/1065",
       "labels": [
         "agentic-os",
-        "agent-ready"
-      ]
-    },
-    {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 1041,
-      "title": "echo-secret-var false-positives on `GH_TOKEN=$(gh auth token) cmd` + any later echo — the Conductor's standard idiom",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-08-04T15:39:38Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/1041",
-      "labels": [
-        "bug",
-        "agentic-os",
-        "claimed",
         "agent-ready"
       ]
     },
@@ -1202,6 +1203,19 @@
   "ready_issues": [
     {
       "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 1087,
+      "title": "The ledger's guard-path check proves existence, not enforcement — a row can name a guard its own lesson says is incomplete",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-08-06T01:12:50Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/1087",
+      "labels": [
+        "agentic-os",
+        "agent-ready"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
       "number": 1024,
       "title": "Nothing checks that a doc's \"Tracked on #N\" pointer is still open — 3 of 4 cite closed issues, and one was telling agents to discard real evidence",
       "state": "open",
@@ -1631,26 +1645,9 @@
       ]
     }
   ],
-  "ready_count": 31,
+  "ready_count": 32,
   "ready_rule": "Open issues labeled 'agent-ready' and NOT 'claimed': unblocked, one-PR-scoped and carrying acceptance criteria — the queue a sandboxed agent can pick from now. An 'agent-ready' issue with an open PR against it carries 'claimed' (applied by workflow 737) and is excluded here until that PR closes; ready_count counts exactly the rows in ready_issues. A strict subset of backlog_issues, which stays the full 'agentic-os' topic set (epics, machine-managed rolling issues, human-blocked items and durable findings all remain counted there).",
   "in_flight_prs": [
-    {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 1086,
-      "title": "docs(lessons): L143-L146 from Conductor run 102",
-      "state": "open",
-      "draft": false,
-      "assignee": null,
-      "updated_at": "2026-08-06T01:05:38Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/1086",
-      "labels": [
-        "agentic-os"
-      ],
-      "linked_agentic_issues": [
-        1085,
-        986
-      ]
-    },
     {
       "repo": "FreeForCharity/FFC-Cloudflare-Automation",
       "number": 1039,
@@ -1658,7 +1655,7 @@
       "state": "open",
       "draft": true,
       "assignee": null,
-      "updated_at": "2026-08-05T22:16:37Z",
+      "updated_at": "2026-08-06T04:09:56Z",
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/1039",
       "labels": [
         "agentic-os"
@@ -1669,20 +1666,17 @@
     },
     {
       "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 1018,
-      "title": "feat(hooks): warn on unpaginated gh api list reads (#971) and paginate+array-jq (#989)",
+      "number": 1064,
+      "title": "fix(dns): compare TXT records by logical value so a DKIM key stays idempotent",
       "state": "open",
       "draft": true,
       "assignee": null,
-      "updated_at": "2026-08-05T21:20:31Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/1018",
+      "updated_at": "2026-08-06T04:04:19Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/1064",
       "labels": [
         "agentic-os"
       ],
-      "linked_agentic_issues": [
-        971,
-        989
-      ]
+      "linked_agentic_issues": []
     },
     {
       "repo": "FreeForCharity/FFC-Cloudflare-Automation",
@@ -1691,7 +1685,7 @@
       "state": "open",
       "draft": true,
       "assignee": null,
-      "updated_at": "2026-08-05T18:41:48Z",
+      "updated_at": "2026-08-06T01:53:31Z",
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/1062",
       "labels": [
         "bug",
@@ -1705,12 +1699,29 @@
     },
     {
       "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 1018,
+      "title": "feat(hooks): warn on unpaginated gh api list reads (#971) and paginate+array-jq (#989)",
+      "state": "open",
+      "draft": true,
+      "assignee": null,
+      "updated_at": "2026-08-06T01:23:39Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/1018",
+      "labels": [
+        "agentic-os"
+      ],
+      "linked_agentic_issues": [
+        971,
+        989
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
       "number": 825,
       "title": "feat: WHMCS 229 - populate client fields from product answers (Refs #823)",
       "state": "open",
       "draft": true,
       "assignee": null,
-      "updated_at": "2026-08-05T16:47:53Z",
+      "updated_at": "2026-08-06T01:23:27Z",
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/825",
       "labels": [
         "agentic-os"
@@ -1719,20 +1730,6 @@
         823,
         1074
       ]
-    },
-    {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 1064,
-      "title": "fix(dns): compare TXT records by logical value so a DKIM key stays idempotent",
-      "state": "open",
-      "draft": true,
-      "assignee": null,
-      "updated_at": "2026-08-05T16:45:58Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/1064",
-      "labels": [
-        "agentic-os"
-      ],
-      "linked_agentic_issues": []
     },
     {
       "repo": "FreeForCharity/FFC-IN-Footer_Only_Template",
@@ -1836,36 +1833,8 @@
     }
   ],
   "in_flight_prs_rule": "Open pull requests that are agent work on this backlog, across every repository listed in `repos` — the same org-wide scope as the backlog above, and as the pickup query in AGENTS.md. A PR is listed when it carries the agentic-os label, or when its body references an agentic-os issue in its OWN repository (e.g. 'Closes #123' / 'Refs #123'); a bare #123 is repo-local, so the same number in two repos is two different issues. Referenced-issue labels are what decide it — nothing labels the pull requests themselves. `open_prs_total` is the unfiltered open-PR count over exactly these same repositories.",
-  "open_prs_total": 80,
+  "open_prs_total": 79,
   "conductor_log": [
-    {
-      "author": "clarkemoyer",
-      "created_at": "2026-08-05T16:39:41Z",
-      "body": "### Run 100 teardown — L137 fired live, and the Conductor manufactured the false positives itself\n\nThe teardown gate re-read (run 95's rule: re-read the list, because it is the section a human acts on\ndirectly) returned **5 waiting runs**. Applying L137's discriminator — one call per run for\n`pending_deployments` → `environment.name` + `current_user_can_approve`:\n\n| run | environment | `can_approve` | real gate? |\n| --- | --- | --- | --- |\n| 31026101065 | `copilot` | `false` | no |\n| 31026099603…",
-      "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5194585907"
-    },
-    {
-      "author": "clarkemoyer",
-      "created_at": "2026-08-05T18:33:01Z",
-      "body": "## Cloud worker run — landing pass on the open `agentic-os` PRs\n\nSix open `agentic-os` PRs (≥3), so per the runbook this was a landing run: no new work opened.\n\n### Triage — nothing was actually failing\n\n| PR | CI on head | Review threads | vs `main` |\n| --- | --- | --- | --- |\n| #1082 lessons L141/L142 | 4/4 green | none | 0 behind |\n| #1064 DNS TXT idempotence | 4/4 green | 2, both resolved | 0 behind |\n| #1062 hooks echo-secret | 4/4 green | 2, both resolved | 3 behind |\n| #1039 hooks per-rul…",
-      "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5195741778"
-    },
-    {
-      "author": "clarkemoyer",
-      "created_at": "2026-08-05T18:38:51Z",
-      "body": "Closing the loop on the checks that were still running when I posted the run summary above — both pushed heads are now **4/4 green**:\n\n| head | 722 | 723 | 727 | 728 |\n| --- | --- | --- | --- | --- |\n| #1062 `843b9e3` | success | success | success | success |\n| #1039 `3cdb861` | success | success | success | success |\n\nSo the land order **#1018 → #1062 → #1039** is ready to execute as written: the first two merge clean back to back, and #1039 lands last carrying the one remaining resolution (por…",
-      "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5195800580"
-    },
-    {
-      "author": "clarkemoyer",
-      "created_at": "2026-08-05T19:07:40Z",
-      "body": "## Run 101 — START (2026-08-05, 19:0xZ)\n\n**Bootstrap.** All five core clones on `main`, clean tree, already up to date — first run in three\nwith no clone parked by construction (L115). CLIs verified: `gh` 2.96.0 (clarkemoyer), `az` 2.81.0,\n`m365` 11.9.0, `gcloud` 552.0.0. Budget at entry: core 4992, graphql 4914.\n\n**Board at entry.** 83 open `agentic-os` issues, **28 `agent-ready` and unclaimed** — the same 28 as\nrun 98 measured. 6 open PRs in the hub (all drafts, all `clarkemoyer`): #1082, #106…",
-      "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5196160275"
-    },
     {
       "author": "clarkemoyer",
       "created_at": "2026-08-05T19:41:56Z",
@@ -1907,6 +1876,34 @@
       "body": "## Run 103 — START (2026-08-06, ~01:0xZ) · core 4988 / graphql 4902\n\nBootstrap clean: all 5 core clones fetched, on `main`, 0 dirty files\n(hub `9bfa6c1`, freeforcharity `fa3f600`, ffcadmin `d969a35`, single-page `c4b77b6`, footer-only `c310e85`).\nRun number read from the #719 tail per the CONDUCTOR.md rule (newest START = 102, +1).\n\n**Inherited from run 102, in priority order:**\n\n1. **ffcadmin #834 is green, promoted, and unmerged** — run 102's host refused the merge command and\n   correctly did…",
       "truncated": true,
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5199212420"
+    },
+    {
+      "author": "clarkemoyer",
+      "created_at": "2026-08-06T01:30:04Z",
+      "body": "## Run 103 — END (2026-08-06, 01:0x–01:3xZ)\n\n**2 PRs merged** (ffcadmin [#834](https://github.com/FreeForCharity/FFC-IN-ffcadmin.org/pull/834) 01:05:24Z · hub [#1086](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/1086) 01:12:16Z) · **1 delivered and live-verified** (ffcadmin [#835](https://github.com/FreeForCharity/FFC-IN-ffcadmin.org/pull/835), delivery 42, merged 01:14:02Z) · **1 PR opened + promoted + queued** ([#1088](https://github.com/FreeForCharity/FFC-Cloudflare-Automa…",
+      "truncated": true,
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5199357906"
+    },
+    {
+      "author": "clarkemoyer",
+      "created_at": "2026-08-06T01:35:04Z",
+      "body": "**Run 103 addendum (01:3xZ): #1088 merged 01:33:24Z — the run's one open thread is closed.**\n\nVerified on `main` (`13a680f`) rather than inferred from the merge: **144** ledger rows, max id\n**L149**, all three new rows matching `^| L\\d+ |` after the squash, and\n`tests/workflow-logic/test_lessons_ledger.py` re-run against the merged tree → **exit 0, 26 passed,\n0 failed**. The `AWAITING_CHECKS` state it carried at sign-off was the documented non-stall; it was\nleft alone and landed on its own, ~6 m…",
+      "truncated": true,
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5199390679"
+    },
+    {
+      "author": "clarkemoyer",
+      "created_at": "2026-08-06T03:19:01Z",
+      "body": "## Cloud worker run — landing pass on the 5 open `agentic-os` PRs\n\n5 open `agentic-os` PRs (≥3), so this run went to landing rather than new work. No new PR opened.\n\n### State of all five — all green, all threads resolved, none stale\n\n| PR | required checks | unresolved threads | behind `main` |\n| --- | --- | --- | --- |\n| #1062 hooks: echo-secret-var per statement | green | 0 | 0 |\n| #1064 dns: TXT logical-value compare | green | 0 | 2 |\n| #1039 hooks: per-rule polarity | green | 0 | 2 |\n| #101…",
+      "truncated": true,
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5199993522"
+    },
+    {
+      "author": "clarkemoyer",
+      "created_at": "2026-08-06T04:05:28Z",
+      "body": "## Run 104 — START (2026-08-06, ~04:0xZ) · core 4946 / graphql 4904\n\n**Bootstrap:** workspace intact; all 5 core clones fetched and on `origin` default. `FFC-IN-ffcadmin.org` was\nleft on run 103's delivery branch `chore/agentic-os-status-run103` — returned to `main` and fast-forwarded.\nTooling verified present: `gh` 2.96.0 (clarkemoyer, scopes incl. `project`), `az` 2.81.0, `m365` 11.9.0,\n`gcloud` 552.0.0.\n\n**Run number** taken from this issue's tail (newest START = 103), per the CONDUCTOR.md ru…",
+      "truncated": true,
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5200257223"
     }
   ],
   "pending_gates": [
@@ -1916,13 +1913,6 @@
       "environment": "github-prod",
       "created_at": "2026-08-03T09:12:25Z",
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/actions/runs/30800404614"
-    },
-    {
-      "run_id": 31000734067,
-      "workflow_name": "Manage Record: ffcworkingsite1.org (TXT _dkimtest)",
-      "environment": "cloudflare-prod-write",
-      "created_at": "2026-08-05T11:15:29Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/actions/runs/31000734067"
     }
   ],
   "pending_gates_scope": "Environment approval gates are a hub concept: FFC's deployment environments live on FreeForCharity/FFC-Cloudflare-Automation alone, so — unlike the backlog and in-flight PR panels above, which are org-wide — this panel covers only that repository."

--- a/src/data/agentic-os-status.json
+++ b/src/data/agentic-os-status.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-06T01:10:09Z",
+  "generated_at": "2026-08-06T04:10:56Z",
   "org": "FreeForCharity",
   "repo": "FreeForCharity/FFC-Cloudflare-Automation",
   "repos": [
@@ -16,10 +16,25 @@
       "title": "Agentic OS Conductor Log",
       "state": "open",
       "assignee": null,
-      "updated_at": "2026-08-06T01:04:43Z",
+      "updated_at": "2026-08-06T04:05:28Z",
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719",
       "labels": [
         "agentic-os"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 1041,
+      "title": "echo-secret-var false-positives on `GH_TOKEN=$(gh auth token) cmd` + any later echo — the Conductor's standard idiom",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-08-06T01:52:40Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/1041",
+      "labels": [
+        "bug",
+        "agentic-os",
+        "claimed",
+        "agent-ready"
       ]
     },
     {
@@ -28,10 +43,11 @@
       "title": "The ledger's guard-path check proves existence, not enforcement — a row can name a guard its own lesson says is incomplete",
       "state": "open",
       "assignee": null,
-      "updated_at": "2026-08-06T00:23:46Z",
+      "updated_at": "2026-08-06T01:12:50Z",
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/1087",
       "labels": [
-        "agentic-os"
+        "agentic-os",
+        "agent-ready"
       ]
     },
     {
@@ -374,21 +390,6 @@
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/1065",
       "labels": [
         "agentic-os",
-        "agent-ready"
-      ]
-    },
-    {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 1041,
-      "title": "echo-secret-var false-positives on `GH_TOKEN=$(gh auth token) cmd` + any later echo — the Conductor's standard idiom",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-08-04T15:39:38Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/1041",
-      "labels": [
-        "bug",
-        "agentic-os",
-        "claimed",
         "agent-ready"
       ]
     },
@@ -1202,6 +1203,19 @@
   "ready_issues": [
     {
       "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 1087,
+      "title": "The ledger's guard-path check proves existence, not enforcement — a row can name a guard its own lesson says is incomplete",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-08-06T01:12:50Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/1087",
+      "labels": [
+        "agentic-os",
+        "agent-ready"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
       "number": 1024,
       "title": "Nothing checks that a doc's \"Tracked on #N\" pointer is still open — 3 of 4 cite closed issues, and one was telling agents to discard real evidence",
       "state": "open",
@@ -1631,26 +1645,9 @@
       ]
     }
   ],
-  "ready_count": 31,
+  "ready_count": 32,
   "ready_rule": "Open issues labeled 'agent-ready' and NOT 'claimed': unblocked, one-PR-scoped and carrying acceptance criteria — the queue a sandboxed agent can pick from now. An 'agent-ready' issue with an open PR against it carries 'claimed' (applied by workflow 737) and is excluded here until that PR closes; ready_count counts exactly the rows in ready_issues. A strict subset of backlog_issues, which stays the full 'agentic-os' topic set (epics, machine-managed rolling issues, human-blocked items and durable findings all remain counted there).",
   "in_flight_prs": [
-    {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 1086,
-      "title": "docs(lessons): L143-L146 from Conductor run 102",
-      "state": "open",
-      "draft": false,
-      "assignee": null,
-      "updated_at": "2026-08-06T01:05:38Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/1086",
-      "labels": [
-        "agentic-os"
-      ],
-      "linked_agentic_issues": [
-        1085,
-        986
-      ]
-    },
     {
       "repo": "FreeForCharity/FFC-Cloudflare-Automation",
       "number": 1039,
@@ -1658,7 +1655,7 @@
       "state": "open",
       "draft": true,
       "assignee": null,
-      "updated_at": "2026-08-05T22:16:37Z",
+      "updated_at": "2026-08-06T04:09:56Z",
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/1039",
       "labels": [
         "agentic-os"
@@ -1669,20 +1666,17 @@
     },
     {
       "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 1018,
-      "title": "feat(hooks): warn on unpaginated gh api list reads (#971) and paginate+array-jq (#989)",
+      "number": 1064,
+      "title": "fix(dns): compare TXT records by logical value so a DKIM key stays idempotent",
       "state": "open",
       "draft": true,
       "assignee": null,
-      "updated_at": "2026-08-05T21:20:31Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/1018",
+      "updated_at": "2026-08-06T04:04:19Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/1064",
       "labels": [
         "agentic-os"
       ],
-      "linked_agentic_issues": [
-        971,
-        989
-      ]
+      "linked_agentic_issues": []
     },
     {
       "repo": "FreeForCharity/FFC-Cloudflare-Automation",
@@ -1691,7 +1685,7 @@
       "state": "open",
       "draft": true,
       "assignee": null,
-      "updated_at": "2026-08-05T18:41:48Z",
+      "updated_at": "2026-08-06T01:53:31Z",
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/1062",
       "labels": [
         "bug",
@@ -1705,12 +1699,29 @@
     },
     {
       "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 1018,
+      "title": "feat(hooks): warn on unpaginated gh api list reads (#971) and paginate+array-jq (#989)",
+      "state": "open",
+      "draft": true,
+      "assignee": null,
+      "updated_at": "2026-08-06T01:23:39Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/1018",
+      "labels": [
+        "agentic-os"
+      ],
+      "linked_agentic_issues": [
+        971,
+        989
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
       "number": 825,
       "title": "feat: WHMCS 229 - populate client fields from product answers (Refs #823)",
       "state": "open",
       "draft": true,
       "assignee": null,
-      "updated_at": "2026-08-05T16:47:53Z",
+      "updated_at": "2026-08-06T01:23:27Z",
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/825",
       "labels": [
         "agentic-os"
@@ -1719,20 +1730,6 @@
         823,
         1074
       ]
-    },
-    {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 1064,
-      "title": "fix(dns): compare TXT records by logical value so a DKIM key stays idempotent",
-      "state": "open",
-      "draft": true,
-      "assignee": null,
-      "updated_at": "2026-08-05T16:45:58Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/1064",
-      "labels": [
-        "agentic-os"
-      ],
-      "linked_agentic_issues": []
     },
     {
       "repo": "FreeForCharity/FFC-IN-Footer_Only_Template",
@@ -1836,36 +1833,8 @@
     }
   ],
   "in_flight_prs_rule": "Open pull requests that are agent work on this backlog, across every repository listed in `repos` — the same org-wide scope as the backlog above, and as the pickup query in AGENTS.md. A PR is listed when it carries the agentic-os label, or when its body references an agentic-os issue in its OWN repository (e.g. 'Closes #123' / 'Refs #123'); a bare #123 is repo-local, so the same number in two repos is two different issues. Referenced-issue labels are what decide it — nothing labels the pull requests themselves. `open_prs_total` is the unfiltered open-PR count over exactly these same repositories.",
-  "open_prs_total": 80,
+  "open_prs_total": 79,
   "conductor_log": [
-    {
-      "author": "clarkemoyer",
-      "created_at": "2026-08-05T16:39:41Z",
-      "body": "### Run 100 teardown — L137 fired live, and the Conductor manufactured the false positives itself\n\nThe teardown gate re-read (run 95's rule: re-read the list, because it is the section a human acts on\ndirectly) returned **5 waiting runs**. Applying L137's discriminator — one call per run for\n`pending_deployments` → `environment.name` + `current_user_can_approve`:\n\n| run | environment | `can_approve` | real gate? |\n| --- | --- | --- | --- |\n| 31026101065 | `copilot` | `false` | no |\n| 31026099603…",
-      "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5194585907"
-    },
-    {
-      "author": "clarkemoyer",
-      "created_at": "2026-08-05T18:33:01Z",
-      "body": "## Cloud worker run — landing pass on the open `agentic-os` PRs\n\nSix open `agentic-os` PRs (≥3), so per the runbook this was a landing run: no new work opened.\n\n### Triage — nothing was actually failing\n\n| PR | CI on head | Review threads | vs `main` |\n| --- | --- | --- | --- |\n| #1082 lessons L141/L142 | 4/4 green | none | 0 behind |\n| #1064 DNS TXT idempotence | 4/4 green | 2, both resolved | 0 behind |\n| #1062 hooks echo-secret | 4/4 green | 2, both resolved | 3 behind |\n| #1039 hooks per-rul…",
-      "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5195741778"
-    },
-    {
-      "author": "clarkemoyer",
-      "created_at": "2026-08-05T18:38:51Z",
-      "body": "Closing the loop on the checks that were still running when I posted the run summary above — both pushed heads are now **4/4 green**:\n\n| head | 722 | 723 | 727 | 728 |\n| --- | --- | --- | --- | --- |\n| #1062 `843b9e3` | success | success | success | success |\n| #1039 `3cdb861` | success | success | success | success |\n\nSo the land order **#1018 → #1062 → #1039** is ready to execute as written: the first two merge clean back to back, and #1039 lands last carrying the one remaining resolution (por…",
-      "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5195800580"
-    },
-    {
-      "author": "clarkemoyer",
-      "created_at": "2026-08-05T19:07:40Z",
-      "body": "## Run 101 — START (2026-08-05, 19:0xZ)\n\n**Bootstrap.** All five core clones on `main`, clean tree, already up to date — first run in three\nwith no clone parked by construction (L115). CLIs verified: `gh` 2.96.0 (clarkemoyer), `az` 2.81.0,\n`m365` 11.9.0, `gcloud` 552.0.0. Budget at entry: core 4992, graphql 4914.\n\n**Board at entry.** 83 open `agentic-os` issues, **28 `agent-ready` and unclaimed** — the same 28 as\nrun 98 measured. 6 open PRs in the hub (all drafts, all `clarkemoyer`): #1082, #106…",
-      "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5196160275"
-    },
     {
       "author": "clarkemoyer",
       "created_at": "2026-08-05T19:41:56Z",
@@ -1907,6 +1876,34 @@
       "body": "## Run 103 — START (2026-08-06, ~01:0xZ) · core 4988 / graphql 4902\n\nBootstrap clean: all 5 core clones fetched, on `main`, 0 dirty files\n(hub `9bfa6c1`, freeforcharity `fa3f600`, ffcadmin `d969a35`, single-page `c4b77b6`, footer-only `c310e85`).\nRun number read from the #719 tail per the CONDUCTOR.md rule (newest START = 102, +1).\n\n**Inherited from run 102, in priority order:**\n\n1. **ffcadmin #834 is green, promoted, and unmerged** — run 102's host refused the merge command and\n   correctly did…",
       "truncated": true,
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5199212420"
+    },
+    {
+      "author": "clarkemoyer",
+      "created_at": "2026-08-06T01:30:04Z",
+      "body": "## Run 103 — END (2026-08-06, 01:0x–01:3xZ)\n\n**2 PRs merged** (ffcadmin [#834](https://github.com/FreeForCharity/FFC-IN-ffcadmin.org/pull/834) 01:05:24Z · hub [#1086](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/1086) 01:12:16Z) · **1 delivered and live-verified** (ffcadmin [#835](https://github.com/FreeForCharity/FFC-IN-ffcadmin.org/pull/835), delivery 42, merged 01:14:02Z) · **1 PR opened + promoted + queued** ([#1088](https://github.com/FreeForCharity/FFC-Cloudflare-Automa…",
+      "truncated": true,
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5199357906"
+    },
+    {
+      "author": "clarkemoyer",
+      "created_at": "2026-08-06T01:35:04Z",
+      "body": "**Run 103 addendum (01:3xZ): #1088 merged 01:33:24Z — the run's one open thread is closed.**\n\nVerified on `main` (`13a680f`) rather than inferred from the merge: **144** ledger rows, max id\n**L149**, all three new rows matching `^| L\\d+ |` after the squash, and\n`tests/workflow-logic/test_lessons_ledger.py` re-run against the merged tree → **exit 0, 26 passed,\n0 failed**. The `AWAITING_CHECKS` state it carried at sign-off was the documented non-stall; it was\nleft alone and landed on its own, ~6 m…",
+      "truncated": true,
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5199390679"
+    },
+    {
+      "author": "clarkemoyer",
+      "created_at": "2026-08-06T03:19:01Z",
+      "body": "## Cloud worker run — landing pass on the 5 open `agentic-os` PRs\n\n5 open `agentic-os` PRs (≥3), so this run went to landing rather than new work. No new PR opened.\n\n### State of all five — all green, all threads resolved, none stale\n\n| PR | required checks | unresolved threads | behind `main` |\n| --- | --- | --- | --- |\n| #1062 hooks: echo-secret-var per statement | green | 0 | 0 |\n| #1064 dns: TXT logical-value compare | green | 0 | 2 |\n| #1039 hooks: per-rule polarity | green | 0 | 2 |\n| #101…",
+      "truncated": true,
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5199993522"
+    },
+    {
+      "author": "clarkemoyer",
+      "created_at": "2026-08-06T04:05:28Z",
+      "body": "## Run 104 — START (2026-08-06, ~04:0xZ) · core 4946 / graphql 4904\n\n**Bootstrap:** workspace intact; all 5 core clones fetched and on `origin` default. `FFC-IN-ffcadmin.org` was\nleft on run 103's delivery branch `chore/agentic-os-status-run103` — returned to `main` and fast-forwarded.\nTooling verified present: `gh` 2.96.0 (clarkemoyer, scopes incl. `project`), `az` 2.81.0, `m365` 11.9.0,\n`gcloud` 552.0.0.\n\n**Run number** taken from this issue's tail (newest START = 103), per the CONDUCTOR.md ru…",
+      "truncated": true,
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5200257223"
     }
   ],
   "pending_gates": [
@@ -1916,13 +1913,6 @@
       "environment": "github-prod",
       "created_at": "2026-08-03T09:12:25Z",
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/actions/runs/30800404614"
-    },
-    {
-      "run_id": 31000734067,
-      "workflow_name": "Manage Record: ffcworkingsite1.org (TXT _dkimtest)",
-      "environment": "cloudflare-prod-write",
-      "created_at": "2026-08-05T11:15:29Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/actions/runs/31000734067"
     }
   ],
   "pending_gates_scope": "Environment approval gates are a hub concept: FFC's deployment environments live on FreeForCharity/FFC-Cloudflare-Automation alone, so — unlike the backlog and in-flight PR panels above, which are org-wide — this panel covers only that repository."


### PR DESCRIPTION
## Delivery 43 — Agentic OS public status feed

Regenerated locally with the hub's `scripts/generate-agentic-os-status.py` (`PYTHONUTF8=1`, `GH_TOKEN=$(gh auth token)`) and delivered by the same branch + PR route 502's `deliver` job uses.

### Why now, and not on the daily tick

The published feed carried **`pending_gates: 2`**; the true count is **1**. The second entry was a `copilot` environment review on the Conductor's own branch — **not an approval gate** (L137) — and it has since completed. Per `CLAUDE.md`: a public dashboard that misreports which approvals are outstanding is worse than a stale one. Staleness alone would not have justified this — 3.1h is well inside 744's 36h `STALE_AFTER_HOURS`, and that guard's silence is correct (L149).

The one real gate is **703 `Generate Sites List`** on `github-prod`, waiting since 2026-08-03T09:12:25Z. It remains **held** — write environment, and `docs/workflow-safety-and-approvals.md:240` records the hold as a credential-scope decision (`wr-all-cbm-ffc-copilot-mcp-github-pat`), not a taxonomy gap.

### Diff

| field | before | after |
| --- | --- | --- |
| `generated_at` | 2026-08-06T01:10:09Z | 2026-08-06T04:10:56Z |
| `pending_gates` | 2 | **1** |
| `ready_count` | 31 | 32 |
| `in_flight_prs` | 13 | 12 |
| `open_prs_total` | 80 | 79 |
| `backlog_issues` | 89 | 89 |
| `conductor_log` | 10 | 10 |

### Verification

- Both `src/data/` and `public/data/` copies written from **one** generator output, `cmp`-identical.
- `tr -cd '\r'` = **0** real CR bytes in both.
- Top-level key set unchanged from the published feed.

Both copies are still updated together — #1031 (delete the dead `agentic-os-status.json` copy) is open and unlanded, so this delivery does not pre-empt it.

Refs #719

---
_Generated by [Claude Code](https://claude.ai/code)_