### PR TITLE
fix(deps): override fast-uri to >=3.1.4 to clear the two high Dependabot alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
   "pnpm": {
     "overrides": {
       "postcss@<8.5.18": ">=8.5.18",
+      "fast-uri@<3.1.4": ">=3.1.4",
       "eslint-plugin-react-hooks": "7.0.1",
       "undici@>=7.0.0 <7.28.0": ">=7.28.0 <8.0.0",
       "sharp": "^0.35.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   postcss@<8.5.18: '>=8.5.18'
+  fast-uri@<3.1.4: '>=3.1.4'
   eslint-plugin-react-hooks: 7.0.1
   undici@>=7.0.0 <7.28.0: '>=7.28.0 <8.0.0'
   sharp: ^0.35.3
@@ -2229,9 +2230,6 @@ packages:
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
-
-  fast-uri@3.1.2:
-    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fast-uri@3.1.6:
     resolution: {integrity: sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==}
@@ -5345,7 +5343,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
+      fast-uri: 3.1.6
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -6310,8 +6308,6 @@ snapshots:
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
-
-  fast-uri@3.1.2: {}
 
   fast-uri@3.1.6: {}
 


### PR DESCRIPTION
Fixes #756.

## What

Adds the one-line `pnpm.overrides` entry #756 prescribes — `"fast-uri@<3.1.4": ">=3.1.4"` — matching the repo's existing override style (`postcss`, `undici`, `sharp`), and regenerates the lockfile.

## Why

`serve@14.2.6 → ajv@8.18.0` pinned `fast-uri@3.1.2`, which sits in the vulnerable range of **both open high Dependabot alerts** (host confusion via literal-backslash authority delimiter, and via failed IDN canonicalization). Neither open Dependabot PR moved that entry — the bumped `fast-uri` line was the already-safe one under `ajv@8.20.0`.

## Diff

Two files: `package.json` (+1 line) and `pnpm-lock.yaml`, where `ajv@8.18.0` now resolves `fast-uri@3.1.6` and nothing else moves.

## Verification (acceptance criteria from #756)

| Check | Result |
| --- | --- |
| `grep -c "fast-uri@3.1.2" pnpm-lock.yaml` | **0** |
| `pnpm run lint` | rc=0 |
| `pnpm run type-check` | rc=0 |
| `pnpm run build` (static export) | rc=0 |
| `pnpm test` | 1221/1221 pass |
| `pnpm audit --prod --audit-level high` (CI's command) | rc=0 — "No known vulnerabilities found" |

Criterion 3 (open high alerts = 0 via the Dependabot alerts API) is repo state, to be verified on `main` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wf57QsusNZqRLvTxFcAT3L

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wf57QsusNZqRLvTxFcAT3L)_