### PR TITLE
chore: upgrade pnpm 9 → 10.34.5 with 7-day release cooldown

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -37,14 +37,14 @@ This repository contains the **Free For Charity (FFC) Admin Portal**, a Next.js 
 ```bash
 # Required versions (specified in package.json)
 Node.js >= 20.0.0
-pnpm 9.0.0
+pnpm 10.34.5
 ```
 
 ### Quick Start
 
 ```bash
 # Install pnpm globally if needed
-npm install -g pnpm@9.0.0
+corepack enable   # pnpm version is pinned by the packageManager field (pnpm@10.34.5)
 
 # Install dependencies (always use frozen lockfile)
 pnpm install --frozen-lockfile
@@ -100,7 +100,7 @@ pnpm test              # 4. Test last
 - **UI Library:** React 18.3
 - **Styling:** Tailwind CSS 3.4
 - **Language:** TypeScript 5 (strict mode enabled)
-- **Package Manager:** pnpm 9.0.0
+- **Package Manager:** pnpm 10.34.5
 - **Testing:** Jest 30 + React Testing Library
 - **Linting:** ESLint (next/core-web-vitals) + Prettier
 - **Analytics:** Google Tag Manager (GTM-WMZH965Q) with Microsoft Clarity

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -20,7 +20,7 @@ Runs automated tests and build verification on all pull requests and pushes to m
 **Build, Test, and Verify Job:**
 
 1. Checks out the code
-2. Installs pnpm 9.0.0
+2. Installs pnpm (version from the packageManager field, currently 10.34.5)
 3. Sets up Node.js 20 (LTS) with pnpm cache enabled
 4. Installs dependencies with `pnpm install --frozen-lockfile`
 5. Checks code formatting with `pnpm run format:check` (Prettier validation)
@@ -106,7 +106,7 @@ This ensures code is never deployed without passing all quality and security che
 
 1. Checks out the code
 2. Sets up Node.js 20 (LTS)
-3. Installs pnpm 9.0.0
+3. Installs pnpm (version from the packageManager field, currently 10.34.5)
 4. Installs dependencies with `pnpm install --frozen-lockfile`
 5. Runs tests with `pnpm test` (validates build output and configuration)
 6. Builds the site with `pnpm run build` (creates `out/` directory)

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -21,7 +21,7 @@ Runs automated tests and build verification on all pull requests and pushes to m
 
 1. Checks out the code
 2. Installs pnpm (version from the packageManager field, currently 10.34.5)
-3. Sets up Node.js 20 (LTS) with pnpm cache enabled
+3. Sets up Node.js 24 with pnpm cache enabled
 4. Installs dependencies with `pnpm install --frozen-lockfile`
 5. Checks code formatting with `pnpm run format:check` (Prettier validation)
 6. Runs linter with `pnpm run lint` (ESLint validation)
@@ -105,8 +105,8 @@ This ensures code is never deployed without passing all quality and security che
 ### Build Process
 
 1. Checks out the code
-2. Sets up Node.js 20 (LTS)
-3. Installs pnpm (version from the packageManager field, currently 10.34.5)
+2. Installs pnpm (version from the packageManager field, currently 10.34.5)
+3. Sets up Node.js 24 with pnpm cache enabled
 4. Installs dependencies with `pnpm install --frozen-lockfile`
 5. Runs tests with `pnpm test` (validates build output and configuration)
 6. Builds the site with `pnpm run build` (creates `out/` directory)

--- a/.github/workflows/build-roadmap-data.yml
+++ b/.github/workflows/build-roadmap-data.yml
@@ -30,8 +30,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 9.0.0
 
       - name: Setup Node.js
         uses: actions/setup-node@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 9.0.0
 
       - name: Setup Node.js
         uses: actions/setup-node@v7

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -121,8 +121,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 9.0.0
 
       - name: Setup Node.js
         uses: actions/setup-node@v7

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -24,8 +24,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 9.0.0
 
       - name: Setup Node.js
         uses: actions/setup-node@v7

--- a/.github/workflows/linkinator-external.yml
+++ b/.github/workflows/linkinator-external.yml
@@ -32,8 +32,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 9.0.0
 
       - name: Setup Node.js
         uses: actions/setup-node@v7

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -41,8 +41,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 9.0.0
 
       - name: Setup Node.js
         uses: actions/setup-node@v7

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ git clone https://github.com/FreeForCharity/ffcadmin.org.git
 cd ffcadmin.org
 
 # 2. Install pnpm (if not already installed)
-npm install -g pnpm@9.0.0
+corepack enable   # pnpm version is pinned by the packageManager field (pnpm@10.34.5)
 
 # 3. Install dependencies
 pnpm install --frozen-lockfile

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -59,7 +59,7 @@ Located in `public/.nojekyll`, this empty file is automatically copied to the `o
 Located at `.github/workflows/deploy.yml`, this workflow:
 
 - Triggers on push to `main` branch
-- Uses Node.js 20 LTS and pnpm 9.0.0
+- Uses Node.js 20 LTS and pnpm 10.34.5
 - Builds the site with `pnpm run build`
 - Uses `actions/upload-pages-artifact@v3` to create the GitHub Pages artifact
   - **Note**: Version 3 is used (not v4) because v4 excludes dotfiles by default

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -59,7 +59,7 @@ Located in `public/.nojekyll`, this empty file is automatically copied to the `o
 Located at `.github/workflows/deploy.yml`, this workflow:
 
 - Triggers on push to `main` branch
-- Uses Node.js 20 LTS and pnpm 10.34.5
+- Uses Node.js 24 and pnpm 10.34.5
 - Builds the site with `pnpm run build`
 - Uses `actions/upload-pages-artifact@v3` to create the GitHub Pages artifact
   - **Note**: Version 3 is used (not v4) because v4 excludes dotfiles by default

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   "engines": {
     "node": ">=20.18.1"
   },
-  "packageManager": "pnpm@9.0.0",
+  "packageManager": "pnpm@10.34.5",
   "pnpm": {
     "overrides": {
       "postcss@<8.5.18": ">=8.5.18",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,6 @@
-# pnpm settings. Since v10 this file is also pnpm's configuration home; this
-# repo defines no `packages` list, so it stays a single-package project (the
-# repo root is the workspace root and its only package).
+# pnpm settings. Since v10 pnpm reads workspace-local settings from this
+# file; no `packages` list is defined, so the repo stays a single-package
+# project (the repo root is the workspace root and its only package).
 #
 # Supply-chain hardening (FFC fleet standard):
 # - minimumReleaseAge: refuse to resolve package versions published less than

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,13 @@
+# pnpm settings (this repo is a single package, not a workspace — pnpm reads
+# its configuration from this file since v10).
+#
+# Supply-chain hardening (FFC fleet standard):
+# - minimumReleaseAge: refuse to resolve package versions published less than
+#   7 days ago (value is in minutes). Compromised releases are typically
+#   caught and unpublished within days; the cooldown means freshly poisoned
+#   versions never reach our lockfile. Frozen-lockfile installs in CI are
+#   unaffected — this only gates NEW resolutions (adds/updates).
+# - Dependency lifecycle scripts (postinstall etc.) are blocked by default in
+#   pnpm 10+. If a dependency legitimately needs its build script, allowlist
+#   it explicitly under onlyBuiltDependencies rather than re-enabling all.
+minimumReleaseAge: 10080

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
-# pnpm settings (this repo is a single package, not a workspace — pnpm reads
-# its configuration from this file since v10).
+# pnpm settings. Since v10 this file is also pnpm's configuration home; this
+# repo defines no `packages` list, so it stays a single-package project (the
+# repo root is the workspace root and its only package).
 #
 # Supply-chain hardening (FFC fleet standard):
 # - minimumReleaseAge: refuse to resolve package versions published less than


### PR DESCRIPTION
## Summary

Phase 1 of the fleet-wide pnpm standardization (internal sites first, then templates, then FFC-EX sites; companion PR: FreeForCharity/FFC-IN-freeforcharity.org#531). This repo was already on pnpm, but pnpm 9 predates the two supply-chain protections the fleet standard is built on:

- **`minimumReleaseAge: 10080`** (new `pnpm-workspace.yaml`) — pnpm refuses to resolve any dependency version published less than 7 days ago, so freshly compromised releases (the vector in the 2025 npm worm attacks) never reach the lockfile. Frozen-lockfile CI installs are unaffected.
- **Dependency lifecycle scripts blocked by default** (pnpm 10; pnpm 9 ran them) — postinstall scripts are the primary execution vector in npm supply-chain attacks. Full checklist verified passing with **zero** allowlisted scripts; the blocked `esbuild`/`unrs-resolver` scripts are prebuilt-binary fallbacks this repo doesn't need.

## Changes

- `packageManager: pnpm@10.34.5`; the six workflow `pnpm/action-setup` steps drop their hardcoded `version: 9.0.0` so the `packageManager` field is the single source of truth
- New `pnpm-workspace.yaml` carrying the hardening settings
- Docs updated (copilot-instructions, CONTRIBUTING, DEPLOYMENT, workflows README); LESSONS_LEARNED.md left as a historical record
- **Lockfile unchanged** — pnpm 10 installs the existing lockfile frozen, no dependency churn

## Verification

- `pnpm install --frozen-lockfile` under 10.34.5 ✅
- `pnpm run format:check` ✅ · `pnpm run lint` ✅ · `pnpm run type-check` ✅
- `pnpm run build` ✅ static export complete
- `pnpm test` ✅ 1221/1221
- `pnpm run test:e2e` ✅ 32/32 (run against the sandbox's system Chromium; the pinned Playwright browser revision isn't shipped in this dev environment — CI installs its own browsers as usual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XH284LwLJAUAeFifR7B5tH

---
_Generated by [Claude Code](https://claude.ai/code/session_01XH284LwLJAUAeFifR7B5tH)_