### PR TITLE
chore(agentic-os): refresh status feed (delivery 58)

### DIFF
--- a/public/data/agentic-os-status.json
+++ b/public/data/agentic-os-status.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-08T11:02:48Z",
+  "generated_at": "2026-08-08T13:20:11Z",
   "org": "FreeForCharity",
   "repo": "FreeForCharity/FFC-Cloudflare-Automation",
   "repos": [
@@ -9,17 +9,55 @@
   "backlog_issues": [
     {
       "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 1081,
+      "title": "The federated-credential guard is blind to 4 OIDC lanes — and they contain every failing workflow in the repo",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-08-08T13:18:35Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/1081",
+      "labels": [
+        "security",
+        "agentic-os",
+        "agent-ready"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
       "number": 880,
       "title": "Every FFC Pages deploy silently discards next.config.ts (configure-pages writes its own .js)",
       "state": "open",
       "assignee": null,
-      "updated_at": "2026-08-08T10:58:56Z",
+      "updated_at": "2026-08-08T13:17:47Z",
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/880",
       "labels": [
         "bug",
         "agentic-os",
-        "claimed",
-        "priority: high"
+        "priority: high",
+        "agent-ready"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 719,
+      "title": "Agentic OS Conductor Log",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-08-08T13:05:59Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719",
+      "labels": [
+        "agentic-os"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 1119,
+      "title": "test(workflow-logic): 104 of 1170 tests fail on Windows while ubuntu-only CI stays green",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-08-08T11:30:04Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/1119",
+      "labels": [
+        "agentic-os"
       ]
     },
     {
@@ -34,18 +72,6 @@
         "security",
         "agentic-os",
         "priority: high"
-      ]
-    },
-    {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 719,
-      "title": "Agentic OS Conductor Log",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-08-08T10:29:45Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719",
-      "labels": [
-        "agentic-os"
       ]
     },
     {
@@ -457,20 +483,6 @@
       "labels": [
         "agentic-os",
         "priority: high",
-        "agent-ready"
-      ]
-    },
-    {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 1081,
-      "title": "The federated-credential guard is blind to 4 OIDC lanes — and they contain every failing workflow in the repo",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-08-05T16:27:18Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/1081",
-      "labels": [
-        "security",
-        "agentic-os",
         "agent-ready"
       ]
     },
@@ -1292,6 +1304,35 @@
   "ready_issues": [
     {
       "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 1081,
+      "title": "The federated-credential guard is blind to 4 OIDC lanes — and they contain every failing workflow in the repo",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-08-08T13:18:35Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/1081",
+      "labels": [
+        "security",
+        "agentic-os",
+        "agent-ready"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 880,
+      "title": "Every FFC Pages deploy silently discards next.config.ts (configure-pages writes its own .js)",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-08-08T13:17:47Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/880",
+      "labels": [
+        "bug",
+        "agentic-os",
+        "priority: high",
+        "agent-ready"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
       "number": 1111,
       "title": "Board audit cannot see work that merges before it is carded: #1108 merged uncarded and every category reported 0",
       "state": "open",
@@ -1527,20 +1568,6 @@
       "labels": [
         "agentic-os",
         "priority: high",
-        "agent-ready"
-      ]
-    },
-    {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 1081,
-      "title": "The federated-credential guard is blind to 4 OIDC lanes — and they contain every failing workflow in the repo",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-08-05T16:27:18Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/1081",
-      "labels": [
-        "security",
-        "agentic-os",
         "agent-ready"
       ]
     },
@@ -1849,9 +1876,23 @@
       ]
     }
   ],
-  "ready_count": 40,
+  "ready_count": 41,
   "ready_rule": "Open issues labeled 'agent-ready' and NOT 'claimed': unblocked, one-PR-scoped and carrying acceptance criteria — the queue a sandboxed agent can pick from now. An 'agent-ready' issue with an open PR against it carries 'claimed' (applied by workflow 737) and is excluded here until that PR closes; ready_count counts exactly the rows in ready_issues. A strict subset of backlog_issues, which stays the full 'agentic-os' topic set (epics, machine-managed rolling issues, human-blocked items and durable findings all remain counted there).",
   "in_flight_prs": [
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 1117,
+      "title": "feat: add Cloudflare cache purge and cache-rules audit automation",
+      "state": "open",
+      "draft": true,
+      "assignee": null,
+      "updated_at": "2026-08-08T13:15:07Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/1117",
+      "labels": [
+        "agentic-os"
+      ],
+      "linked_agentic_issues": []
+    },
     {
       "repo": "FreeForCharity/FFC-Cloudflare-Automation",
       "number": 1039,
@@ -1870,22 +1911,8 @@
     }
   ],
   "in_flight_prs_rule": "Open pull requests that are agent work on this backlog, across every repository listed in `repos` — the same org-wide scope as the backlog above, and as the pickup query in AGENTS.md. A PR is listed when it carries the agentic-os label, or when its body references an agentic-os issue in its OWN repository (e.g. 'Closes #123' / 'Refs #123'); a bare #123 is repo-local, so the same number in two repos is two different issues. Referenced-issue labels are what decide it — nothing labels the pull requests themselves. `open_prs_total` is the unfiltered open-PR count over exactly these same repositories.",
-  "open_prs_total": 7,
+  "open_prs_total": 8,
   "conductor_log": [
-    {
-      "author": "clarkemoyer",
-      "created_at": "2026-08-08T01:06:39Z",
-      "body": "## Run 119 — START (2026-08-08, ~01:0xZ) · core 4983 / graphql 4967\n\nBootstrap clean: all 5 core clones fetched to `main`, **0 dirty files in any of the five**, hub `main` = `ec5a689` (unchanged since run 118's last merge). AGENTS.md and `docs/workflow-safety-and-approvals.md` re-read from the repo, not from memory. Tooling verified at start: `gh` 2.96.0 (clarkemoyer, scopes `admin:org gist project repo workflow write:packages`), `az` 2.81.0, `m365` v11.9.0, `gcloud` 552.0.0 — nothing to install…",
-      "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5223750742"
-    },
-    {
-      "author": "clarkemoyer",
-      "created_at": "2026-08-08T01:54:00Z",
-      "body": "## Run 119 — END (2026-08-08, 01:0x–01:5xZ) · core 4983 -> 4916 / graphql 4967 -> 4862\n\n**4 PRs merged and verified on their merged trees · 1 issue filed · 2 issues corrected · 0 gates approved (54th hold on 703, 2nd on 106) · delivery 54 live and byte-identical · board 0/0/0/0 exit 0 · 3 lessons**\n\nThree of this run's findings are corrections to things that were already written down and looked\nright: a count in a ledger row that merged four hours ago, a premise in an open issue, and two claims\n…",
-      "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5223941518"
-    },
     {
       "author": "clarkemoyer",
       "created_at": "2026-08-08T04:06:40Z",
@@ -1941,6 +1968,20 @@
       "body": "## Run 122 — START (2026-08-08, ~10:2xZ) · core 4994 / graphql 5000\n\nBootstrap clean. All five core clones fetched and hard-reset to `origin/main`, working trees clean, no leftover worktrees:\n\n| repo | head |\n| --- | --- |\n| FFC-Cloudflare-Automation | `5ade5cc` (#1115, 10:17:02Z) |\n| FFC-IN-ffcadmin.org | `bf60dd3` (#862, delivery 56) |\n| FFC-IN-FFC_Single_Page_Template | `7455a44` (#428, 07:21Z) |\n| FFC-IN-Footer_Only_Template | `fbb0faf` (#123) |\n| FFC-IN-freeforcharity.org | `88593b3` |\n\nToo…",
       "truncated": true,
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5225708710"
+    },
+    {
+      "author": "clarkemoyer",
+      "created_at": "2026-08-08T11:49:34Z",
+      "body": "## Run 122 — END (2026-08-08, 10:2x–12:1xZ) · core 4994 → 4991 / graphql 5000 → 4838\n\n**4 PRs merged and verified on their merged trees · delivery 57 live and byte-identical (34th hand delivery) · 3 ledger rows (L185–L187) · 1 issue filed · 1 incoming PR triaged, labelled and carded · 0 gates approved (57th hold on 703) · board 364 items, 0/0/0/0/0, exit 0 · Clarke pinged once**\n\nThe run cleared the entire satellite queue, and both of its findings are about the Conductor: a probe I used is a con…",
+      "truncated": true,
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5225971268"
+    },
+    {
+      "author": "clarkemoyer",
+      "created_at": "2026-08-08T13:05:59Z",
+      "body": "## Run 123 — START (2026-08-08, ~13:0xZ) · core 4989 / graphql 4972\n\nBootstrap clean. All **5/5 core clones** fetched and fast-forwarded to `main`, **0 dirty files** in any of the five; `core.autocrlf=false` from run 122 held. Hub `main` = `cea0e6e` (#1118, ledger at **L187**).\n\n| clone | head |\n| --- | --- |\n| FFC-Cloudflare-Automation | `cea0e6e` |\n| FFC-IN-freeforcharity.org | `88593b3` |\n| FFC-IN-ffcadmin.org | `043cc3a` |\n| FFC-IN-FFC_Single_Page_Template | `edfd3ff` |\n| FFC-IN-Footer_Only_…",
+      "truncated": true,
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5226231409"
     }
   ],
   "conductor_log_rule": "The last 10 comments on the Conductor log issue #719, ordered OLDEST FIRST — element 0 is the oldest of the 10, and the LAST element is the most recent. Each body is redacted and truncated to 500 characters. Hub-only: there is one log. This is a tail, not the whole thread, so an entry's absence means it fell off the end of the window, not that it was never written; and the newest entry here is at most as recent as `generated_at`, never fresher.",

--- a/src/data/agentic-os-status.json
+++ b/src/data/agentic-os-status.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-08T11:02:48Z",
+  "generated_at": "2026-08-08T13:20:11Z",
   "org": "FreeForCharity",
   "repo": "FreeForCharity/FFC-Cloudflare-Automation",
   "repos": [
@@ -9,17 +9,55 @@
   "backlog_issues": [
     {
       "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 1081,
+      "title": "The federated-credential guard is blind to 4 OIDC lanes — and they contain every failing workflow in the repo",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-08-08T13:18:35Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/1081",
+      "labels": [
+        "security",
+        "agentic-os",
+        "agent-ready"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
       "number": 880,
       "title": "Every FFC Pages deploy silently discards next.config.ts (configure-pages writes its own .js)",
       "state": "open",
       "assignee": null,
-      "updated_at": "2026-08-08T10:58:56Z",
+      "updated_at": "2026-08-08T13:17:47Z",
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/880",
       "labels": [
         "bug",
         "agentic-os",
-        "claimed",
-        "priority: high"
+        "priority: high",
+        "agent-ready"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 719,
+      "title": "Agentic OS Conductor Log",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-08-08T13:05:59Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719",
+      "labels": [
+        "agentic-os"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 1119,
+      "title": "test(workflow-logic): 104 of 1170 tests fail on Windows while ubuntu-only CI stays green",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-08-08T11:30:04Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/1119",
+      "labels": [
+        "agentic-os"
       ]
     },
     {
@@ -34,18 +72,6 @@
         "security",
         "agentic-os",
         "priority: high"
-      ]
-    },
-    {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 719,
-      "title": "Agentic OS Conductor Log",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-08-08T10:29:45Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719",
-      "labels": [
-        "agentic-os"
       ]
     },
     {
@@ -457,20 +483,6 @@
       "labels": [
         "agentic-os",
         "priority: high",
-        "agent-ready"
-      ]
-    },
-    {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 1081,
-      "title": "The federated-credential guard is blind to 4 OIDC lanes — and they contain every failing workflow in the repo",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-08-05T16:27:18Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/1081",
-      "labels": [
-        "security",
-        "agentic-os",
         "agent-ready"
       ]
     },
@@ -1292,6 +1304,35 @@
   "ready_issues": [
     {
       "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 1081,
+      "title": "The federated-credential guard is blind to 4 OIDC lanes — and they contain every failing workflow in the repo",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-08-08T13:18:35Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/1081",
+      "labels": [
+        "security",
+        "agentic-os",
+        "agent-ready"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 880,
+      "title": "Every FFC Pages deploy silently discards next.config.ts (configure-pages writes its own .js)",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-08-08T13:17:47Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/880",
+      "labels": [
+        "bug",
+        "agentic-os",
+        "priority: high",
+        "agent-ready"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
       "number": 1111,
       "title": "Board audit cannot see work that merges before it is carded: #1108 merged uncarded and every category reported 0",
       "state": "open",
@@ -1527,20 +1568,6 @@
       "labels": [
         "agentic-os",
         "priority: high",
-        "agent-ready"
-      ]
-    },
-    {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 1081,
-      "title": "The federated-credential guard is blind to 4 OIDC lanes — and they contain every failing workflow in the repo",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-08-05T16:27:18Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/1081",
-      "labels": [
-        "security",
-        "agentic-os",
         "agent-ready"
       ]
     },
@@ -1849,9 +1876,23 @@
       ]
     }
   ],
-  "ready_count": 40,
+  "ready_count": 41,
   "ready_rule": "Open issues labeled 'agent-ready' and NOT 'claimed': unblocked, one-PR-scoped and carrying acceptance criteria — the queue a sandboxed agent can pick from now. An 'agent-ready' issue with an open PR against it carries 'claimed' (applied by workflow 737) and is excluded here until that PR closes; ready_count counts exactly the rows in ready_issues. A strict subset of backlog_issues, which stays the full 'agentic-os' topic set (epics, machine-managed rolling issues, human-blocked items and durable findings all remain counted there).",
   "in_flight_prs": [
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 1117,
+      "title": "feat: add Cloudflare cache purge and cache-rules audit automation",
+      "state": "open",
+      "draft": true,
+      "assignee": null,
+      "updated_at": "2026-08-08T13:15:07Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/1117",
+      "labels": [
+        "agentic-os"
+      ],
+      "linked_agentic_issues": []
+    },
     {
       "repo": "FreeForCharity/FFC-Cloudflare-Automation",
       "number": 1039,
@@ -1870,22 +1911,8 @@
     }
   ],
   "in_flight_prs_rule": "Open pull requests that are agent work on this backlog, across every repository listed in `repos` — the same org-wide scope as the backlog above, and as the pickup query in AGENTS.md. A PR is listed when it carries the agentic-os label, or when its body references an agentic-os issue in its OWN repository (e.g. 'Closes #123' / 'Refs #123'); a bare #123 is repo-local, so the same number in two repos is two different issues. Referenced-issue labels are what decide it — nothing labels the pull requests themselves. `open_prs_total` is the unfiltered open-PR count over exactly these same repositories.",
-  "open_prs_total": 7,
+  "open_prs_total": 8,
   "conductor_log": [
-    {
-      "author": "clarkemoyer",
-      "created_at": "2026-08-08T01:06:39Z",
-      "body": "## Run 119 — START (2026-08-08, ~01:0xZ) · core 4983 / graphql 4967\n\nBootstrap clean: all 5 core clones fetched to `main`, **0 dirty files in any of the five**, hub `main` = `ec5a689` (unchanged since run 118's last merge). AGENTS.md and `docs/workflow-safety-and-approvals.md` re-read from the repo, not from memory. Tooling verified at start: `gh` 2.96.0 (clarkemoyer, scopes `admin:org gist project repo workflow write:packages`), `az` 2.81.0, `m365` v11.9.0, `gcloud` 552.0.0 — nothing to install…",
-      "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5223750742"
-    },
-    {
-      "author": "clarkemoyer",
-      "created_at": "2026-08-08T01:54:00Z",
-      "body": "## Run 119 — END (2026-08-08, 01:0x–01:5xZ) · core 4983 -> 4916 / graphql 4967 -> 4862\n\n**4 PRs merged and verified on their merged trees · 1 issue filed · 2 issues corrected · 0 gates approved (54th hold on 703, 2nd on 106) · delivery 54 live and byte-identical · board 0/0/0/0 exit 0 · 3 lessons**\n\nThree of this run's findings are corrections to things that were already written down and looked\nright: a count in a ledger row that merged four hours ago, a premise in an open issue, and two claims\n…",
-      "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5223941518"
-    },
     {
       "author": "clarkemoyer",
       "created_at": "2026-08-08T04:06:40Z",
@@ -1941,6 +1968,20 @@
       "body": "## Run 122 — START (2026-08-08, ~10:2xZ) · core 4994 / graphql 5000\n\nBootstrap clean. All five core clones fetched and hard-reset to `origin/main`, working trees clean, no leftover worktrees:\n\n| repo | head |\n| --- | --- |\n| FFC-Cloudflare-Automation | `5ade5cc` (#1115, 10:17:02Z) |\n| FFC-IN-ffcadmin.org | `bf60dd3` (#862, delivery 56) |\n| FFC-IN-FFC_Single_Page_Template | `7455a44` (#428, 07:21Z) |\n| FFC-IN-Footer_Only_Template | `fbb0faf` (#123) |\n| FFC-IN-freeforcharity.org | `88593b3` |\n\nToo…",
       "truncated": true,
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5225708710"
+    },
+    {
+      "author": "clarkemoyer",
+      "created_at": "2026-08-08T11:49:34Z",
+      "body": "## Run 122 — END (2026-08-08, 10:2x–12:1xZ) · core 4994 → 4991 / graphql 5000 → 4838\n\n**4 PRs merged and verified on their merged trees · delivery 57 live and byte-identical (34th hand delivery) · 3 ledger rows (L185–L187) · 1 issue filed · 1 incoming PR triaged, labelled and carded · 0 gates approved (57th hold on 703) · board 364 items, 0/0/0/0/0, exit 0 · Clarke pinged once**\n\nThe run cleared the entire satellite queue, and both of its findings are about the Conductor: a probe I used is a con…",
+      "truncated": true,
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5225971268"
+    },
+    {
+      "author": "clarkemoyer",
+      "created_at": "2026-08-08T13:05:59Z",
+      "body": "## Run 123 — START (2026-08-08, ~13:0xZ) · core 4989 / graphql 4972\n\nBootstrap clean. All **5/5 core clones** fetched and fast-forwarded to `main`, **0 dirty files** in any of the five; `core.autocrlf=false` from run 122 held. Hub `main` = `cea0e6e` (#1118, ledger at **L187**).\n\n| clone | head |\n| --- | --- |\n| FFC-Cloudflare-Automation | `cea0e6e` |\n| FFC-IN-freeforcharity.org | `88593b3` |\n| FFC-IN-ffcadmin.org | `043cc3a` |\n| FFC-IN-FFC_Single_Page_Template | `edfd3ff` |\n| FFC-IN-Footer_Only_…",
+      "truncated": true,
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5226231409"
     }
   ],
   "conductor_log_rule": "The last 10 comments on the Conductor log issue #719, ordered OLDEST FIRST — element 0 is the oldest of the 10, and the LAST element is the most recent. Each body is redacted and truncated to 500 characters. Hub-only: there is one log. This is a tail, not the whole thread, so an entry's absence means it fell off the end of the window, not that it was never written; and the newest entry here is at most as recent as `generated_at`, never fresher.",


### PR DESCRIPTION
Refreshes the public Agentic OS status feed at https://ffcadmin.org/agentic-os/.

Generated `2026-08-08T13:20:11Z` by `scripts/generate-agentic-os-status.py` in FFC-Cloudflare-Automation, against hub `main` = `146599e`.

| field | value |
| --- | --- |
| `backlog_issues` | 97 |
| `in_flight_prs` | 2 of 8 |
| `pending_gates` | 1 (703, 58th hold) |
| `repos` | 2 |

**Byte-integrity verified after the commit, not before it** (CLAUDE.md:509 — the pre-commit staged check measures a blob `lint-staged` is free to rewrite):

```
generated file                          sha256 7717235bfe16cbf1
HEAD:src/data/agentic-os-status.json    sha256 7717235bfe16cbf1
HEAD:public/data/agentic-os-status.json sha256 7717235bfe16cbf1
CR bytes in public copy: 0
```

Three equal digests, so `prettier` left both copies byte-identical to the generator's output.

**34th consecutive hand delivery.** 502 still cannot publish this itself — `read-all-cbm-github-pat` is dead (#848, day 17).

_Conductor, local. Run 123._