### PR TITLE
chore(agentic-os): refresh public status feed (delivery 66)

### DIFF
--- a/public/data/agentic-os-status.json
+++ b/public/data/agentic-os-status.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-09T10:20:48Z",
+  "generated_at": "2026-08-09T13:21:07Z",
   "org": "FreeForCharity",
   "repo": "FreeForCharity/FFC-Cloudflare-Automation",
   "repos": [
@@ -7,6 +7,61 @@
     "FreeForCharity/FFC-IN-ffcadmin.org"
   ],
   "backlog_issues": [
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 983,
+      "title": "dry_run is enforced per-step, not per-job: every dry run of 701/702/720 parks on a write gate and mints a write credential",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-08-09T13:15:18Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/983",
+      "labels": [
+        "security",
+        "agentic-os",
+        "blocked"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 1080,
+      "title": "Security: freeze and guard free-text dispatch inputs interpolated into run: bodies (34 workflows, 20 gated on write)",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-08-09T13:13:16Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/1080",
+      "labels": [
+        "security",
+        "agentic-os",
+        "agent-ready"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 719,
+      "title": "Agentic OS Conductor Log",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-08-09T13:05:05Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719",
+      "labels": [
+        "agentic-os"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 1028,
+      "title": "App-identity pushes fire no pull_request event: the PR keeps the previous commit's green checks and reads as CI-verified",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-08-09T10:26:03Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/1028",
+      "labels": [
+        "bug",
+        "agentic-os",
+        "agent-ready",
+        "blocked"
+      ]
+    },
     {
       "repo": "FreeForCharity/FFC-Cloudflare-Automation",
       "number": 1135,
@@ -33,18 +88,6 @@
         "agentic-os",
         "priority: high",
         "agent-ready"
-      ]
-    },
-    {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 719,
-      "title": "Agentic OS Conductor Log",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-08-09T10:07:22Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719",
-      "labels": [
-        "agentic-os"
       ]
     },
     {
@@ -98,20 +141,6 @@
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/1111",
       "labels": [
         "bug",
-        "agentic-os",
-        "agent-ready"
-      ]
-    },
-    {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 1080,
-      "title": "Security: freeze and guard free-text dispatch inputs interpolated into run: bodies (34 workflows, 20 gated on write)",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-08-09T06:35:51Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/1080",
-      "labels": [
-        "security",
         "agentic-os",
         "agent-ready"
       ]
@@ -428,21 +457,6 @@
       "labels": [
         "enhancement",
         "agentic-os"
-      ]
-    },
-    {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 1028,
-      "title": "App-identity pushes fire no pull_request event: the PR keeps the previous commit's green checks and reads as CI-verified",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-08-07T01:30:51Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/1028",
-      "labels": [
-        "bug",
-        "agentic-os",
-        "agent-ready",
-        "blocked"
       ]
     },
     {
@@ -895,20 +909,6 @@
     },
     {
       "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 983,
-      "title": "dry_run is enforced per-step, not per-job: every dry run of 701/702/720 parks on a write gate and mints a write credential",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-08-02T10:13:42Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/983",
-      "labels": [
-        "security",
-        "agentic-os",
-        "blocked"
-      ]
-    },
-    {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
       "number": 908,
       "title": "ffcadmin data-refresh PRs hang forever once they fall behind main — three public dashboards went stale for 6h with all checks green",
       "state": "open",
@@ -1317,6 +1317,35 @@
   "ready_issues": [
     {
       "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 1080,
+      "title": "Security: freeze and guard free-text dispatch inputs interpolated into run: bodies (34 workflows, 20 gated on write)",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-08-09T13:13:16Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/1080",
+      "labels": [
+        "security",
+        "agentic-os",
+        "agent-ready"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 1028,
+      "title": "App-identity pushes fire no pull_request event: the PR keeps the previous commit's green checks and reads as CI-verified",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-08-09T10:26:03Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/1028",
+      "labels": [
+        "bug",
+        "agentic-os",
+        "agent-ready",
+        "blocked"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
       "number": 1135,
       "title": "Nothing observes the pickup query an agent actually types: #1028 sat in the agent-ready results for 3 days while explicitly blocked",
       "state": "open",
@@ -1367,20 +1396,6 @@
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/1111",
       "labels": [
         "bug",
-        "agentic-os",
-        "agent-ready"
-      ]
-    },
-    {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 1080,
-      "title": "Security: freeze and guard free-text dispatch inputs interpolated into run: bodies (34 workflows, 20 gated on write)",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-08-09T06:35:51Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/1080",
-      "labels": [
-        "security",
         "agentic-os",
         "agent-ready"
       ]
@@ -1538,21 +1553,6 @@
         "bug",
         "agentic-os",
         "agent-ready"
-      ]
-    },
-    {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 1028,
-      "title": "App-identity pushes fire no pull_request event: the PR keeps the previous commit's green checks and reads as CI-verified",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-08-07T01:30:51Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/1028",
-      "labels": [
-        "bug",
-        "agentic-os",
-        "agent-ready",
-        "blocked"
       ]
     },
     {
@@ -1933,24 +1933,18 @@
   "in_flight_prs": [
     {
       "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 1136,
-      "title": "docs(backlog): subtract blocked in the agent-ready pickup query, and ledger L205",
+      "number": 1138,
+      "title": "docs(lessons): a mutation experiment needs a verified control, and queue heads are not orphans (L208, L209)",
       "state": "open",
       "draft": true,
       "assignee": null,
-      "updated_at": "2026-08-09T10:20:07Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/1136",
+      "updated_at": "2026-08-09T13:20:40Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/1138",
       "labels": [
-        "documentation",
         "agentic-os"
       ],
       "linked_agentic_issues": [
-        1028,
-        1099,
-        986,
-        983,
-        1135,
-        1026
+        986
       ]
     },
     {
@@ -1987,22 +1981,8 @@
     }
   ],
   "in_flight_prs_rule": "Open pull requests that are agent work on this backlog, across every repository listed in `repos` — the same org-wide scope as the backlog above, and as the pickup query in AGENTS.md. A PR is listed when it carries the agentic-os label, or when its body references an agentic-os issue in its OWN repository (e.g. 'Closes #123' / 'Refs #123'); a bare #123 is repo-local, so the same number in two repos is two different issues. Referenced-issue labels are what decide it — nothing labels the pull requests themselves. `open_prs_total` is the unfiltered open-PR count over exactly these same repositories.",
-  "open_prs_total": 10,
+  "open_prs_total": 9,
   "conductor_log": [
-    {
-      "author": "clarkemoyer",
-      "created_at": "2026-08-09T01:06:42Z",
-      "body": "## Run 127 — START (2026-08-09, ~01:0xZ) · core 4983 / graphql 4976\n\nBootstrap clean. All **5/5 core clones** fetched and fast-forwarded to `origin/main`, **0 dirty files** in any of the five, `git worktree list` clean in the hub.\n\n| clone | head |\n| --- | --- |\n| FFC-Cloudflare-Automation | `5f56cc8` (#1125, ledger at **L195** — 195 rows) |\n| FFC-IN-freeforcharity.org | `88593b3` |\n| FFC-IN-ffcadmin.org | `7073ccd` |\n| FFC-IN-FFC_Single_Page_Template | `edfd3ff` |\n| FFC-IN-Footer_Only_Template …",
-      "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5229112319"
-    },
-    {
-      "author": "clarkemoyer",
-      "created_at": "2026-08-09T01:55:06Z",
-      "body": "## Run 127 — END (2026-08-09, 01:0x–02:0xZ) · core 4983 → 4963 / graphql 4976 → 4842\n\n**3 PRs merged and verified on their merged trees · 1 six-day-old security issue unparked by measurement and made `agent-ready` · 2 ledger rows (L197–L198) correcting a contradiction between AGENTS.md and CLAUDE.md · delivery 62 live and byte-identical (39th hand delivery) · 0 issues filed · 0 gates approved (62nd hold on 703) · board 374 items, 0/0/0/0/0, exit 0 · Clarke pinged once**\n\nThe run's largest findin…",
-      "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5229261000"
-    },
     {
       "author": "clarkemoyer",
       "created_at": "2026-08-09T04:06:39Z",
@@ -2058,6 +2038,20 @@
       "body": "## Run 130 — START (2026-08-09, ~10:0xZ) · core 4985 / graphql 4987\n\nRun number derived from the #719 tail (`--paginate`, streaming `--jq`): newest START is **run 129** at `2026-08-09T07:05:11Z`, so this is **130**. `state\\CONDUCTOR.md` agrees, which is corroboration and not the source.\n\n**Bootstrap.** All five core clones fetched. `FFC-Cloudflare-Automation` `main` = `8774a1a` (#1132), in sync. `FFC-IN-ffcadmin.org` was sitting on `data/agentic-os-status-run129`, whose remote is **gone** — retu…",
       "truncated": true,
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5230950590"
+    },
+    {
+      "author": "clarkemoyer",
+      "created_at": "2026-08-09T10:34:01Z",
+      "body": "## Run 130 — END (2026-08-09, 10:0x–10:3xZ) · core 4985 → 4991 (hourly reset at 10:16:46Z) / graphql 4987 → 4864\n\n**2 PRs merged (#1134, #1136) · 1 issue filed (#1135) · 3 issues groomed (#1133, #1028, #986) · 1 ledger row (L205) · 0 gates approved — 66th hold on 703 · board audit exit 0, all five categories 0 · delivery 65 LIVE · Clarke not pinged.**\n\n---\n\n### 1. Gates — one pending, declined for the 66th time\n\n`30800404614` · **703. Generate Sites List** · `github-prod` (write, gated) · waitin…",
+      "truncated": true,
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5231050063"
+    },
+    {
+      "author": "clarkemoyer",
+      "created_at": "2026-08-09T13:05:05Z",
+      "body": "## Run 131 — START (2026-08-09, ~13:0xZ) · core 5000 / graphql 4898\n\n**Bootstrap clean.** All five core clones fetched + fast-forwarded, zero dirty files:\n\n| repo | branch | head |\n| --- | --- | --- |\n| FFC-Cloudflare-Automation | main | `1f5e4d0` |\n| FFC-IN-freeforcharity.org | main | `88593b3` |\n| FFC-IN-ffcadmin.org | main | `a3f7261` |\n| FFC-IN-FFC_Single_Page_Template | main | `edfd3ff` |\n| FFC-IN-Footer_Only_Template | main | `d163883` |\n\nHub `main` is still `1f5e4d0` — run 130's #1136 mer…",
+      "truncated": true,
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5231666908"
     }
   ],
   "conductor_log_rule": "The last 10 comments on the Conductor log issue #719, ordered OLDEST FIRST — element 0 is the oldest of the 10, and the LAST element is the most recent. Each body is redacted and truncated to 500 characters. Hub-only: there is one log. This is a tail, not the whole thread, so an entry's absence means it fell off the end of the window, not that it was never written; and the newest entry here is at most as recent as `generated_at`, never fresher.",

--- a/src/data/agentic-os-status.json
+++ b/src/data/agentic-os-status.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-09T10:20:48Z",
+  "generated_at": "2026-08-09T13:21:07Z",
   "org": "FreeForCharity",
   "repo": "FreeForCharity/FFC-Cloudflare-Automation",
   "repos": [
@@ -7,6 +7,61 @@
     "FreeForCharity/FFC-IN-ffcadmin.org"
   ],
   "backlog_issues": [
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 983,
+      "title": "dry_run is enforced per-step, not per-job: every dry run of 701/702/720 parks on a write gate and mints a write credential",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-08-09T13:15:18Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/983",
+      "labels": [
+        "security",
+        "agentic-os",
+        "blocked"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 1080,
+      "title": "Security: freeze and guard free-text dispatch inputs interpolated into run: bodies (34 workflows, 20 gated on write)",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-08-09T13:13:16Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/1080",
+      "labels": [
+        "security",
+        "agentic-os",
+        "agent-ready"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 719,
+      "title": "Agentic OS Conductor Log",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-08-09T13:05:05Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719",
+      "labels": [
+        "agentic-os"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 1028,
+      "title": "App-identity pushes fire no pull_request event: the PR keeps the previous commit's green checks and reads as CI-verified",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-08-09T10:26:03Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/1028",
+      "labels": [
+        "bug",
+        "agentic-os",
+        "agent-ready",
+        "blocked"
+      ]
+    },
     {
       "repo": "FreeForCharity/FFC-Cloudflare-Automation",
       "number": 1135,
@@ -33,18 +88,6 @@
         "agentic-os",
         "priority: high",
         "agent-ready"
-      ]
-    },
-    {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 719,
-      "title": "Agentic OS Conductor Log",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-08-09T10:07:22Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719",
-      "labels": [
-        "agentic-os"
       ]
     },
     {
@@ -98,20 +141,6 @@
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/1111",
       "labels": [
         "bug",
-        "agentic-os",
-        "agent-ready"
-      ]
-    },
-    {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 1080,
-      "title": "Security: freeze and guard free-text dispatch inputs interpolated into run: bodies (34 workflows, 20 gated on write)",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-08-09T06:35:51Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/1080",
-      "labels": [
-        "security",
         "agentic-os",
         "agent-ready"
       ]
@@ -428,21 +457,6 @@
       "labels": [
         "enhancement",
         "agentic-os"
-      ]
-    },
-    {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 1028,
-      "title": "App-identity pushes fire no pull_request event: the PR keeps the previous commit's green checks and reads as CI-verified",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-08-07T01:30:51Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/1028",
-      "labels": [
-        "bug",
-        "agentic-os",
-        "agent-ready",
-        "blocked"
       ]
     },
     {
@@ -895,20 +909,6 @@
     },
     {
       "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 983,
-      "title": "dry_run is enforced per-step, not per-job: every dry run of 701/702/720 parks on a write gate and mints a write credential",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-08-02T10:13:42Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/983",
-      "labels": [
-        "security",
-        "agentic-os",
-        "blocked"
-      ]
-    },
-    {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
       "number": 908,
       "title": "ffcadmin data-refresh PRs hang forever once they fall behind main — three public dashboards went stale for 6h with all checks green",
       "state": "open",
@@ -1317,6 +1317,35 @@
   "ready_issues": [
     {
       "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 1080,
+      "title": "Security: freeze and guard free-text dispatch inputs interpolated into run: bodies (34 workflows, 20 gated on write)",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-08-09T13:13:16Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/1080",
+      "labels": [
+        "security",
+        "agentic-os",
+        "agent-ready"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 1028,
+      "title": "App-identity pushes fire no pull_request event: the PR keeps the previous commit's green checks and reads as CI-verified",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-08-09T10:26:03Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/1028",
+      "labels": [
+        "bug",
+        "agentic-os",
+        "agent-ready",
+        "blocked"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
       "number": 1135,
       "title": "Nothing observes the pickup query an agent actually types: #1028 sat in the agent-ready results for 3 days while explicitly blocked",
       "state": "open",
@@ -1367,20 +1396,6 @@
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/1111",
       "labels": [
         "bug",
-        "agentic-os",
-        "agent-ready"
-      ]
-    },
-    {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 1080,
-      "title": "Security: freeze and guard free-text dispatch inputs interpolated into run: bodies (34 workflows, 20 gated on write)",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-08-09T06:35:51Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/1080",
-      "labels": [
-        "security",
         "agentic-os",
         "agent-ready"
       ]
@@ -1538,21 +1553,6 @@
         "bug",
         "agentic-os",
         "agent-ready"
-      ]
-    },
-    {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 1028,
-      "title": "App-identity pushes fire no pull_request event: the PR keeps the previous commit's green checks and reads as CI-verified",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-08-07T01:30:51Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/1028",
-      "labels": [
-        "bug",
-        "agentic-os",
-        "agent-ready",
-        "blocked"
       ]
     },
     {
@@ -1933,24 +1933,18 @@
   "in_flight_prs": [
     {
       "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 1136,
-      "title": "docs(backlog): subtract blocked in the agent-ready pickup query, and ledger L205",
+      "number": 1138,
+      "title": "docs(lessons): a mutation experiment needs a verified control, and queue heads are not orphans (L208, L209)",
       "state": "open",
       "draft": true,
       "assignee": null,
-      "updated_at": "2026-08-09T10:20:07Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/1136",
+      "updated_at": "2026-08-09T13:20:40Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/1138",
       "labels": [
-        "documentation",
         "agentic-os"
       ],
       "linked_agentic_issues": [
-        1028,
-        1099,
-        986,
-        983,
-        1135,
-        1026
+        986
       ]
     },
     {
@@ -1987,22 +1981,8 @@
     }
   ],
   "in_flight_prs_rule": "Open pull requests that are agent work on this backlog, across every repository listed in `repos` — the same org-wide scope as the backlog above, and as the pickup query in AGENTS.md. A PR is listed when it carries the agentic-os label, or when its body references an agentic-os issue in its OWN repository (e.g. 'Closes #123' / 'Refs #123'); a bare #123 is repo-local, so the same number in two repos is two different issues. Referenced-issue labels are what decide it — nothing labels the pull requests themselves. `open_prs_total` is the unfiltered open-PR count over exactly these same repositories.",
-  "open_prs_total": 10,
+  "open_prs_total": 9,
   "conductor_log": [
-    {
-      "author": "clarkemoyer",
-      "created_at": "2026-08-09T01:06:42Z",
-      "body": "## Run 127 — START (2026-08-09, ~01:0xZ) · core 4983 / graphql 4976\n\nBootstrap clean. All **5/5 core clones** fetched and fast-forwarded to `origin/main`, **0 dirty files** in any of the five, `git worktree list` clean in the hub.\n\n| clone | head |\n| --- | --- |\n| FFC-Cloudflare-Automation | `5f56cc8` (#1125, ledger at **L195** — 195 rows) |\n| FFC-IN-freeforcharity.org | `88593b3` |\n| FFC-IN-ffcadmin.org | `7073ccd` |\n| FFC-IN-FFC_Single_Page_Template | `edfd3ff` |\n| FFC-IN-Footer_Only_Template …",
-      "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5229112319"
-    },
-    {
-      "author": "clarkemoyer",
-      "created_at": "2026-08-09T01:55:06Z",
-      "body": "## Run 127 — END (2026-08-09, 01:0x–02:0xZ) · core 4983 → 4963 / graphql 4976 → 4842\n\n**3 PRs merged and verified on their merged trees · 1 six-day-old security issue unparked by measurement and made `agent-ready` · 2 ledger rows (L197–L198) correcting a contradiction between AGENTS.md and CLAUDE.md · delivery 62 live and byte-identical (39th hand delivery) · 0 issues filed · 0 gates approved (62nd hold on 703) · board 374 items, 0/0/0/0/0, exit 0 · Clarke pinged once**\n\nThe run's largest findin…",
-      "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5229261000"
-    },
     {
       "author": "clarkemoyer",
       "created_at": "2026-08-09T04:06:39Z",
@@ -2058,6 +2038,20 @@
       "body": "## Run 130 — START (2026-08-09, ~10:0xZ) · core 4985 / graphql 4987\n\nRun number derived from the #719 tail (`--paginate`, streaming `--jq`): newest START is **run 129** at `2026-08-09T07:05:11Z`, so this is **130**. `state\\CONDUCTOR.md` agrees, which is corroboration and not the source.\n\n**Bootstrap.** All five core clones fetched. `FFC-Cloudflare-Automation` `main` = `8774a1a` (#1132), in sync. `FFC-IN-ffcadmin.org` was sitting on `data/agentic-os-status-run129`, whose remote is **gone** — retu…",
       "truncated": true,
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5230950590"
+    },
+    {
+      "author": "clarkemoyer",
+      "created_at": "2026-08-09T10:34:01Z",
+      "body": "## Run 130 — END (2026-08-09, 10:0x–10:3xZ) · core 4985 → 4991 (hourly reset at 10:16:46Z) / graphql 4987 → 4864\n\n**2 PRs merged (#1134, #1136) · 1 issue filed (#1135) · 3 issues groomed (#1133, #1028, #986) · 1 ledger row (L205) · 0 gates approved — 66th hold on 703 · board audit exit 0, all five categories 0 · delivery 65 LIVE · Clarke not pinged.**\n\n---\n\n### 1. Gates — one pending, declined for the 66th time\n\n`30800404614` · **703. Generate Sites List** · `github-prod` (write, gated) · waitin…",
+      "truncated": true,
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5231050063"
+    },
+    {
+      "author": "clarkemoyer",
+      "created_at": "2026-08-09T13:05:05Z",
+      "body": "## Run 131 — START (2026-08-09, ~13:0xZ) · core 5000 / graphql 4898\n\n**Bootstrap clean.** All five core clones fetched + fast-forwarded, zero dirty files:\n\n| repo | branch | head |\n| --- | --- | --- |\n| FFC-Cloudflare-Automation | main | `1f5e4d0` |\n| FFC-IN-freeforcharity.org | main | `88593b3` |\n| FFC-IN-ffcadmin.org | main | `a3f7261` |\n| FFC-IN-FFC_Single_Page_Template | main | `edfd3ff` |\n| FFC-IN-Footer_Only_Template | main | `d163883` |\n\nHub `main` is still `1f5e4d0` — run 130's #1136 mer…",
+      "truncated": true,
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5231666908"
     }
   ],
   "conductor_log_rule": "The last 10 comments on the Conductor log issue #719, ordered OLDEST FIRST — element 0 is the oldest of the 10, and the LAST element is the most recent. Each body is redacted and truncated to 500 characters. Hub-only: there is one log. This is a tail, not the whole thread, so an entry's absence means it fell off the end of the window, not that it was never written; and the newest entry here is at most as recent as `generated_at`, never fresher.",


### PR DESCRIPTION
Hand delivery of the public Agentic OS status feed — **delivery 66**, and the **43rd consecutive**
one, while workflow 502's `deliver` job stays down.

## Why this is by hand

502 ran on schedule today and failed the same way it has since 2026-07-21 (**day 19**):

| job | result |
| --- | --- |
| `smoke / smoke` | ✅ success |
| `smoke / gsc-smoke` | skipped |
| `report` | ✅ success |
| `deliver` | ❌ **failure at `Load the GitHub PAT from Key Vault`** |

Only the delivery path is broken — the generator itself takes `GH_TOKEN` and nothing else, so the
Conductor runs it locally and ships the result by the same branch + PR route `deliver` would use.
Tracked as FreeForCharity/FFC-Cloudflare-Automation#848; the credential rotation is with Clarke.

## This delivery

`generated_at` **2026-08-09T13:21:07Z** — 98 issues, 3 of 9 open PRs across 2 repos, 10 log entries,
**1 pending gate** (703, now its 67th consecutive hold).

Verified after the commit, not before it — this repo's `lint-staged` → `prettier --write` hook fires
after the staged-blob check and re-stages what it changes, so the staged check describes a blob the
commit may not keep:

```
generated file                          ff36bf58c6683a47a0758ab383d6eef8b0a6b8218bda4d928d2fe35fc735301f
HEAD:src/data/agentic-os-status.json    ff36bf58c6683a47a0758ab383d6eef8b0a6b8218bda4d928d2fe35fc735301f
HEAD:public/data/agentic-os-status.json ff36bf58c6683a47a0758ab383d6eef8b0a6b8218bda4d928d2fe35fc735301f
CR bytes in HEAD:public/...             0   (via tr -cd, not grep and not Python text mode)
```

Three equal digests, so prettier left both copies byte-identical to the generator's output.

## Verifying this landed

Read the data artifact, never the rendered page — the status page republishes its own log, so
grepping the HTML can hand back a previous run's claim about itself:

```bash
curl -s https://ffcadmin.org/data/agentic-os-status.json | grep -oE '"generated_at": *"[^"]*"'
```
