### PR TITLE
feat(data): refresh Agentic OS status feed (Conductor run 105)

### DIFF
--- a/public/data/agentic-os-status.json
+++ b/public/data/agentic-os-status.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-06T04:10:56Z",
+  "generated_at": "2026-08-06T07:12:34Z",
   "org": "FreeForCharity",
   "repo": "FreeForCharity/FFC-Cloudflare-Automation",
   "repos": [
@@ -16,8 +16,20 @@
       "title": "Agentic OS Conductor Log",
       "state": "open",
       "assignee": null,
-      "updated_at": "2026-08-06T04:05:28Z",
+      "updated_at": "2026-08-06T07:05:27Z",
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719",
+      "labels": [
+        "agentic-os"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 1089,
+      "title": "Step 4's backlog band has been unmet for 10 consecutive runs and its only lever is disconnected: the queue is over-full with fresh work, not stale work",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-08-06T04:14:38Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/1089",
       "labels": [
         "agentic-os"
       ]
@@ -1650,12 +1662,29 @@
   "in_flight_prs": [
     {
       "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 825,
+      "title": "feat: WHMCS 229 - populate client fields from product answers (Refs #823)",
+      "state": "open",
+      "draft": true,
+      "assignee": null,
+      "updated_at": "2026-08-06T06:32:28Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/825",
+      "labels": [
+        "agentic-os"
+      ],
+      "linked_agentic_issues": [
+        823,
+        1074
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
       "number": 1039,
       "title": "test(hooks): per-rule polarity + source-derived block-site coverage (#1027)",
       "state": "open",
       "draft": true,
       "assignee": null,
-      "updated_at": "2026-08-06T04:09:56Z",
+      "updated_at": "2026-08-06T06:30:33Z",
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/1039",
       "labels": [
         "agentic-os"
@@ -1671,12 +1700,29 @@
       "state": "open",
       "draft": true,
       "assignee": null,
-      "updated_at": "2026-08-06T04:04:19Z",
+      "updated_at": "2026-08-06T06:30:23Z",
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/1064",
       "labels": [
         "agentic-os"
       ],
       "linked_agentic_issues": []
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 1018,
+      "title": "feat(hooks): warn on unpaginated gh api list reads (#971) and paginate+array-jq (#989)",
+      "state": "open",
+      "draft": true,
+      "assignee": null,
+      "updated_at": "2026-08-06T06:29:57Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/1018",
+      "labels": [
+        "agentic-os"
+      ],
+      "linked_agentic_issues": [
+        971,
+        989
+      ]
     },
     {
       "repo": "FreeForCharity/FFC-Cloudflare-Automation",
@@ -1695,40 +1741,6 @@
         1041,
         964,
         1042
-      ]
-    },
-    {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 1018,
-      "title": "feat(hooks): warn on unpaginated gh api list reads (#971) and paginate+array-jq (#989)",
-      "state": "open",
-      "draft": true,
-      "assignee": null,
-      "updated_at": "2026-08-06T01:23:39Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/1018",
-      "labels": [
-        "agentic-os"
-      ],
-      "linked_agentic_issues": [
-        971,
-        989
-      ]
-    },
-    {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 825,
-      "title": "feat: WHMCS 229 - populate client fields from product answers (Refs #823)",
-      "state": "open",
-      "draft": true,
-      "assignee": null,
-      "updated_at": "2026-08-06T01:23:27Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/825",
-      "labels": [
-        "agentic-os"
-      ],
-      "linked_agentic_issues": [
-        823,
-        1074
       ]
     },
     {
@@ -1837,34 +1849,6 @@
   "conductor_log": [
     {
       "author": "clarkemoyer",
-      "created_at": "2026-08-05T19:41:56Z",
-      "body": "## Run 101 — END (2026-08-05, 19:0x–19:4xZ)\n\n### Gates — both still pending, neither approved\n\nNo response from Clarke this run, so both stay parked. **No response is never approval.**\n\n| run | workflow | env | state at teardown |\n| --- | --- | --- | --- |\n| [31000734067](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/actions/runs/31000734067) | 105 Manage Record — `ffcworkingsite1.org` TXT `_dkimtest`, `DryRun: false` | `cloudflare-prod-write` | `waiting`, recommended **approve** |…",
-      "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5196526644"
-    },
-    {
-      "author": "clarkemoyer",
-      "created_at": "2026-08-05T19:42:34Z",
-      "body": "**Run 101 addendum (19:5xZ):** #1083 merged. Verified on `main` (`b0483c5`) rather than inferred from the merge: the README now says 3.8.1 in both places, and the new guard runs 3/3 PASS against the merged tree — which is the first time it has been exercised while genuinely tracked and unmodified, i.e. the condition its own failure this run was about. Board card set to `Done` by hand; the merge does not move it (#835 still open).\n\nBoth gates remain `waiting` and unapproved.",
-      "truncated": false,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5196534798"
-    },
-    {
-      "author": "clarkemoyer",
-      "created_at": "2026-08-05T21:21:02Z",
-      "body": "## Cloud worker — landing run (2026-08-05)\n\n**Triage: 6 open `agentic-os` PRs ≥ 3, so this was a landing run. No new work PR opened.**\n\nAll six are **CI-green on every check** and have **every review thread resolved**. None is blocked on agent work. Each is draft for a stated reason, and the reasons sort into exactly two buckets — both of which terminate at @clarkemoyer:\n\n| PR | Held by |\n| --- | --- |\n| #1064 | `cloudflare-prod-write` gate — needs one live `105` write to a throwaway name to con…",
-      "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5197489914"
-    },
-    {
-      "author": "clarkemoyer",
-      "created_at": "2026-08-05T22:06:05Z",
-      "body": "## Run 102 — START (2026-08-05, 22:0xZ)\n\n**Bootstrap.** All five core clones on `main`, clean tree, already up to date — second consecutive\nrun with no clone parked by construction (L115). CLIs verified: `gh` 2.96.0 (clarkemoyer), `az`\n2.81.0, `m365` 11.9.0, `gcloud` 552.0.0. Budget at entry: core 4996, graphql 4921.\n\n**Board at entry.** 78 open `agentic-os` issues, **29 `agent-ready` and unclaimed** — up one from\nrun 101's 28, and the one is #1084, filed by the 21:21Z cloud worker. Six open PRs…",
-      "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5197933828"
-    },
-    {
-      "author": "clarkemoyer",
       "created_at": "2026-08-05T22:29:14Z",
       "body": "## Run 102 — END (2026-08-05, 22:0x–22:4xZ)\n\n### Gates — both still pending, neither approved, and neither re-announced\n\n**No response from Clarke this run, so both stay parked. No response is never approval.**\n\n| run | workflow | env | state at teardown |\n| --- | --- | --- | --- |\n| [31000734067](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/actions/runs/31000734067) | 105 Manage Record — `ffcworkingsite1.org` TXT `_dkimtest`, `DryRun: false` | `cloudflare-prod-write` | `waiting`,…",
       "truncated": true,
@@ -1904,6 +1888,34 @@
       "body": "## Run 104 — START (2026-08-06, ~04:0xZ) · core 4946 / graphql 4904\n\n**Bootstrap:** workspace intact; all 5 core clones fetched and on `origin` default. `FFC-IN-ffcadmin.org` was\nleft on run 103's delivery branch `chore/agentic-os-status-run103` — returned to `main` and fast-forwarded.\nTooling verified present: `gh` 2.96.0 (clarkemoyer, scopes incl. `project`), `az` 2.81.0, `m365` 11.9.0,\n`gcloud` 552.0.0.\n\n**Run number** taken from this issue's tail (newest START = 103), per the CONDUCTOR.md ru…",
       "truncated": true,
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5200257223"
+    },
+    {
+      "author": "github-actions[bot]",
+      "created_at": "2026-08-06T04:42:41Z",
+      "body": "🔓 Claim released — linked PR #1090 merged and no other open PR references this issue. Available again (`is:open -label:claimed`).",
+      "truncated": false,
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5200470925"
+    },
+    {
+      "author": "clarkemoyer",
+      "created_at": "2026-08-06T04:47:11Z",
+      "body": "## Run 104 — END (2026-08-06, 04:0x–04:4xZ) · core 4946 → 4998 / graphql 4904 → 3917\n\n**2 PRs merged** · **1 issue filed** · **1 PR reviewed with a correction that changes the fix** · **3 board cards hand-managed** · **0 gates approved** · **0 Clarke contacts**.\n\n### THE HEADLINE: the handoff I inherited was right about the action and falsifiably wrong about the cause\n\nThe 03:19Z cloud-worker pass reported that #1062 and #1039 are mutually unmergeable **because #1062 rewords the `echo-secret-var…",
+      "truncated": true,
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5200496902"
+    },
+    {
+      "author": "clarkemoyer",
+      "created_at": "2026-08-06T06:34:34Z",
+      "body": "## Cloud worker run — landing pass on the open `agentic-os` PR queue\n\n5 open `agentic-os` PRs (≥3), so this run was spent landing rather than starting new work. No new PR opened.\n\n### What I found\n\nAll five were green on every check and had **every review thread resolved** — so nothing was blocked on the usual suspects. The actual blocker was staleness, and it was invisible because the last guard run on each PR had passed.\n\n`727. Phantom Revert Guard` fails when `BEHIND_COUNT > 5`, where `BEHIND…",
+      "truncated": true,
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5201211650"
+    },
+    {
+      "author": "clarkemoyer",
+      "created_at": "2026-08-06T07:05:27Z",
+      "body": "## Run 105 — START (2026-08-06, ~06:5xZ) · core 4981 / graphql 4926\n\nWorkspace bootstrapped: all 5 core clones fetched and hard-reset to `origin/main`\n(hub `d96230a`, ffcadmin `ea72839`, freeforcharity `fa3f600`, single-page `c4b77b6`,\nfooter-only `c310e85`). `AGENTS.md` and `docs/workflow-safety-and-approvals.md` re-read from the\nrefreshed tree.\n\nInherited from run 104 (#719 tail + `state/CONDUCTOR.md`):\n\n- **#1039 must not be rebased naively** — the red it will show reads \"the rule was removed…",
+      "truncated": true,
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5201483914"
     }
   ],
   "pending_gates": [

--- a/src/data/agentic-os-status.json
+++ b/src/data/agentic-os-status.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-06T04:10:56Z",
+  "generated_at": "2026-08-06T07:12:34Z",
   "org": "FreeForCharity",
   "repo": "FreeForCharity/FFC-Cloudflare-Automation",
   "repos": [
@@ -16,8 +16,20 @@
       "title": "Agentic OS Conductor Log",
       "state": "open",
       "assignee": null,
-      "updated_at": "2026-08-06T04:05:28Z",
+      "updated_at": "2026-08-06T07:05:27Z",
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719",
+      "labels": [
+        "agentic-os"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 1089,
+      "title": "Step 4's backlog band has been unmet for 10 consecutive runs and its only lever is disconnected: the queue is over-full with fresh work, not stale work",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-08-06T04:14:38Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/1089",
       "labels": [
         "agentic-os"
       ]
@@ -1650,12 +1662,29 @@
   "in_flight_prs": [
     {
       "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 825,
+      "title": "feat: WHMCS 229 - populate client fields from product answers (Refs #823)",
+      "state": "open",
+      "draft": true,
+      "assignee": null,
+      "updated_at": "2026-08-06T06:32:28Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/825",
+      "labels": [
+        "agentic-os"
+      ],
+      "linked_agentic_issues": [
+        823,
+        1074
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
       "number": 1039,
       "title": "test(hooks): per-rule polarity + source-derived block-site coverage (#1027)",
       "state": "open",
       "draft": true,
       "assignee": null,
-      "updated_at": "2026-08-06T04:09:56Z",
+      "updated_at": "2026-08-06T06:30:33Z",
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/1039",
       "labels": [
         "agentic-os"
@@ -1671,12 +1700,29 @@
       "state": "open",
       "draft": true,
       "assignee": null,
-      "updated_at": "2026-08-06T04:04:19Z",
+      "updated_at": "2026-08-06T06:30:23Z",
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/1064",
       "labels": [
         "agentic-os"
       ],
       "linked_agentic_issues": []
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 1018,
+      "title": "feat(hooks): warn on unpaginated gh api list reads (#971) and paginate+array-jq (#989)",
+      "state": "open",
+      "draft": true,
+      "assignee": null,
+      "updated_at": "2026-08-06T06:29:57Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/1018",
+      "labels": [
+        "agentic-os"
+      ],
+      "linked_agentic_issues": [
+        971,
+        989
+      ]
     },
     {
       "repo": "FreeForCharity/FFC-Cloudflare-Automation",
@@ -1695,40 +1741,6 @@
         1041,
         964,
         1042
-      ]
-    },
-    {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 1018,
-      "title": "feat(hooks): warn on unpaginated gh api list reads (#971) and paginate+array-jq (#989)",
-      "state": "open",
-      "draft": true,
-      "assignee": null,
-      "updated_at": "2026-08-06T01:23:39Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/1018",
-      "labels": [
-        "agentic-os"
-      ],
-      "linked_agentic_issues": [
-        971,
-        989
-      ]
-    },
-    {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 825,
-      "title": "feat: WHMCS 229 - populate client fields from product answers (Refs #823)",
-      "state": "open",
-      "draft": true,
-      "assignee": null,
-      "updated_at": "2026-08-06T01:23:27Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/825",
-      "labels": [
-        "agentic-os"
-      ],
-      "linked_agentic_issues": [
-        823,
-        1074
       ]
     },
     {
@@ -1837,34 +1849,6 @@
   "conductor_log": [
     {
       "author": "clarkemoyer",
-      "created_at": "2026-08-05T19:41:56Z",
-      "body": "## Run 101 — END (2026-08-05, 19:0x–19:4xZ)\n\n### Gates — both still pending, neither approved\n\nNo response from Clarke this run, so both stay parked. **No response is never approval.**\n\n| run | workflow | env | state at teardown |\n| --- | --- | --- | --- |\n| [31000734067](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/actions/runs/31000734067) | 105 Manage Record — `ffcworkingsite1.org` TXT `_dkimtest`, `DryRun: false` | `cloudflare-prod-write` | `waiting`, recommended **approve** |…",
-      "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5196526644"
-    },
-    {
-      "author": "clarkemoyer",
-      "created_at": "2026-08-05T19:42:34Z",
-      "body": "**Run 101 addendum (19:5xZ):** #1083 merged. Verified on `main` (`b0483c5`) rather than inferred from the merge: the README now says 3.8.1 in both places, and the new guard runs 3/3 PASS against the merged tree — which is the first time it has been exercised while genuinely tracked and unmodified, i.e. the condition its own failure this run was about. Board card set to `Done` by hand; the merge does not move it (#835 still open).\n\nBoth gates remain `waiting` and unapproved.",
-      "truncated": false,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5196534798"
-    },
-    {
-      "author": "clarkemoyer",
-      "created_at": "2026-08-05T21:21:02Z",
-      "body": "## Cloud worker — landing run (2026-08-05)\n\n**Triage: 6 open `agentic-os` PRs ≥ 3, so this was a landing run. No new work PR opened.**\n\nAll six are **CI-green on every check** and have **every review thread resolved**. None is blocked on agent work. Each is draft for a stated reason, and the reasons sort into exactly two buckets — both of which terminate at @clarkemoyer:\n\n| PR | Held by |\n| --- | --- |\n| #1064 | `cloudflare-prod-write` gate — needs one live `105` write to a throwaway name to con…",
-      "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5197489914"
-    },
-    {
-      "author": "clarkemoyer",
-      "created_at": "2026-08-05T22:06:05Z",
-      "body": "## Run 102 — START (2026-08-05, 22:0xZ)\n\n**Bootstrap.** All five core clones on `main`, clean tree, already up to date — second consecutive\nrun with no clone parked by construction (L115). CLIs verified: `gh` 2.96.0 (clarkemoyer), `az`\n2.81.0, `m365` 11.9.0, `gcloud` 552.0.0. Budget at entry: core 4996, graphql 4921.\n\n**Board at entry.** 78 open `agentic-os` issues, **29 `agent-ready` and unclaimed** — up one from\nrun 101's 28, and the one is #1084, filed by the 21:21Z cloud worker. Six open PRs…",
-      "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5197933828"
-    },
-    {
-      "author": "clarkemoyer",
       "created_at": "2026-08-05T22:29:14Z",
       "body": "## Run 102 — END (2026-08-05, 22:0x–22:4xZ)\n\n### Gates — both still pending, neither approved, and neither re-announced\n\n**No response from Clarke this run, so both stay parked. No response is never approval.**\n\n| run | workflow | env | state at teardown |\n| --- | --- | --- | --- |\n| [31000734067](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/actions/runs/31000734067) | 105 Manage Record — `ffcworkingsite1.org` TXT `_dkimtest`, `DryRun: false` | `cloudflare-prod-write` | `waiting`,…",
       "truncated": true,
@@ -1904,6 +1888,34 @@
       "body": "## Run 104 — START (2026-08-06, ~04:0xZ) · core 4946 / graphql 4904\n\n**Bootstrap:** workspace intact; all 5 core clones fetched and on `origin` default. `FFC-IN-ffcadmin.org` was\nleft on run 103's delivery branch `chore/agentic-os-status-run103` — returned to `main` and fast-forwarded.\nTooling verified present: `gh` 2.96.0 (clarkemoyer, scopes incl. `project`), `az` 2.81.0, `m365` 11.9.0,\n`gcloud` 552.0.0.\n\n**Run number** taken from this issue's tail (newest START = 103), per the CONDUCTOR.md ru…",
       "truncated": true,
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5200257223"
+    },
+    {
+      "author": "github-actions[bot]",
+      "created_at": "2026-08-06T04:42:41Z",
+      "body": "🔓 Claim released — linked PR #1090 merged and no other open PR references this issue. Available again (`is:open -label:claimed`).",
+      "truncated": false,
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5200470925"
+    },
+    {
+      "author": "clarkemoyer",
+      "created_at": "2026-08-06T04:47:11Z",
+      "body": "## Run 104 — END (2026-08-06, 04:0x–04:4xZ) · core 4946 → 4998 / graphql 4904 → 3917\n\n**2 PRs merged** · **1 issue filed** · **1 PR reviewed with a correction that changes the fix** · **3 board cards hand-managed** · **0 gates approved** · **0 Clarke contacts**.\n\n### THE HEADLINE: the handoff I inherited was right about the action and falsifiably wrong about the cause\n\nThe 03:19Z cloud-worker pass reported that #1062 and #1039 are mutually unmergeable **because #1062 rewords the `echo-secret-var…",
+      "truncated": true,
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5200496902"
+    },
+    {
+      "author": "clarkemoyer",
+      "created_at": "2026-08-06T06:34:34Z",
+      "body": "## Cloud worker run — landing pass on the open `agentic-os` PR queue\n\n5 open `agentic-os` PRs (≥3), so this run was spent landing rather than starting new work. No new PR opened.\n\n### What I found\n\nAll five were green on every check and had **every review thread resolved** — so nothing was blocked on the usual suspects. The actual blocker was staleness, and it was invisible because the last guard run on each PR had passed.\n\n`727. Phantom Revert Guard` fails when `BEHIND_COUNT > 5`, where `BEHIND…",
+      "truncated": true,
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5201211650"
+    },
+    {
+      "author": "clarkemoyer",
+      "created_at": "2026-08-06T07:05:27Z",
+      "body": "## Run 105 — START (2026-08-06, ~06:5xZ) · core 4981 / graphql 4926\n\nWorkspace bootstrapped: all 5 core clones fetched and hard-reset to `origin/main`\n(hub `d96230a`, ffcadmin `ea72839`, freeforcharity `fa3f600`, single-page `c4b77b6`,\nfooter-only `c310e85`). `AGENTS.md` and `docs/workflow-safety-and-approvals.md` re-read from the\nrefreshed tree.\n\nInherited from run 104 (#719 tail + `state/CONDUCTOR.md`):\n\n- **#1039 must not be rebased naively** — the red it will show reads \"the rule was removed…",
+      "truncated": true,
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5201483914"
     }
   ],
   "pending_gates": [


### PR DESCRIPTION
Delivery 44 of the public Agentic OS status feed — the hand-delivery route that stands in for workflow 502's dead `deliver` job (tracked on FreeForCharity/FFC-Cloudflare-Automation#848, now day 21).

Generated locally with `scripts/generate-agentic-os-status.py` per the auth contract in its own docstring, then copied to **both** `src/data/` and `public/data/` from a single generator output.

| field | published (04:10:56Z) | this PR (07:12:34Z) |
| --- | --- | --- |
| `pending_gates` | 1 | 1 — unchanged (run `30800404614`, `github-prod`, waiting since 08-03T09:12:25Z) |
| `ready_count` | 32 | 32 |
| `open_prs_total` | 79 | 79 |
| newest `conductor_log` | 2026-08-06T04:05:28Z | 2026-08-06T07:05:27Z |

This is a **freshness** delivery, not an accuracy fix: the published copy was checked field-by-field first and every count in it was correct. What it was missing was the four log entries since 04:05Z — run 104's END, the claim release, the 06:34Z cloud-worker landing pass, and run 105's START.

Verification: both copies `cmp`-identical, **0** CR bytes in the staged blobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)