### PR TITLE
feat: add GDPR and CCPA/CPRA rights sections to privacy policy

### DIFF
--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -7,7 +7,8 @@
         "http://localhost/tech-stack/index.html",
         "http://localhost/documentation/index.html",
         "http://localhost/legacy-wordpress-administration/index.html",
-        "http://localhost/legacy-wordpress-administration/wordpress-web-hosting/index.html"
+        "http://localhost/legacy-wordpress-administration/wordpress-web-hosting/index.html",
+        "http://localhost/guides/website-templates-and-footer-standard/index.html"
       ],
       "numberOfRuns": 3
     },

--- a/src/app/cookie-policy/page.tsx
+++ b/src/app/cookie-policy/page.tsx
@@ -320,9 +320,9 @@ export default function CookiePolicy() {
                 This site does not need to react to these browser signals to honor their intent:
                 analytics and marketing cookies are off for every visitor until you opt in through
                 the consent banner, and we do not sell or share personal information as defined by
-                the CCPA/CPRA. Declining consent — or withdrawing it later, which stops the tracking
-                scripts and removes the cookies they set on this site — keeps you in the untracked
-                state those signals ask for.
+                the CCPA/CPRA. Declining consent — or withdrawing it later, which removes the
+                cookies those scripts set on this site and stops them loading from your next page
+                view — keeps you in the untracked state those signals ask for.
               </p>
             </section>
 

--- a/src/app/cookie-policy/page.tsx
+++ b/src/app/cookie-policy/page.tsx
@@ -320,8 +320,9 @@ export default function CookiePolicy() {
                 This site does not need to react to these browser signals to honor their intent:
                 analytics and marketing cookies are off for every visitor until you opt in through
                 the consent banner, and we do not sell or share personal information as defined by
-                the CCPA/CPRA. Declining consent — or withdrawing it later, which also deletes the
-                tracking cookies — keeps you in the untracked state those signals ask for.
+                the CCPA/CPRA. Declining consent — or withdrawing it later, which stops the tracking
+                scripts and removes the cookies they set on this site — keeps you in the untracked
+                state those signals ask for.
               </p>
             </section>
 

--- a/src/app/cookie-policy/page.tsx
+++ b/src/app/cookie-policy/page.tsx
@@ -11,7 +11,7 @@ export const metadata: Metadata = {
 }
 
 // Update this date when the policy changes
-const LAST_UPDATED = 'June 20, 2026'
+const LAST_UPDATED = 'August 29, 2026'
 
 // Table of contents — keep in sync with the section ids below.
 const TOC = [
@@ -19,7 +19,7 @@ const TOC = [
   { n: 2, label: 'How We Use Cookies' },
   { n: 3, label: 'Types of Cookies We Use' },
   { n: 4, label: 'How to Manage Cookies' },
-  { n: 5, label: 'Do Not Track Signals' },
+  { n: 5, label: 'Do Not Track and Global Privacy Control' },
   { n: 6, label: 'Updates to This Cookie Policy' },
   { n: 7, label: 'Contact Us' },
   { n: 8, label: 'More Information' },
@@ -313,12 +313,15 @@ export default function CookiePolicy() {
             </section>
 
             <section id="section-5" className="scroll-mt-20">
-              <h2 className="text-2xl font-bold text-gray-900 mb-4">5. Do Not Track Signals</h2>
+              <h2 className="text-2xl font-bold text-gray-900 mb-4">
+                5. Do Not Track and Global Privacy Control
+              </h2>
               <p>
-                Some browsers have a "Do Not Track" feature that lets you tell websites that you do
-                not want to have your online activities tracked. At this time, we do not respond to
-                browser "Do Not Track" signals. However, you can control cookies through our cookie
-                consent banner.
+                This site does not need to react to these browser signals to honor their intent:
+                analytics and marketing cookies are off for every visitor until you opt in through
+                the consent banner, and we do not sell or share personal information as defined by
+                the CCPA/CPRA. Declining consent — or withdrawing it later, which also deletes the
+                tracking cookies — keeps you in the untracked state those signals ask for.
               </p>
             </section>
 

--- a/src/app/privacy-policy/page.tsx
+++ b/src/app/privacy-policy/page.tsx
@@ -205,9 +205,9 @@ export default function PrivacyPolicy() {
               <ul className="list-disc pl-6 mb-4 space-y-2">
                 <li>
                   <strong>Consent</strong> — analytics and marketing cookies are off until you opt
-                  in through the cookie consent banner. You can withdraw consent at any time via
-                  Cookie Preferences, and withdrawal deletes the associated tracking cookies from
-                  your browser.
+                  in through the cookie consent banner. You can withdraw consent at any time via the
+                  Cookie Preferences link in the footer; this site then stops those scripts and
+                  removes the tracking cookies it set.
                 </li>
                 <li>
                   <strong>Legitimate interests</strong> — operating, securing, and improving this

--- a/src/app/privacy-policy/page.tsx
+++ b/src/app/privacy-policy/page.tsx
@@ -206,8 +206,8 @@ export default function PrivacyPolicy() {
                 <li>
                   <strong>Consent</strong> — analytics and marketing cookies are off until you opt
                   in through the cookie consent banner. You can withdraw consent at any time via the
-                  Cookie Preferences link in the footer; this site then stops those scripts and
-                  removes the tracking cookies it set.
+                  Cookie Preferences link in the footer; this site then removes the tracking cookies
+                  it set and stops loading those scripts from your next page view.
                 </li>
                 <li>
                   <strong>Legitimate interests</strong> — operating, securing, and improving this

--- a/src/app/privacy-policy/page.tsx
+++ b/src/app/privacy-policy/page.tsx
@@ -11,7 +11,7 @@ export const metadata: Metadata = {
 }
 
 // Update this date when the policy changes
-const LAST_UPDATED = 'June 20, 2026'
+const LAST_UPDATED = 'August 29, 2026'
 
 // Table of contents — keep in sync with the section ids below.
 const TOC = [
@@ -191,41 +191,98 @@ export default function PrivacyPolicy() {
               <h2 className="text-2xl font-bold text-gray-900 mb-4">7. Your Privacy Rights</h2>
 
               <h3 className="text-xl font-semibold text-gray-900 mb-3">
-                7.1 GDPR Rights (EU Residents)
+                7.1 Your Rights in the European Union, United Kingdom, and EEA (GDPR)
               </h3>
               <p className="mb-4">
-                If you are in the European Union, you have the following rights:
+                If you visit from the European Union, the United Kingdom, or the wider European
+                Economic Area, the EU General Data Protection Regulation (GDPR) or the UK GDPR
+                applies to our handling of your personal data, and this section supplements the rest
+                of this policy.
+              </p>
+              <p className="mb-4">
+                <strong>Legal bases.</strong> We process personal data only on these bases:
               </p>
               <ul className="list-disc pl-6 mb-4 space-y-2">
-                <li>Right to access your personal data</li>
-                <li>Right to rectification of inaccurate data</li>
-                <li>Right to erasure ("right to be forgotten")</li>
-                <li>Right to restrict processing</li>
-                <li>Right to data portability</li>
-                <li>Right to object to processing</li>
-                <li>Right to withdraw consent at any time</li>
+                <li>
+                  <strong>Consent</strong> — analytics and marketing cookies are off until you opt
+                  in through the cookie consent banner. You can withdraw consent at any time via
+                  Cookie Preferences, and withdrawal deletes the associated tracking cookies from
+                  your browser.
+                </li>
+                <li>
+                  <strong>Legitimate interests</strong> — operating, securing, and improving this
+                  website (for example, essential cookies and server logs), balanced against your
+                  rights.
+                </li>
+                <li>
+                  <strong>Legal obligation</strong> — where processing is required to comply with
+                  applicable law.
+                </li>
               </ul>
+              <p className="mb-4">
+                <strong>Your rights.</strong> You have the right to: access the personal data we
+                hold about you; have inaccurate data rectified; have your data erased; restrict or
+                object to processing; receive your data in a portable format; and withdraw any
+                consent you have given, at any time, without affecting the lawfulness of processing
+                before withdrawal.
+              </p>
+              <p className="mb-4">
+                <strong>Exercising your rights and complaints.</strong> Contact us at{' '}
+                <a
+                  href="mailto:privacy@freeforcharity.org"
+                  className="text-blue-600 hover:underline"
+                >
+                  privacy@freeforcharity.org
+                </a>{' '}
+                to exercise any of these rights; we will respond within the time limits the GDPR
+                sets. You also have the right to lodge a complaint with your national data
+                protection supervisory authority (in the UK, the Information Commissioner's Office).
+              </p>
 
               <h3 className="text-xl font-semibold text-gray-900 mb-3">
-                7.2 CCPA/CPRA Rights (California Residents)
+                7.2 Your California Privacy Rights (CCPA/CPRA)
               </h3>
               <p className="mb-4">
-                If you are a California resident, you have the following rights:
+                If you are a California resident, the California Consumer Privacy Act, as amended by
+                the California Privacy Rights Act (CCPA/CPRA), gives you specific rights, and this
+                section supplements the rest of this policy.
               </p>
-              <ul className="list-disc pl-6 mb-4 space-y-2">
-                <li>Right to know what personal information is collected</li>
-                <li>Right to know if personal information is sold or shared and to whom</li>
-                <li>Right to opt-out of the sale or sharing of personal information</li>
-                <li>Right to delete personal information</li>
-                <li>Right to correct inaccurate personal information</li>
-                <li>Right to limit use of sensitive personal information</li>
-                <li>Right to non-discrimination for exercising your rights</li>
-              </ul>
-
               <p className="mb-4">
-                <strong>Do Not Sell or Share My Personal Information:</strong> We do not sell
-                personal information. When you decline analytics and marketing cookies, we do not
-                share your information with third-party analytics or advertising services.
+                <strong>We do not sell or share your personal information.</strong> Free For Charity
+                does not sell personal information, and does not share it for cross-context
+                behavioral advertising, as those terms are defined by California law — and has not
+                done so in the preceding 12 months. We do not knowingly collect or sell the personal
+                information of anyone under 16. We do not collect sensitive personal information
+                beyond what is necessary to provide this website and our services, and we do not use
+                it to infer characteristics about you.
+              </p>
+              <p className="mb-4">
+                <strong>Your rights.</strong> You have the right to: know what personal information
+                we collect, use, and disclose, and to access it; delete personal information we
+                collected from you; correct inaccurate personal information; opt out of any sale or
+                sharing of personal information (not applicable, since we do neither); limit the use
+                of sensitive personal information; and not be discriminated against for exercising
+                any of these rights.
+              </p>
+              <p className="mb-4">
+                <strong>Opt-out preference signals (Global Privacy Control / Do Not Track).</strong>{' '}
+                Tracking on this site is opt-in for every visitor, everywhere: analytics and
+                marketing cookies stay off until you accept them, and declining or withdrawing
+                consent keeps you — or returns you — to that untracked state. Because we also do not
+                sell or share personal information, every visitor already receives at least the
+                protection a Global Privacy Control or Do Not Track signal would request.
+              </p>
+              <p className="mb-4">
+                <strong>Exercising your rights.</strong> Submit a request to{' '}
+                <a
+                  href="mailto:privacy@freeforcharity.org"
+                  className="text-blue-600 hover:underline"
+                >
+                  privacy@freeforcharity.org
+                </a>
+                . We will verify your request using information associated with your interactions
+                with us, and you may use an authorized agent to submit a request on your behalf. We
+                will respond within the timeframes California law requires.
               </p>
             </section>
 

--- a/src/app/what-ffc-delivers/page.tsx
+++ b/src/app/what-ffc-delivers/page.tsx
@@ -14,10 +14,18 @@ export const metadata: Metadata = {
   },
 }
 
-const included = [
+const included: {
+  title: string
+  body: string
+  link?: { href: string; label: string }
+}[] = [
   {
     title: 'A professional website',
     body: 'A fast, secure, accessible static site built from one of our two open-source templates — a complete single-page site, or the FFC footer added to your existing design — and hosted free. Built and validated first on its free GitHub Pages URL, with AI-assisted editing so you can keep it current yourself.',
+    link: {
+      href: '/guides/website-templates-and-footer-standard',
+      label: 'Learn about the templates and the footer standard',
+    },
   },
   {
     title: 'A domain',
@@ -69,7 +77,20 @@ export default function WhatFfcDeliversPage() {
             {included.map((i) => (
               <div key={i.title} className="border-l-4 border-teal-300 pl-4">
                 <h3 className="font-bold text-gray-900">{i.title}</h3>
-                <p className="text-sm text-gray-700">{i.body}</p>
+                <p className="text-sm text-gray-700">
+                  {i.body}
+                  {i.link && (
+                    <>
+                      {' '}
+                      <Link
+                        href={i.link.href}
+                        className="text-teal-700 underline hover:text-teal-900"
+                      >
+                        {i.link.label}
+                      </Link>
+                    </>
+                  )}
+                </p>
               </div>
             ))}
           </div>


### PR DESCRIPTION
## What changed

1. **Privacy policy (`src/app/privacy-policy/page.tsx`)** — replaced the thin bullet-list subsections under Section 7 "Your Privacy Rights" with the full canonical EU + California sections, keeping the page's existing numbering:
   - **7.1 Your Rights in the European Union, United Kingdom, and EEA (GDPR)** — legal bases (consent, legitimate interests, legal obligation), enumerated rights, and how to exercise them / lodge a complaint (contact: privacy@freeforcharity.org).
   - **7.2 Your California Privacy Rights (CCPA/CPRA)** — no sale/sharing of personal information (including the 12-month lookback and under-16 statement), enumerated rights, the Global Privacy Control / Do Not Track opt-in reasoning, and how to submit a verifiable request.
   - Bumped `LAST_UPDATED` to August 29, 2026.
2. **Cookie policy (`src/app/cookie-policy/page.tsx`)** — replaced Section 5 "Do Not Track Signals" (which stated the site does not respond to DNT) with **5. Do Not Track and Global Privacy Control**, explaining that tracking is opt-in for every visitor and we do not sell or share personal information, so the signals' intent is already honored. Updated the TOC label and `LAST_UPDATED` to match.
3. **What FFC Delivers (`src/app/what-ffc-delivers/page.tsx`)** — added an inline link from the "A professional website" card (the sentence naming our two open-source templates) to the existing guide at `/guides/website-templates-and-footer-standard`, using the page's teal link styling.
4. **Lighthouse (`lighthouserc.json`)** — added `http://localhost/guides/website-templates-and-footer-standard/index.html` to the collected URL list.

## Counsel review

The privacy-policy and cookie-policy copy in this PR is legal-page content. Please flag it for counsel review before further reuse on other FFC sites.

## Verification (full pre-commit chain, in order)

- `pnpm run format` — pass (no residual diffs beyond intended changes)
- `pnpm run lint` — pass (0 errors, 0 warnings)
- `pnpm run type-check` — pass (0 errors)
- `pnpm run build` — pass (static export succeeded; `out/guides/website-templates-and-footer-standard/index.html` present)
- `pnpm test` — pass: 70/70 suites, 1223/1223 tests (includes the banned-phrases scan)
- `pnpm run test:e2e` — pass: 32/32 Playwright tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XHP24s2dinEBxnCAC6ctTe

---
_Generated by [Claude Code](https://claude.ai/code/session_01XHP24s2dinEBxnCAC6ctTe)_