### PR TITLE
chore(data): refresh the Agentic OS status feed (delivery 78)

### DIFF
--- a/public/data/agentic-os-status.json
+++ b/public/data/agentic-os-status.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-11T01:18:56Z",
+  "generated_at": "2026-08-11T04:17:56Z",
   "org": "FreeForCharity",
   "repo": "FreeForCharity/FFC-Cloudflare-Automation",
   "repos": [
@@ -9,14 +9,16 @@
   "backlog_issues": [
     {
       "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 719,
-      "title": "Agentic OS Conductor Log",
+      "number": 1171,
+      "title": "Status feed: pending_gates counts runs AT a gate, not runs stopped BY one (703 holds 2, page says 1)",
       "state": "open",
       "assignee": null,
-      "updated_at": "2026-08-11T01:05:49Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719",
+      "updated_at": "2026-08-11T04:16:43Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/1171",
       "labels": [
-        "agentic-os"
+        "bug",
+        "agentic-os",
+        "agent-ready"
       ]
     },
     {
@@ -25,10 +27,36 @@
       "title": "Security: freeze and guard free-text dispatch inputs interpolated into run: bodies (34 workflows, 20 gated on write)",
       "state": "open",
       "assignee": null,
-      "updated_at": "2026-08-11T00:40:30Z",
+      "updated_at": "2026-08-11T04:14:35Z",
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/1080",
       "labels": [
         "security",
+        "agentic-os",
+        "agent-ready"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 719,
+      "title": "Agentic OS Conductor Log",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-08-11T04:06:39Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719",
+      "labels": [
+        "agentic-os"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 724,
+      "title": "Migrate remaining value out of FFC-IN-AI-Management into the hub (inventory + first tranche)",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-08-11T01:25:23Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/724",
+      "labels": [
+        "documentation",
         "agentic-os",
         "agent-ready"
       ]
@@ -786,20 +814,6 @@
     },
     {
       "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 724,
-      "title": "Migrate remaining value out of FFC-IN-AI-Management into the hub (inventory + first tranche)",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-08-04T01:21:54Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/724",
-      "labels": [
-        "documentation",
-        "agentic-os",
-        "agent-ready"
-      ]
-    },
-    {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
       "number": 1044,
       "title": "Nothing validates that a sites-list Repo URL resolves: a 404 sat in the public dataset until another repo's link checker found it",
       "state": "open",
@@ -1343,14 +1357,42 @@
   "ready_issues": [
     {
       "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 1171,
+      "title": "Status feed: pending_gates counts runs AT a gate, not runs stopped BY one (703 holds 2, page says 1)",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-08-11T04:16:43Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/1171",
+      "labels": [
+        "bug",
+        "agentic-os",
+        "agent-ready"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
       "number": 1080,
       "title": "Security: freeze and guard free-text dispatch inputs interpolated into run: bodies (34 workflows, 20 gated on write)",
       "state": "open",
       "assignee": null,
-      "updated_at": "2026-08-11T00:40:30Z",
+      "updated_at": "2026-08-11T04:14:35Z",
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/1080",
       "labels": [
         "security",
+        "agentic-os",
+        "agent-ready"
+      ]
+    },
+    {
+      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+      "number": 724,
+      "title": "Migrate remaining value out of FFC-IN-AI-Management into the hub (inventory + first tranche)",
+      "state": "open",
+      "assignee": null,
+      "updated_at": "2026-08-11T01:25:23Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/724",
+      "labels": [
+        "documentation",
         "agentic-os",
         "agent-ready"
       ]
@@ -1802,20 +1844,6 @@
     },
     {
       "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 724,
-      "title": "Migrate remaining value out of FFC-IN-AI-Management into the hub (inventory + first tranche)",
-      "state": "open",
-      "assignee": null,
-      "updated_at": "2026-08-04T01:21:54Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/724",
-      "labels": [
-        "documentation",
-        "agentic-os",
-        "agent-ready"
-      ]
-    },
-    {
-      "repo": "FreeForCharity/FFC-Cloudflare-Automation",
       "number": 1044,
       "title": "Nothing validates that a sites-list Repo URL resolves: a 404 sat in the public dataset until another repo's link checker found it",
       "state": "open",
@@ -1953,22 +1981,25 @@
       ]
     }
   ],
-  "ready_count": 44,
+  "ready_count": 45,
   "ready_rule": "Open issues labeled 'agent-ready' and NOT 'claimed': unblocked, one-PR-scoped and carrying acceptance criteria — the queue a sandboxed agent can pick from now. An 'agent-ready' issue with an open PR against it carries 'claimed' (applied by workflow 737) and is excluded here until that PR closes; ready_count counts exactly the rows in ready_issues. A strict subset of backlog_issues, which stays the full 'agentic-os' topic set (epics, machine-managed rolling issues, human-blocked items and durable findings all remain counted there).",
   "in_flight_prs": [
     {
       "repo": "FreeForCharity/FFC-Cloudflare-Automation",
-      "number": 1168,
-      "title": "docs: L231 — a deletion mutation tests that a guard exists, a narrowing one tests that it was the right guard",
+      "number": 1170,
+      "title": "security(103): route the free-text `domain` / `issue_number` inputs through step-level env (#1080 burn-down)",
       "state": "open",
       "draft": true,
       "assignee": null,
-      "updated_at": "2026-08-11T01:18:06Z",
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/1168",
+      "updated_at": "2026-08-11T04:12:11Z",
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/1170",
       "labels": [
+        "security",
         "agentic-os"
       ],
-      "linked_agentic_issues": []
+      "linked_agentic_issues": [
+        1080
+      ]
     },
     {
       "repo": "FreeForCharity/FFC-Cloudflare-Automation",
@@ -2004,29 +2035,8 @@
     }
   ],
   "in_flight_prs_rule": "Open pull requests that are agent work on this backlog, across every repository listed in `repos` — the same org-wide scope as the backlog above, and as the pickup query in AGENTS.md. A PR is listed when it carries the agentic-os label, or when its body references an agentic-os issue in its OWN repository (e.g. 'Closes #123' / 'Refs #123'); a bare #123 is repo-local, so the same number in two repos is two different issues. Referenced-issue labels are what decide it — nothing labels the pull requests themselves. `open_prs_total` is the unfiltered open-PR count over exactly these same repositories.",
-  "open_prs_total": 9,
+  "open_prs_total": 10,
   "conductor_log": [
-    {
-      "author": "clarkemoyer",
-      "created_at": "2026-08-10T16:05:16Z",
-      "body": "## Run 140 — START (2026-08-10, ~16:0xZ) · core 4986 / graphql 4902\n\nBootstrap clean: workspace present, all 5 core clones fetched + hard-reset to `origin/main`. Hub at `70c35e5` (#1159).\n\n**Inherited state read before acting** — run 139 END + its 13:43Z addendum + the **15:39Z cloud-worker landing pass**. Two things carried forward that change this run's shape:\n\n- **#1039 and #1127 are green apart, red together** (cloud worker, 15:39Z). #1039 rewrites `test_hooks.py` around a `RULES` registry w…",
-      "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5242782237"
-    },
-    {
-      "author": "github-actions[bot]",
-      "created_at": "2026-08-10T16:15:05Z",
-      "body": "🔓 Claim released — linked PR #1158 merged and no other open PR references this issue. Available again (`is:open -label:claimed`).",
-      "truncated": false,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5242890902"
-    },
-    {
-      "author": "clarkemoyer",
-      "created_at": "2026-08-10T16:26:35Z",
-      "body": "## Run 140 — END (2026-08-10, 16:0x–16:3xZ) · core 4986 → 4953 / graphql 4902 → 4966 (hourly reset)\n\n**1 PR merged in the hub + 1 delivery merged + 1 draft opened / 0 issues filed / 0 closed / 1 ledger row / 0 gates approved (76th hold on 703) / 4 board corrections / no Clarke ping — two escalations left on the issues that own them.**\n\n### The finding, and it starts with my own error\n\nI pulled `228. WHMCS - Fraud Review` out of the failing-run list, walked it to the failing step, and got a clean…",
-      "truncated": true,
-      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5243017231"
-    },
     {
       "author": "clarkemoyer",
       "created_at": "2026-08-10T19:05:15Z",
@@ -2075,6 +2085,27 @@
       "body": "## Run 143 — START (2026-08-11, ~01:0xZ) · core 4984 / graphql 4911\n\nConductor host bootstrapped. All five core clones fetched and fast-forwarded to `origin/main`;\n`FFC-Cloudflare-Automation` at `d8647d6` (#1166). Tooling re-derived rather than assumed:\n`gh` 2.96.0 (clarkemoyer, scopes incl. `project`), `az` 2.81.0, `m365` 11.9.0, `gcloud` 552.0.0.\n\nRun number taken from this issue's tail (newest START = 142), not from local notes.\n\nPlan for this run:\n1. **Gates** — pending deployment approvals;…",
       "truncated": true,
       "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5247858263"
+    },
+    {
+      "author": "clarkemoyer",
+      "created_at": "2026-08-11T01:30:52Z",
+      "body": "## Run 143 — END (2026-08-11, 01:0x–02:0xZ) · core 4984 → 4986 (hourly reset) / graphql 4911 → 4894\r\n\r\n**1 agent PR reviewed and merged (#1167) · 1 ledger PR shipped and queued (#1168, L231) · 1 delivery merged\r\n(ffcadmin #896, delivery 77) · 1 issue groomed (#724) · 0 issues filed · 1 standing open thread\r\nclosed by falsification · 0 gates approved — 79th hold on 703 · 3 board cards · no Clarke contact.**\r\n\r\n---\r\n\r\n### Gates — one, unchanged, and not approved\r\n\r\n`30800404614` (**703 Generate Si…",
+      "truncated": true,
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5248007945"
+    },
+    {
+      "author": "clarkemoyer",
+      "created_at": "2026-08-11T01:34:36Z",
+      "body": "### Run 143 — addendum (01:3xZ): #1168 landed, and the queue branch behaved exactly as L226 + L230 jointly predict\n\n**#1168 (L231) merged as `affb9f5` at 01:33:59Z.** Card moved to Done; the ledger row is on `main`.\nThe END comment above recorded it as queued-and-building because that is what it was at the time —\nthis closes it, and **run 144 no longer needs to check thread 1**.\n\nWorth one paragraph because it is the first clean joint observation of L226 and L230, which were\nwritten a run apart …",
+      "truncated": true,
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5248028885"
+    },
+    {
+      "author": "clarkemoyer",
+      "created_at": "2026-08-11T04:06:39Z",
+      "body": "## Run 144 — START (2026-08-11, ~03:0xZ) · core 4989 / graphql 4912\n\nConductor host verified: `gh` 2.96.0 (clarkemoyer, keyring), `az` 2.81.0, `m365` 11.9.0, `gcloud` 552.0.0.\nAll five core clones fetched and hard-reset to `origin/main`; hub at `affb9f5` (L231, run 143).\n\n**Gate state up front: one hold, and it is now demonstrably TWO runs deep.**\n`703. Generate Sites List` run `30800404614` is still `waiting` on `github-prod` (write,\n`current_user_can_approve=true`, approver `clarkemoyer`) — **…",
+      "truncated": true,
+      "url": "https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/719#issuecomment-5248865609"
     }
   ],
   "conductor_log_rule": "The last 10 comments on the Conductor log issue #719, ordered OLDEST FIRST — element 0 is the oldest of the 10, and the LAST element is the most recent. Each body is redacted and truncated to 500 characters. Hub-only: there is one log. This is a tail, not the whole thread, so an entry's absence means it fell off the end of the window, not that it was never written; and the newest entry here is at most as recent as `generated_at`, never fresher.",


### PR DESCRIPTION
Data-only refresh of the public Agentic OS status feed. Regenerated from the hub with `scripts/generate-agentic-os-status.py`; nothing hand-edited.

| | delivery 77 | **delivery 78** |
| --- | --- | --- |
| `generated_at` | 2026-08-11T01:18:56Z | **2026-08-11T04:17:56Z** |
| backlog issues | 100 | **101** |
| `ready_count` | 44 | **45** |
| in-flight PRs | — | 3 of 10 open, across 2 repos |
| pending gates | 1 | 1 (`703`, `github-prod`) |

What moved since 77: hub PRs **#1169** and **#1170** opened, issue **#1171** filed (the `pending_gates` blast-radius defect found this run), and the run 144 START entry joined the Conductor log panel.

Hand-delivered because 502's `deliver` job is still down — #848, day 25.

**Checks run locally:** `prettier --check` clean on the changed file; the feed parses as valid UTF-8 (81,715 bytes) with real `U+2014` em dashes and no mojibake.

**One observation, not fixed here:** `src/data/agentic-os-status.json` is tracked and is still on delivery 76's `generated_at` (`2026-08-10T22:42:36Z`). It is **not** what the page renders — `src/lib/dashboardData.ts:147` reads `public/data` unconditionally — so the live page and the JSON endpoint agree and there is no public discrepancy. It is a dead tracked duplicate that will keep drifting and will eventually be read as the source by someone. Left alone to keep this delivery data-only; worth a separate cleanup PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)