### PR TITLE
fix: replace retired MS-900 with AB-900 across the site

### DIFF
--- a/__tests__/components/ContributorLadderPage.test.tsx
+++ b/__tests__/components/ContributorLadderPage.test.tsx
@@ -231,7 +231,7 @@ describe('Contributor Ladder Page', () => {
       render(<ContributorLadderPage />)
 
       // Check for mentions of certifications
-      expect(screen.getAllByText(/MS-900/i).length).toBeGreaterThan(0)
+      expect(screen.getAllByText(/AB-900/i).length).toBeGreaterThan(0)
       expect(screen.getAllByText(/GitHub Foundations/i).length).toBeGreaterThan(0)
       expect(screen.getAllByText(/Canva Design School/i).length).toBeGreaterThan(0)
     })

--- a/__tests__/route-generation.test.js
+++ b/__tests__/route-generation.test.js
@@ -104,7 +104,7 @@ describe('Route Generation Tests', () => {
       if (fs.existsSync(trainingPlanPath)) {
         const content = fs.readFileSync(trainingPlanPath, 'utf-8')
         expect(content).toContain('Operation Digital Sovereignty')
-        expect(content).toContain('MS-900')
+        expect(content).toContain('AB-900')
         expect(content).toContain('GitHub Foundations')
       }
     })

--- a/src/app/blog/day-in-the-life-global-admin/page.tsx
+++ b/src/app/blog/day-in-the-life-global-admin/page.tsx
@@ -258,7 +258,7 @@ export default function DayInTheLifeGlobalAdmin() {
               There is also always something new to learn. Microsoft 365 releases new features
               monthly. GitHub Actions evolves rapidly. Cloudflare adds new security capabilities.
               Staying current is part of the role — and FFC supports it by covering the cost of
-              certification exams like MS-900 and GitHub Foundations.
+              certification exams like AB-900 and GitHub Foundations.
             </p>
 
             <h2 className="text-2xl font-bold text-gray-900 mt-10 mb-4">The Tools of the Trade</h2>
@@ -297,7 +297,7 @@ export default function DayInTheLifeGlobalAdmin() {
                 Global Admin Training Plan
               </Link>{' '}
               is a self-paced curriculum that covers everything you need to know — from creating
-              your first DNS record to passing the MS-900 certification exam. It is structured as
+              your first DNS record to passing the AB-900 certification exam. It is structured as
               interactive checklists so you can track your progress as you go.
             </p>
             <p className="text-gray-700 leading-relaxed">

--- a/src/app/canva-designer-path/page.tsx
+++ b/src/app/canva-designer-path/page.tsx
@@ -162,7 +162,7 @@ export default function CanvaDesignerPath() {
                       Canva Pro for Nonprofits + Canva for Work courses
                     </td>
                     <td className="px-4 py-3 text-sm text-gray-700">
-                      MS-900 + GitHub Foundations certifications
+                      AB-900 + GitHub Foundations certifications
                     </td>
                   </tr>
                   <tr className="bg-gray-50">

--- a/src/app/contributor-ladder/page.tsx
+++ b/src/app/contributor-ladder/page.tsx
@@ -173,7 +173,7 @@ export default function ContributorLadder() {
       requirements: [
         'Successfully complete Unpaid Intern requirements',
         'Lead development of at least 2 major features or initiatives',
-        'Obtain relevant certification (MS-900, GitHub Foundations, or Canva Design School)',
+        'Obtain relevant certification (AB-900, GitHub Foundations, or Canva Design School)',
         'Demonstrate ability to work independently on complex projects',
         'Support onboarding and mentoring of new contributors',
       ],
@@ -522,7 +522,7 @@ export default function ContributorLadder() {
             >
               wordpress-volunteer-core-competencies
             </Link>{' '}
-            — seven core competencies (LastPass, AI assistants, MS-900, MS-700, OneDrive, Planner,
+            — seven core competencies (LastPass, AI assistants, AB-900, MS-700, OneDrive, Planner,
             M365 Apps) covering 33–46 hours of self-study. Use it as supplemental reading when
             moving through the modern contributor ladder.
           </p>

--- a/src/app/legacy-wordpress-administration/wordpress-volunteer-core-competencies/page.tsx
+++ b/src/app/legacy-wordpress-administration/wordpress-volunteer-core-competencies/page.tsx
@@ -13,7 +13,7 @@ export const metadata: Metadata = {
     canonical: `https://ffcadmin.org/legacy-wordpress-administration/${SLUG}/`,
   },
   keywords:
-    'FFC volunteer proving ground, core competencies, LastPass, AI assistants, MS-900, MS-700, OneDrive, Planner, Microsoft 365',
+    'FFC volunteer proving ground, core competencies, LastPass, AI assistants, AB-900, MS-700, OneDrive, Planner, Microsoft 365',
 }
 
 interface Module {
@@ -65,9 +65,9 @@ const modules: Module[] = [
       'Update: Claude and GPT-class models are now the FFC primary recommendation; Copilot / Gemini remain acceptable. Prompt-engineering principles unchanged.',
   },
   {
-    id: 'ms-900',
+    id: 'ab-900',
     index: 3,
-    name: 'MS-900 — Microsoft 365 Fundamentals',
+    name: 'AB-900 — Microsoft 365 Copilot and Agent Administration Fundamentals',
     duration: '12-16 hours',
     purpose: 'Foundational knowledge of M365 cloud services, apps, security, and compliance.',
     keyConcept:
@@ -76,11 +76,11 @@ const modules: Module[] = [
       'Explain the primary difference between Microsoft 365 and Office 365 (subscription bundle vs. productivity-app suite).',
     resources: [
       'Microsoft Learn self-paced course',
-      'Official MS-900 study guide',
+      'Official AB-900 study guide',
       'Optional: certification exam funding available case-by-case',
     ],
     modernNotes:
-      'Required for the Global Admin training plan. See /training-plan for the full progression beyond MS-900.',
+      'Required for the Global Admin training plan. See /training-plan for the full progression beyond AB-900.',
   },
   {
     id: 'ms-700',

--- a/src/app/training-plan/components/TrainingPlanInteractive.tsx
+++ b/src/app/training-plan/components/TrainingPlanInteractive.tsx
@@ -106,8 +106,8 @@ export function TrainingPlanInteractive({ prerequisites }: { prerequisites: Reac
               <li className="text-gray-700">
                 <strong className="text-blue-600">Phase 1 (The Administrative Beachhead):</strong>{' '}
                 Focuses on Microsoft 365 identity, security, and governance. Candidates must pass a
-                simulated validation (MS-900 practice) before being granted live "Global Admin" keys
-                to the charity tenant. The phase concludes with the actual MS-900 certification.
+                simulated validation (AB-900 practice) before being granted live "Global Admin" keys
+                to the charity tenant. The phase concludes with the actual AB-900 certification.
               </li>
               <li className="text-gray-700">
                 <strong className="text-blue-600">Phase 2 (The Code Supremacy Campaign):</strong>{' '}
@@ -120,7 +120,7 @@ export function TrainingPlanInteractive({ prerequisites }: { prerequisites: Reac
 
             <div className="bg-green-50 border-l-4 border-green-600 p-4 rounded">
               <p className="text-green-900">
-                <strong>Logistics Note:</strong> Test vouchers for both MS-900 and GitHub
+                <strong>Logistics Note:</strong> Test vouchers for both AB-900 and GitHub
                 Foundations are fully funded at nonprofit/student rates.
               </p>
             </div>
@@ -334,7 +334,7 @@ export function TrainingPlanInteractive({ prerequisites }: { prerequisites: Reac
               <tbody className="divide-y divide-gray-200 bg-white">
                 <tr>
                   <td className="px-4 py-3 text-sm text-gray-900 border-r border-gray-300">
-                    Microsoft 365 Fundamentals (MS-900)
+                    Microsoft 365 Copilot and Agent Administration Fundamentals (AB-900)
                   </td>
                   <td className="px-4 py-3 text-sm text-gray-700 border-r border-gray-300">
                     $99.00

--- a/src/app/training-plan/page.tsx
+++ b/src/app/training-plan/page.tsx
@@ -5,7 +5,7 @@ import { TrainingPlanInteractive } from './components/TrainingPlanInteractive'
 export const metadata: Metadata = {
   title: 'Microsoft 365 Administrator Training Plan',
   description:
-    'Operation Digital Sovereignty — the full Microsoft 365 Administrator + GitHub Owner training plan, backed by MS-900 and GitHub Foundations.',
+    'Operation Digital Sovereignty — the full Microsoft 365 Administrator + GitHub Owner training plan, backed by AB-900 and GitHub Foundations.',
   alternates: { canonical: 'https://ffcadmin.org/training-plan/' },
 }
 

--- a/src/app/volunteer/page.tsx
+++ b/src/app/volunteer/page.tsx
@@ -38,7 +38,7 @@ const benefits = [
   {
     title: 'Free Certifications',
     description:
-      'FFC covers the cost of industry certifications like MS-900 (Microsoft 365 Fundamentals) and GitHub Foundations for active volunteers.',
+      'FFC covers the cost of industry certifications like AB-900 (Microsoft 365 Copilot and Agent Administration Fundamentals) and GitHub Foundations for active volunteers.',
     icon: (
       <path
         strokeLinecap="round"
@@ -361,7 +361,7 @@ export default function VolunteerPage() {
                       d="M5 13l4 4L19 7"
                     />
                   </svg>
-                  MS-900 and GitHub Foundations certifications
+                  AB-900 and GitHub Foundations certifications
                 </li>
               </ul>
               <Link

--- a/src/data/ce-bodies.ts
+++ b/src/data/ce-bodies.ts
@@ -327,7 +327,7 @@ export const CE_BODIES: CeBody[] = [
     slug: 'microsoft',
     name: 'Microsoft',
     fullName: 'Microsoft Certifications',
-    certs: ['MS-900', 'AZ-900', 'and role-based certs'],
+    certs: ['AB-900', 'AZ-900', 'and role-based certs'],
     unit: 'n/a',
     unitPlural: 'n/a',
     cycleYears: 1,

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -100,7 +100,7 @@ export const volunteerMenu: NavMenu = {
         {
           label: 'Microsoft 365 Administrator',
           href: '/training-plan',
-          description: 'Run M365 email, identity & security — MS-900 + GitHub Foundations.',
+          description: 'Run M365 email, identity & security — AB-900 + GitHub Foundations.',
         },
         {
           label: 'Google Workspace Administrator',

--- a/src/data/recognition.ts
+++ b/src/data/recognition.ts
@@ -114,7 +114,7 @@ export const RECOGNITION_TIERS: RecognitionTier[] = [
     ],
     criteria: [
       'A solid body of merged work in commit history',
-      'Relevant certification (MS-900, GitHub Foundations, Canva, GA4, or Workspace)',
+      'Relevant certification (AB-900, GitHub Foundations, Canva, GA4, or Workspace)',
       'Board/maintainer certification',
     ],
     ladderAlignment: 'Paid Intern',

--- a/src/data/training-modules.ts
+++ b/src/data/training-modules.ts
@@ -281,14 +281,14 @@ export const TRAINING_MODULES: TrainingModule[] = [
         ],
       },
       T3: {
-        objective: 'Administer Microsoft 365 end to end and hold the MS-900 certification.',
+        objective: 'Administer Microsoft 365 end to end and hold the AB-900 certification.',
         directives: [
           {
             id: 'm-email-t3-1',
-            text: 'Complete the Microsoft 365 Fundamentals (MS-900) learning path and exam.',
+            text: 'Complete the Microsoft 365 Copilot and Agent Administration Fundamentals (AB-900) study guide and exam.',
             link: {
-              url: 'https://learn.microsoft.com/en-us/training/courses/ms-900t01',
-              label: 'MS-900 Learning Path',
+              url: 'https://learn.microsoft.com/en-us/credentials/certifications/resources/study-guides/ab-900',
+              label: 'AB-900 Study Guide',
             },
           },
           {
@@ -809,11 +809,14 @@ export const LEARNING_PATHS: LearningPath[] = [
     title: 'Microsoft 365 Administrator',
     persona: 'You manage Microsoft 365, GitHub, and infrastructure for all FFC charities.',
     intro:
-      'The administrator path: full depth across every module, backed by the MS-900 and GitHub Foundations certifications. This is the complete "Operation Digital Sovereignty" program.',
+      'The administrator path: full depth across every module, backed by the AB-900 and GitHub Foundations certifications. This is the complete "Operation Digital Sovereignty" program.',
     icon: '🛡️',
     gradient: 'from-teal-500 to-emerald-600',
     href: '/training-plan',
-    certifications: ['MS-900 (Microsoft 365 Fundamentals)', 'GitHub Foundations'],
+    certifications: [
+      'AB-900 (Microsoft 365 Copilot and Agent Administration Fundamentals)',
+      'GitHub Foundations',
+    ],
     prerequisiteGuides: [
       'github-account',
       'multi-factor-authentication',

--- a/src/data/training-plan-data.ts
+++ b/src/data/training-plan-data.ts
@@ -41,7 +41,7 @@ export const TRAINING_CURRICULUM: TrainingPhase[] = [
     title: 'Phase 1: Operation Certified Foundation (Microsoft 365)',
     mission: 'Establish the secure identity perimeter and governance structure.',
     endState:
-      'Candidate holds Global Administrator access to the live tenant and possesses the MS-900 Certification.',
+      'Candidate holds Global Administrator access to the live tenant and possesses the AB-900 Certification.',
     blocks: [
       {
         id: 'block-a',
@@ -84,7 +84,7 @@ export const TRAINING_CURRICULUM: TrainingPhase[] = [
       },
       {
         id: 'block-b',
-        title: 'Block B: The MS-900 Theoretical Gate (Simulation)',
+        title: 'Block B: The AB-900 Theoretical Gate (Simulation)',
         badge: 'B',
         description:
           'Simulated Combat Evaluation. The candidate must prove competence in a controlled environment before receiving command codes.',
@@ -92,15 +92,15 @@ export const TRAINING_CURRICULUM: TrainingPhase[] = [
         directives: [
           {
             id: 'p1-b-1',
-            text: 'Study: Microsoft 365 Fundamentals (MS-900) Learning Path',
+            text: 'Study: Microsoft 365 Copilot and Agent Administration Fundamentals (AB-900) Study Guide',
             link: {
-              url: 'https://learn.microsoft.com/en-us/training/courses/ms-900t01',
+              url: 'https://learn.microsoft.com/en-us/credentials/certifications/resources/study-guides/ab-900',
               label: 'Microsoft Learn',
             },
           },
           {
             id: 'p1-b-2',
-            text: 'Validation Event: Complete official MS-900 Practice Tests.',
+            text: 'Validation Event: Complete official AB-900 Practice Tests.',
           },
           {
             id: 'p1-b-3',
@@ -161,10 +161,11 @@ export const TRAINING_CURRICULUM: TrainingPhase[] = [
       },
     ],
     finalGate: {
-      title: 'Phase 1 Final Gate: MS-900 Certification',
-      mission: 'Pass the official Microsoft 365 Fundamentals (MS-900) Exam.',
+      title: 'Phase 1 Final Gate: AB-900 Certification',
+      mission:
+        'Pass the official Microsoft 365 Copilot and Agent Administration Fundamentals (AB-900) Exam.',
       link: {
-        url: 'https://learn.microsoft.com/en-us/credentials/certifications/exams/ms-900/',
+        url: 'https://learn.microsoft.com/en-us/credentials/certifications/exams/ab-900',
         label: 'Exam Details',
       },
       support: 'Voucher provided by unit command.',

--- a/src/data/vendor-urls.ts
+++ b/src/data/vendor-urls.ts
@@ -48,7 +48,7 @@ export const VENDOR_URLS = {
   microsoftLearnHome: {
     url: 'https://learn.microsoft.com/',
     lastVerified: '2026-05-24',
-    description: 'Microsoft Learn — MS-900 / MS-700 study material.',
+    description: 'Microsoft Learn — AB-900 / MS-700 study material.',
   },
   interserverSales: {
     url: 'mailto:sales@interserver.net',

--- a/src/data/volunteer-roles.ts
+++ b/src/data/volunteer-roles.ts
@@ -53,14 +53,14 @@ export const VOLUNTEER_ROLES: VolunteerRole[] = [
     title: 'Microsoft 365 Administrator Volunteer',
     tagline: 'Run email, identity, and security for charities',
     intro:
-      'Administer Microsoft 365 for nonprofits — mailboxes, identity, MFA, and security baselines — and earn the MS-900 certification along the way. This is the infrastructure backbone every charity relies on.',
+      'Administer Microsoft 365 for nonprofits — mailboxes, identity, MFA, and security baselines — and earn the AB-900 certification along the way. This is the infrastructure backbone every charity relies on.',
     keywords:
-      'Microsoft 365 admin volunteer, MS-900 volunteer, nonprofit IT volunteer, Entra ID volunteer, email administration volunteer',
+      'Microsoft 365 admin volunteer, AB-900 volunteer, nonprofit IT volunteer, Entra ID volunteer, email administration volunteer',
     responsibilities: [
       'Provision mailboxes, licenses, and security policies',
       'Enforce MFA and Conditional Access',
       'Manage compliance and data retention',
-      'Earn MS-900 (FFC sponsors the exam)',
+      'Earn AB-900 (FFC sponsors the exam)',
     ],
     startHref: '/training-plan',
     pathId: 'global-admin',


### PR DESCRIPTION
## Summary

Microsoft retired **MS-900 (Microsoft 365 Fundamentals)** on 2026-03-31. Per issue #539's canonical facts, every MS-900 reference is replaced with **AB-900 — Microsoft 365 Copilot and Agent Administration Fundamentals**, mirroring the main-site work (FreeForCharity/FFC-IN-freeforcharity.org#359 / #361).

## Changes

All 16 files from #539's checklist updated (14 src files + 2 test files):

- **Cert name/code**: `MS-900` → `AB-900`; long-form "Microsoft 365 Fundamentals" → "Microsoft 365 Copilot and Agent Administration Fundamentals" wherever it named the cert.
- **Exam link** (`src/data/training-plan-data.ts` final gate): now `https://learn.microsoft.com/en-us/credentials/certifications/exams/ab-900`.
- **Learning-path links** (`training-plan-data.ts`, `training-modules.ts`): the old `training/courses/ms-900t01` course URLs now point to the issue-vouched AB-900 study guide, `https://learn.microsoft.com/en-us/credentials/certifications/resources/study-guides/ab-900` (the issue names exam + study-guide URLs as canonical; no AB-900 course URL is named there, and learn.microsoft.com is not reachable from this sandbox to verify one, so both links use the vouched study-guide URL).
- **Anchor id** on `/legacy-wordpress-administration/wordpress-volunteer-core-competencies/`: `id: 'ms-900'` → `'ab-900'` (in-page anchor only; verified nothing links to `#ms-900`).
- **MS-700 left unchanged** everywhere, per the issue's note that it is not retired.
- **Tests updated**: `__tests__/route-generation.test.js` and `__tests__/components/ContributorLadderPage.test.tsx` now assert on AB-900.

## Acceptance criteria check

- `grep -rni "ms-900"` (repo-wide, excluding node_modules/.next/out/.git) → **zero matches**
- No "Microsoft 365 Fundamentals" strings remain
- MS-700 references intact (`wordpress-volunteer-core-competencies`, `contributor-ladder`, `vendor-urls`)
- `/training-plan/` and the volunteer M365 role now describe earning **AB-900**

## Verification

- `pnpm run format` / `lint` / `type-check` → clean
- `pnpm run build` → static export succeeded
- `pnpm test` → 70 suites, **1223 passed, 0 failed**

(test:e2e left to CI.)

Fixes #539

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wf57QsusNZqRLvTxFcAT3L)_